### PR TITLE
feat: Add getitrack core data types and tracker config

### DIFF
--- a/libraries/getitrack/configs/default.yaml
+++ b/libraries/getitrack/configs/default.yaml
@@ -1,14 +1,13 @@
 # Default tracker configuration.
 algorithm: bytetrack
 verbose: false
-association:
-  # Detection filtering, applied before matching.
-  score_threshold: 0.1
-  class_filter: null
-  # Detection-to-track matching.
-  match_threshold: 0.8
-  high_score_threshold: 0.6
-  match_class_only: true
+# Detection filtering, applied before tracking.
+score_threshold: 0.1
+class_filter: null
+# Detection-to-track matching.
+match_threshold: 0.8
+high_score_threshold: 0.6
+match_class_only: true
 lifecycle:
   max_age: 30
   min_hits: 2
@@ -17,12 +16,6 @@ motion:
   process_noise: 1.0
   measurement_noise: 1.0
   velocity_decay: 0.99
-appearance:
-  enabled: false
-  embedding_dim: 512
-  similarity_threshold: 0.7
-  memory_bank_size: 10
-  weight: 0.5
 interpolation:
   enabled: true
   method: linear

--- a/libraries/getitrack/configs/default.yaml
+++ b/libraries/getitrack/configs/default.yaml
@@ -1,0 +1,31 @@
+# Default tracker configuration.
+algorithm: bytetrack
+verbose: false
+association:
+  # Detection filtering, applied before matching.
+  score_threshold: 0.1
+  class_filter: null
+  # Detection-to-track matching.
+  match_threshold: 0.8
+  high_score_threshold: 0.6
+  match_class_only: true
+lifecycle:
+  max_age: 30
+  min_hits: 2
+  tentative_max_age: 0
+motion:
+  process_noise: 1.0
+  measurement_noise: 1.0
+  velocity_decay: 0.99
+appearance:
+  enabled: false
+  embedding_dim: 512
+  similarity_threshold: 0.7
+  memory_bank_size: 10
+  weight: 0.5
+interpolation:
+  enabled: true
+  method: linear
+  max_gap: 5
+  smoothing_window: 5
+  online_buffer: 0

--- a/libraries/getitrack/pyproject.toml
+++ b/libraries/getitrack/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
+    "loguru>=0.7",
     "numpy>=2.0",
     "pydantic>=2.7",
     "pyyaml==6.0.3",

--- a/libraries/getitrack/src/getitrack/__init__.py
+++ b/libraries/getitrack/src/getitrack/__init__.py
@@ -2,4 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """getitrack: Multi-object tracking toolkit."""
 
+from loguru import logger
+
+# Stay silent until the application opts in via `logger.enable("getitrack")`
+# or a tracker's `verbose` flag.
+logger.disable("getitrack")
+
 __version__ = "0.1.0"

--- a/libraries/getitrack/src/getitrack/config.py
+++ b/libraries/getitrack/src/getitrack/config.py
@@ -56,7 +56,7 @@ class LifecycleConfig(_StrictModel):
 
     tentative_max_age: Annotated[int, Field(ge=0)] = 0
     """Consecutive missed frames a TENTATIVE track tolerates before removal.
-    0 removes on the first miss (reference ByteTrack behavior)."""
+    0 removes on the first miss."""
 
 
 class MotionConfig(_StrictModel):

--- a/libraries/getitrack/src/getitrack/config.py
+++ b/libraries/getitrack/src/getitrack/config.py
@@ -1,0 +1,178 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Pydantic configuration models for getitrack.
+
+`TrackerConfig` is the top-level entry point. Sub-configs group fields by
+responsibility (association, lifecycle, motion, appearance, interpolation)
+so a YAML file can tune one concern in isolation. Field docstrings surface
+as ``description`` strings in ``model_json_schema()`` because each model
+sets ``use_attribute_docstrings=True``.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from pathlib import Path
+from typing import Annotated, Any
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AlgorithmType(StrEnum):
+    """Identifier resolving to a registered `BaseTracker` subclass."""
+
+    BYTETRACK = "bytetrack"
+    OCSORT = "ocsort"
+    BOTSORT = "botsort"
+    MEMORY = "memory"
+
+
+class InterpolationMethod(StrEnum):
+    """Strategy used by the post-processing interpolator."""
+
+    LINEAR = "linear"
+    KALMAN = "kalman"
+    SPLINE = "spline"
+
+
+class AssociationConfig(BaseModel):
+    """Detection-to-track matching parameters."""
+
+    model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
+
+    match_threshold: Annotated[float, Field(ge=0.0, le=1.0)] = 0.8
+    """Maximum assignment cost accepted when matching detections to tracks.
+    The cost is ``1 - IoU``, score-fused to ``1 - IoU * score`` where fusion
+    applies, so larger values accept weaker overlaps."""
+
+    score_threshold: Annotated[float, Field(ge=0.0, le=1.0)] = 0.1
+    """Drop detections with confidence below this value before matching runs."""
+
+    high_score_threshold: Annotated[float, Field(ge=0.0, le=1.0)] = 0.6
+    """Boundary used by two-stage association (ByteTrack) to split detections into high-score and low-score buckets."""
+
+    match_class_only: bool = True
+    """Restrict matching to detection-track pairs that share a class id."""
+
+    class_filter: list[int] | None = None
+    """Track only detections whose class id is in this list; None tracks all
+    classes. Applied before association, so excluded classes never spawn or
+    match tracks."""
+
+
+class LifecycleConfig(BaseModel):
+    """Track creation, confirmation, and removal parameters."""
+
+    model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
+
+    max_age: Annotated[int, Field(ge=1)] = 30
+    """Consecutive missed frames a LOST track may accumulate before removal."""
+
+    min_hits: Annotated[int, Field(ge=1)] = 2
+    """Observed detections required to promote a TENTATIVE track to ACTIVE.
+    Trackers may bypass this on the first frame of a sequence."""
+
+    tentative_max_age: Annotated[int, Field(ge=0)] = 0
+    """Consecutive missed frames a TENTATIVE track tolerates before removal.
+    0 removes on the first miss (reference ByteTrack behavior)."""
+
+
+class MotionConfig(BaseModel):
+    """Kalman filter and motion model parameters."""
+
+    model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
+
+    process_noise: Annotated[float, Field(gt=0.0)] = 1.0
+    """Multiplier on the process-noise covariance (Q). Larger values weight observations over the motion prior."""
+
+    measurement_noise: Annotated[float, Field(gt=0.0)] = 1.0
+    """Multiplier on the measurement-noise covariance (R). Larger values weight the motion prior over observations."""
+
+    velocity_decay: Annotated[float, Field(gt=0.0, le=1.0)] = 0.99
+    """Per-frame velocity damping in ``(0, 1]``. Values below 1.0 simulate gradual deceleration."""
+
+
+class AppearanceConfig(BaseModel):
+    """Appearance and embedding-based matching parameters."""
+
+    model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
+
+    enabled: bool = False
+    """Fuse appearance similarity into the matching cost when true."""
+
+    embedding_dim: Annotated[int, Field(ge=1)] = 512
+    """Feature-vector dimensionality expected from a detector or re-identification head."""
+
+    similarity_threshold: Annotated[float, Field(ge=0.0, le=1.0)] = 0.7
+    """Minimum cosine similarity accepted as an appearance match."""
+
+    memory_bank_size: Annotated[int, Field(ge=1)] = 10
+    """Number of recent embeddings retained per track."""
+
+    weight: Annotated[float, Field(ge=0.0, le=1.0)] = 0.5
+    """Blend between motion and appearance cost: 0.0 is pure motion, 1.0 is pure appearance."""
+
+
+class InterpolationConfig(BaseModel):
+    """Bbox interpolation and smoothing parameters."""
+
+    model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
+
+    enabled: bool = True
+    """Enable the interpolation post-processing stage."""
+
+    method: InterpolationMethod = InterpolationMethod.LINEAR
+    """Interpolation strategy used when ``enabled`` is true."""
+
+    max_gap: Annotated[int, Field(ge=1)] = 5
+    """Maximum consecutive missing frames bridged by interpolation."""
+
+    smoothing_window: Annotated[int, Field(ge=1)] = 5
+    """Window size for spline or moving-average smoothing."""
+
+    online_buffer: Annotated[int, Field(ge=0)] = 0
+    """Frames of lookahead permitted in online mode. 0 is strictly causal (zero latency)."""
+
+
+class TrackerConfig(BaseModel):
+    """Top-level tracker configuration.
+
+    Construct from a YAML file via `TrackerConfig.from_yaml`, from a dict
+    via `TrackerConfig.model_validate`, or programmatically.
+    """
+
+    model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
+
+    algorithm: AlgorithmType = AlgorithmType.BYTETRACK
+    """Algorithm identifier. Each value resolves to a registered `BaseTracker` subclass."""
+
+    verbose: bool = False
+    """Log a one-line tracking summary per frame at INFO level on the ``getitrack`` logger."""
+
+    association: AssociationConfig = Field(default_factory=AssociationConfig)
+    """Detection-to-track matching parameters."""
+
+    lifecycle: LifecycleConfig = Field(default_factory=LifecycleConfig)
+    """Track creation, confirmation, and removal parameters."""
+
+    motion: MotionConfig = Field(default_factory=MotionConfig)
+    """Kalman filter and motion model parameters."""
+
+    appearance: AppearanceConfig = Field(default_factory=AppearanceConfig)
+    """Appearance and embedding-based matching parameters."""
+
+    interpolation: InterpolationConfig = Field(default_factory=InterpolationConfig)
+    """Bbox interpolation and smoothing parameters."""
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> TrackerConfig:
+        """Load a validated configuration from a YAML file."""
+        with Path(path).open(encoding="utf-8") as f:
+            raw: Any = yaml.safe_load(f)
+        return cls.model_validate(raw or {})
+
+    def to_yaml(self, path: str | Path) -> None:
+        """Serialise this configuration to a YAML file."""
+        with Path(path).open("w", encoding="utf-8") as f:
+            yaml.safe_dump(self.model_dump(mode="json"), f, default_flow_style=False, sort_keys=False)

--- a/libraries/getitrack/src/getitrack/config.py
+++ b/libraries/getitrack/src/getitrack/config.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Annotated, Any
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class AlgorithmType(StrEnum):
@@ -121,6 +121,15 @@ class TrackerConfig(_StrictModel):
 
     interpolation: InterpolationConfig = Field(default_factory=InterpolationConfig)
     """Bbox interpolation and smoothing parameters."""
+
+    @model_validator(mode="after")
+    def _algorithm_matches_variant(self) -> TrackerConfig:
+        """Reject an ``algorithm`` value that differs from the one a subclass pins."""
+        field = type(self).model_fields["algorithm"]
+        if not field.is_required() and self.algorithm != field.default:
+            msg = f"{type(self).__name__} pins algorithm={field.default!r}; got {self.algorithm!r}"
+            raise ValueError(msg)
+        return self
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> TrackerConfig:

--- a/libraries/getitrack/src/getitrack/config.py
+++ b/libraries/getitrack/src/getitrack/config.py
@@ -5,8 +5,8 @@
 `TrackerConfig` is the top-level entry point. Sub-configs group fields by
 responsibility (association, lifecycle, motion, appearance, interpolation)
 so a YAML file can tune one concern in isolation. Field docstrings surface
-as ``description`` strings in ``model_json_schema()`` because each model
-sets ``use_attribute_docstrings=True``.
+as ``description`` strings in ``model_json_schema()`` because the shared
+`_StrictModel` base sets ``use_attribute_docstrings=True``.
 """
 
 from __future__ import annotations
@@ -36,10 +36,14 @@ class InterpolationMethod(StrEnum):
     SPLINE = "spline"
 
 
-class AssociationConfig(BaseModel):
-    """Detection-to-track matching parameters."""
+class _StrictModel(BaseModel):
+    """Base for config models: reject unknown keys and expose field docstrings."""
 
     model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
+
+
+class AssociationConfig(_StrictModel):
+    """Detection-to-track matching parameters."""
 
     match_threshold: Annotated[float, Field(ge=0.0, le=1.0)] = 0.8
     """Maximum assignment cost accepted when matching detections to tracks.
@@ -61,10 +65,8 @@ class AssociationConfig(BaseModel):
     match tracks."""
 
 
-class LifecycleConfig(BaseModel):
+class LifecycleConfig(_StrictModel):
     """Track creation, confirmation, and removal parameters."""
-
-    model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
 
     max_age: Annotated[int, Field(ge=1)] = 30
     """Consecutive missed frames a LOST track may accumulate before removal."""
@@ -78,10 +80,8 @@ class LifecycleConfig(BaseModel):
     0 removes on the first miss (reference ByteTrack behavior)."""
 
 
-class MotionConfig(BaseModel):
+class MotionConfig(_StrictModel):
     """Kalman filter and motion model parameters."""
-
-    model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
 
     process_noise: Annotated[float, Field(gt=0.0)] = 1.0
     """Multiplier on the process-noise covariance (Q). Larger values weight observations over the motion prior."""
@@ -93,10 +93,8 @@ class MotionConfig(BaseModel):
     """Per-frame velocity damping in ``(0, 1]``. Values below 1.0 simulate gradual deceleration."""
 
 
-class AppearanceConfig(BaseModel):
+class AppearanceConfig(_StrictModel):
     """Appearance and embedding-based matching parameters."""
-
-    model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
 
     enabled: bool = False
     """Fuse appearance similarity into the matching cost when true."""
@@ -114,10 +112,8 @@ class AppearanceConfig(BaseModel):
     """Blend between motion and appearance cost: 0.0 is pure motion, 1.0 is pure appearance."""
 
 
-class InterpolationConfig(BaseModel):
+class InterpolationConfig(_StrictModel):
     """Bbox interpolation and smoothing parameters."""
-
-    model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
 
     enabled: bool = True
     """Enable the interpolation post-processing stage."""
@@ -135,14 +131,12 @@ class InterpolationConfig(BaseModel):
     """Frames of lookahead permitted in online mode. 0 is strictly causal (zero latency)."""
 
 
-class TrackerConfig(BaseModel):
+class TrackerConfig(_StrictModel):
     """Top-level tracker configuration.
 
     Construct from a YAML file via `TrackerConfig.from_yaml`, from a dict
     via `TrackerConfig.model_validate`, or programmatically.
     """
-
-    model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
 
     algorithm: AlgorithmType = AlgorithmType.BYTETRACK
     """Algorithm identifier. Each value resolves to a registered `BaseTracker` subclass."""

--- a/libraries/getitrack/src/getitrack/config.py
+++ b/libraries/getitrack/src/getitrack/config.py
@@ -111,7 +111,7 @@ class TrackerConfig(_StrictModel):
     match tracks."""
 
     score_threshold: Annotated[float, Field(ge=0.0, le=1.0)] = 0.1
-    """Drop detections with confidence below this value before tracking runs."""
+    """Minimum detection confidence the tracking algorithm considers; lower-scoring detections are excluded."""
 
     lifecycle: LifecycleConfig = Field(default_factory=LifecycleConfig)
     """Track creation, confirmation, and removal parameters."""

--- a/libraries/getitrack/src/getitrack/config.py
+++ b/libraries/getitrack/src/getitrack/config.py
@@ -1,12 +1,14 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-"""Pydantic configuration models for getitrack.
+"""Shared Pydantic configuration models for getitrack.
 
-`TrackerConfig` is the top-level entry point. Sub-configs group fields by
-responsibility (association, lifecycle, motion, appearance, interpolation)
-so a YAML file can tune one concern in isolation. Field docstrings surface
-as ``description`` strings in ``model_json_schema()`` because the shared
-`_StrictModel` base sets ``use_attribute_docstrings=True``.
+`TrackerConfig` holds the parameters common to every algorithm. Each algorithm
+defines its own subclass (e.g. `ByteTrackConfig`) and registers it under an
+``algorithm`` name; loading dispatches on that name so a config validates against
+the matching algorithm and rejects parameters that do not apply.
+
+Sub-configs (lifecycle, motion, interpolation) group related fields. Field
+docstrings become schema ``description`` strings via ``use_attribute_docstrings``.
 """
 
 from __future__ import annotations
@@ -42,29 +44,6 @@ class _StrictModel(BaseModel):
     model_config = ConfigDict(extra="forbid", use_attribute_docstrings=True)
 
 
-class AssociationConfig(_StrictModel):
-    """Detection-to-track matching parameters."""
-
-    match_threshold: Annotated[float, Field(ge=0.0, le=1.0)] = 0.8
-    """Maximum assignment cost accepted when matching detections to tracks.
-    The cost is ``1 - IoU``, score-fused to ``1 - IoU * score`` where fusion
-    applies, so larger values accept weaker overlaps."""
-
-    score_threshold: Annotated[float, Field(ge=0.0, le=1.0)] = 0.1
-    """Drop detections with confidence below this value before matching runs."""
-
-    high_score_threshold: Annotated[float, Field(ge=0.0, le=1.0)] = 0.6
-    """Boundary used by two-stage association (ByteTrack) to split detections into high-score and low-score buckets."""
-
-    match_class_only: bool = True
-    """Restrict matching to detection-track pairs that share a class id."""
-
-    class_filter: list[int] | None = None
-    """Track only detections whose class id is in this list; None tracks all
-    classes. Applied before association, so excluded classes never spawn or
-    match tracks."""
-
-
 class LifecycleConfig(_StrictModel):
     """Track creation, confirmation, and removal parameters."""
 
@@ -93,25 +72,6 @@ class MotionConfig(_StrictModel):
     """Per-frame velocity damping in ``(0, 1]``. Values below 1.0 simulate gradual deceleration."""
 
 
-class AppearanceConfig(_StrictModel):
-    """Appearance and embedding-based matching parameters."""
-
-    enabled: bool = False
-    """Fuse appearance similarity into the matching cost when true."""
-
-    embedding_dim: Annotated[int, Field(ge=1)] = 512
-    """Feature-vector dimensionality expected from a detector or re-identification head."""
-
-    similarity_threshold: Annotated[float, Field(ge=0.0, le=1.0)] = 0.7
-    """Minimum cosine similarity accepted as an appearance match."""
-
-    memory_bank_size: Annotated[int, Field(ge=1)] = 10
-    """Number of recent embeddings retained per track."""
-
-    weight: Annotated[float, Field(ge=0.0, le=1.0)] = 0.5
-    """Blend between motion and appearance cost: 0.0 is pure motion, 1.0 is pure appearance."""
-
-
 class InterpolationConfig(_StrictModel):
     """Bbox interpolation and smoothing parameters."""
 
@@ -132,20 +92,26 @@ class InterpolationConfig(_StrictModel):
 
 
 class TrackerConfig(_StrictModel):
-    """Top-level tracker configuration.
+    """Parameters shared by all tracking algorithms.
 
-    Construct from a YAML file via `TrackerConfig.from_yaml`, from a dict
-    via `TrackerConfig.model_validate`, or programmatically.
+    Each algorithm subclasses this with its own parameters and pins
+    ``algorithm`` to a single value. Load any variant from YAML via
+    `TrackerConfig.from_yaml`, which dispatches on the ``algorithm`` key.
     """
 
-    algorithm: AlgorithmType = AlgorithmType.BYTETRACK
-    """Algorithm identifier. Each value resolves to a registered `BaseTracker` subclass."""
+    algorithm: AlgorithmType
+    """Algorithm identifier; each subclass defaults it to a single value."""
 
     verbose: bool = False
     """Log a one-line tracking summary per frame at INFO level on the ``getitrack`` logger."""
 
-    association: AssociationConfig = Field(default_factory=AssociationConfig)
-    """Detection-to-track matching parameters."""
+    class_filter: list[int] | None = None
+    """Track only detections whose class id is in this list; None tracks all
+    classes. Applied before association, so excluded classes never spawn or
+    match tracks."""
+
+    score_threshold: Annotated[float, Field(ge=0.0, le=1.0)] = 0.1
+    """Drop detections with confidence below this value before tracking runs."""
 
     lifecycle: LifecycleConfig = Field(default_factory=LifecycleConfig)
     """Track creation, confirmation, and removal parameters."""
@@ -153,18 +119,21 @@ class TrackerConfig(_StrictModel):
     motion: MotionConfig = Field(default_factory=MotionConfig)
     """Kalman filter and motion model parameters."""
 
-    appearance: AppearanceConfig = Field(default_factory=AppearanceConfig)
-    """Appearance and embedding-based matching parameters."""
-
     interpolation: InterpolationConfig = Field(default_factory=InterpolationConfig)
     """Bbox interpolation and smoothing parameters."""
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> TrackerConfig:
-        """Load a validated configuration from a YAML file."""
+        """Load and validate a tracker configuration from a YAML file.
+
+        Dispatches on the ``algorithm`` key (default ``bytetrack``) and returns
+        the matching algorithm's config variant.
+        """
+        from getitrack.core.registry import resolve_tracker_config
+
         with Path(path).open(encoding="utf-8") as f:
             raw: Any = yaml.safe_load(f)
-        return cls.model_validate(raw or {})
+        return resolve_tracker_config(raw or {})
 
     def to_yaml(self, path: str | Path) -> None:
         """Serialise this configuration to a YAML file."""

--- a/libraries/getitrack/src/getitrack/core/__init__.py
+++ b/libraries/getitrack/src/getitrack/core/__init__.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Core data types and tracker interface."""
 
-from getitrack.core.base import ALGORITHM_REGISTRY, BaseTracker, register_algorithm
+from getitrack.core.base import BaseTracker
 from getitrack.core.detection import Detections, TrackedDetections, TrackState
+from getitrack.core.registry import ALGORITHM_REGISTRY, register_algorithm
 from getitrack.core.track import Track
 
 __all__ = [

--- a/libraries/getitrack/src/getitrack/core/__init__.py
+++ b/libraries/getitrack/src/getitrack/core/__init__.py
@@ -3,9 +3,9 @@
 """Core data types and tracker interface."""
 
 from getitrack.core.base import BaseTracker
-from getitrack.core.detection import Detections, TrackedDetections, TrackState
+from getitrack.core.detection import Detections, TrackedDetections
 from getitrack.core.registry import ALGORITHM_REGISTRY, register_algorithm
-from getitrack.core.track import Track
+from getitrack.core.track import Track, TrackState
 
 __all__ = [
     "ALGORITHM_REGISTRY",

--- a/libraries/getitrack/src/getitrack/core/__init__.py
+++ b/libraries/getitrack/src/getitrack/core/__init__.py
@@ -1,3 +1,17 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 """Core data types and tracker interface."""
+
+from getitrack.core.base import ALGORITHM_REGISTRY, BaseTracker, register_algorithm
+from getitrack.core.detection import Detections, TrackedDetections, TrackState
+from getitrack.core.track import Track
+
+__all__ = [
+    "ALGORITHM_REGISTRY",
+    "BaseTracker",
+    "Detections",
+    "Track",
+    "TrackState",
+    "TrackedDetections",
+    "register_algorithm",
+]

--- a/libraries/getitrack/src/getitrack/core/base.py
+++ b/libraries/getitrack/src/getitrack/core/base.py
@@ -1,0 +1,150 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Tracker interface and algorithm registry.
+
+Concrete trackers register themselves with the `register_algorithm`
+decorator, and `BaseTracker.from_config` dispatches on the registered
+name. The registry is populated once the algorithm modules are imported.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import replace
+from pathlib import Path
+from typing import TYPE_CHECKING, ClassVar
+
+import numpy as np
+
+from getitrack.logger import LOGGER, enable_console_output
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from getitrack.config import TrackerConfig
+    from getitrack.core.detection import Detections, TrackedDetections
+
+
+ALGORITHM_REGISTRY: dict[str, type[BaseTracker]] = {}
+
+
+def register_algorithm(name: str) -> Callable[[type[BaseTracker]], type[BaseTracker]]:
+    """Return a decorator that registers a `BaseTracker` subclass under ``name``."""
+
+    def _wrap(cls: type[BaseTracker]) -> type[BaseTracker]:
+        if name in ALGORITHM_REGISTRY:
+            msg = f"algorithm '{name}' is already registered by {ALGORITHM_REGISTRY[name].__name__}"
+            raise ValueError(msg)
+        ALGORITHM_REGISTRY[name] = cls
+        return cls
+
+    return _wrap
+
+
+class BaseTracker(ABC):
+    """Abstract base class for multi-object trackers.
+
+    Concrete subclasses implement `_update_impl`; the public `update`
+    wraps it with cross-cutting concerns such as verbose logging. The
+    base owns the monotonic id allocator and `_frame_id` bookkeeping so
+    subclasses focus on association logic. Track ids are scoped per
+    instance (not per process), so parallel tracker instances do not
+    collide.
+    """
+
+    algorithm_name: ClassVar[str] = ""
+
+    def __init__(self, config: TrackerConfig) -> None:
+        self.config = config
+        self._next_id: int = 1
+        self._frame_id: int | None = None
+        if config.verbose:
+            enable_console_output()
+
+    def update(self, detections: Detections) -> TrackedDetections:
+        """Process one frame's detections and return the tracker output.
+
+        Applies ``association.class_filter`` before the algorithm runs,
+        so excluded classes never spawn or match tracks. ``det_indices``
+        on the output always index into the unfiltered ``detections``
+        passed here.
+        """
+        class_filter = self.config.association.class_filter
+        filtered = detections if class_filter is None else detections.filter_by_class(class_filter)
+        tracked = self._update_impl(filtered)
+        if class_filter is not None and tracked.det_indices is not None:
+            remapped = self._remap_det_indices(detections, class_filter, tracked.det_indices)
+            tracked = replace(tracked, det_indices=remapped)
+        if self.config.verbose:
+            self._log_update(filtered, tracked)
+        return tracked
+
+    @staticmethod
+    def _remap_det_indices(detections: Detections, class_filter: list[int], det_indices: np.ndarray) -> np.ndarray:
+        """Map ``det_indices`` from filtered-row space back to input rows."""
+        source_rows = np.flatnonzero(np.isin(detections.class_ids, np.asarray(class_filter, dtype=np.int64)))
+        remapped = det_indices.copy()
+        matched = remapped >= 0
+        remapped[matched] = source_rows[remapped[matched]]
+        return remapped
+
+    @abstractmethod
+    def _update_impl(self, detections: Detections) -> TrackedDetections:
+        """Algorithm-specific tracking step for one frame."""
+
+    def _log_update(self, detections: Detections, tracked: TrackedDetections) -> None:
+        """Emit a one-line per-frame summary on the ``getitrack`` logger."""
+        n_high = int((detections.scores >= self.config.association.high_score_threshold).sum())
+        pairs = ", ".join(
+            f"{tid}:{cls}:{score:.2f}"
+            for tid, cls, score in zip(
+                tracked.track_ids.tolist(),
+                tracked.class_ids.tolist(),
+                tracked.scores.tolist(),
+                strict=True,
+            )
+        )
+        LOGGER.info(
+            "frame %4d: %d detections (%d high-score), %d tracks [id:class:score %s]",
+            detections.frame_id,
+            len(detections),
+            n_high,
+            len(tracked),
+            pairs,
+        )
+
+    def reset(self) -> None:
+        """Clear internal state between videos or sequences."""
+        self._next_id = 1
+        self._frame_id = None
+
+    def _allocate_id(self) -> int:
+        """Return a fresh monotonic id for a new track."""
+        new_id = self._next_id
+        self._next_id += 1
+        return new_id
+
+    @classmethod
+    def from_config(cls, config: TrackerConfig | dict | str | Path) -> BaseTracker:
+        """Instantiate a tracker dispatched on ``config.algorithm``.
+
+        Accepts a `TrackerConfig`, a dict, or a path to a YAML file.
+        """
+        from getitrack.config import TrackerConfig as _TrackerConfig
+
+        if isinstance(config, _TrackerConfig):
+            resolved = config
+        elif isinstance(config, dict):
+            resolved = _TrackerConfig.model_validate(config)
+        elif isinstance(config, str | Path):
+            resolved = _TrackerConfig.from_yaml(config)
+        else:
+            msg = f"unsupported config type: {type(config).__name__}"
+            raise TypeError(msg)
+
+        name = resolved.algorithm.value
+        if name not in ALGORITHM_REGISTRY:
+            known = sorted(ALGORITHM_REGISTRY) or ["<none registered>"]
+            msg = f"unknown algorithm '{name}'; registered: {known}"
+            raise KeyError(msg)
+        return ALGORITHM_REGISTRY[name](resolved)

--- a/libraries/getitrack/src/getitrack/core/base.py
+++ b/libraries/getitrack/src/getitrack/core/base.py
@@ -14,12 +14,12 @@ from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
-import numpy as np
-
 from getitrack.logger import LOGGER, enable_logging
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    import numpy as np
 
     from getitrack.config import TrackerConfig
     from getitrack.core.detection import Detections, TrackedDetections
@@ -70,19 +70,21 @@ class BaseTracker(ABC):
         passed here.
         """
         class_filter = self.config.association.class_filter
-        filtered = detections if class_filter is None else detections.filter_by_class(class_filter)
+        if class_filter is None:
+            filtered, source_rows = detections, None
+        else:
+            filtered, source_rows = detections.filter_by_class(class_filter)
         tracked = self._update_impl(filtered)
-        if class_filter is not None and tracked.det_indices is not None:
-            remapped = self._remap_det_indices(detections, class_filter, tracked.det_indices)
+        if source_rows is not None and tracked.det_indices is not None:
+            remapped = self._remap_det_indices(source_rows, tracked.det_indices)
             tracked = replace(tracked, det_indices=remapped)
         if self.config.verbose:
             self._log_update(filtered, tracked)
         return tracked
 
     @staticmethod
-    def _remap_det_indices(detections: Detections, class_filter: list[int], det_indices: np.ndarray) -> np.ndarray:
+    def _remap_det_indices(source_rows: np.ndarray, det_indices: np.ndarray) -> np.ndarray:
         """Map ``det_indices`` from filtered-row space back to input rows."""
-        source_rows = np.flatnonzero(np.isin(detections.class_ids, np.asarray(class_filter, dtype=np.int64)))
         remapped = det_indices.copy()
         matched = remapped >= 0
         remapped[matched] = source_rows[remapped[matched]]

--- a/libraries/getitrack/src/getitrack/core/base.py
+++ b/libraries/getitrack/src/getitrack/core/base.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 import numpy as np
 
-from getitrack.logger import LOGGER, enable_console_output
+from getitrack.logger import LOGGER, enable_logging
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -59,7 +59,7 @@ class BaseTracker(ABC):
         self._next_id: int = 1
         self._frame_id: int | None = None
         if config.verbose:
-            enable_console_output()
+            enable_logging()
 
     def update(self, detections: Detections) -> TrackedDetections:
         """Process one frame's detections and return the tracker output.
@@ -105,7 +105,7 @@ class BaseTracker(ABC):
             )
         )
         LOGGER.info(
-            "frame %4d: %d detections (%d high-score), %d tracks [id:class:score %s]",
+            "frame {:4}: {} detections ({} high-score), {} tracks [id:class:score {}]",
             detections.frame_id,
             len(detections),
             n_high,

--- a/libraries/getitrack/src/getitrack/core/base.py
+++ b/libraries/getitrack/src/getitrack/core/base.py
@@ -14,13 +14,13 @@ from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
+from getitrack.config import TrackerConfig
 from getitrack.core.registry import ALGORITHM_REGISTRY
 from getitrack.logger import LOGGER, enable_logging
 
 if TYPE_CHECKING:
     import numpy as np
 
-    from getitrack.config import TrackerConfig
     from getitrack.core.detection import Detections, TrackedDetections
 
 
@@ -115,14 +115,12 @@ class BaseTracker(ABC):
 
         Accepts a `TrackerConfig`, a dict, or a path to a YAML file.
         """
-        from getitrack.config import TrackerConfig as _TrackerConfig
-
-        if isinstance(config, _TrackerConfig):
+        if isinstance(config, TrackerConfig):
             resolved = config
         elif isinstance(config, dict):
-            resolved = _TrackerConfig.model_validate(config)
+            resolved = TrackerConfig.model_validate(config)
         elif isinstance(config, str | Path):
-            resolved = _TrackerConfig.from_yaml(config)
+            resolved = TrackerConfig.from_yaml(config)
         else:
             msg = f"unsupported config type: {type(config).__name__}"
             raise TypeError(msg)

--- a/libraries/getitrack/src/getitrack/core/base.py
+++ b/libraries/getitrack/src/getitrack/core/base.py
@@ -12,10 +12,10 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar
 
 from getitrack.config import TrackerConfig
-from getitrack.core.registry import ALGORITHM_REGISTRY
+from getitrack.core.registry import ALGORITHM_REGISTRY, resolve_tracker_config
 from getitrack.logger import LOGGER, enable_logging
 
 if TYPE_CHECKING:
@@ -23,8 +23,10 @@ if TYPE_CHECKING:
 
     from getitrack.core.detection import Detections, TrackedDetections
 
+ConfigT = TypeVar("ConfigT", bound=TrackerConfig)
 
-class BaseTracker(ABC):
+
+class BaseTracker(ABC, Generic[ConfigT]):
     """Abstract base class for multi-object trackers.
 
     Concrete subclasses implement `_update_impl`; the public `update`
@@ -36,8 +38,10 @@ class BaseTracker(ABC):
     """
 
     algorithm_name: ClassVar[str] = ""
+    config_cls: ClassVar[type[TrackerConfig]]
+    config: ConfigT
 
-    def __init__(self, config: TrackerConfig) -> None:
+    def __init__(self, config: ConfigT) -> None:
         self.config = config
         self._next_id: int = 1
         self._frame_id: int | None = None
@@ -47,12 +51,11 @@ class BaseTracker(ABC):
     def update(self, detections: Detections) -> TrackedDetections:
         """Process one frame's detections and return the tracker output.
 
-        Applies ``association.class_filter`` before the algorithm runs,
-        so excluded classes never spawn or match tracks. ``det_indices``
-        on the output always index into the unfiltered ``detections``
-        passed here.
+        Applies ``class_filter`` before the algorithm runs, so excluded
+        classes never spawn or match tracks. ``det_indices`` on the output
+        always index into the unfiltered ``detections`` passed here.
         """
-        class_filter = self.config.association.class_filter
+        class_filter = self.config.class_filter
         if class_filter is None:
             filtered, source_rows = detections, None
         else:
@@ -79,7 +82,6 @@ class BaseTracker(ABC):
 
     def _log_update(self, detections: Detections, tracked: TrackedDetections) -> None:
         """Emit a one-line per-frame summary on the ``getitrack`` logger."""
-        n_high = int((detections.scores >= self.config.association.high_score_threshold).sum())
         pairs = ", ".join(
             f"{tid}:{cls}:{score:.2f}"
             for tid, cls, score in zip(
@@ -90,10 +92,9 @@ class BaseTracker(ABC):
             )
         )
         LOGGER.info(
-            "frame {:4}: {} detections ({} high-score), {} tracks [id:class:score {}]",
+            "frame {:4}: {} detections, {} tracks [id:class:score {}]",
             detections.frame_id,
             len(detections),
-            n_high,
             len(tracked),
             pairs,
         )
@@ -113,12 +114,12 @@ class BaseTracker(ABC):
     def from_config(cls, config: TrackerConfig | dict[str, Any] | str | Path) -> BaseTracker:
         """Instantiate a tracker dispatched on ``config.algorithm``.
 
-        Accepts a `TrackerConfig`, a dict, or a path to a YAML file.
+        Accepts a tracker-config variant, a dict, or a path to a YAML file.
         """
         if isinstance(config, TrackerConfig):
             resolved = config
         elif isinstance(config, dict):
-            resolved = TrackerConfig.model_validate(config)
+            resolved = resolve_tracker_config(config)
         elif isinstance(config, str | Path):
             resolved = TrackerConfig.from_yaml(config)
         else:

--- a/libraries/getitrack/src/getitrack/core/base.py
+++ b/libraries/getitrack/src/getitrack/core/base.py
@@ -117,7 +117,7 @@ class BaseTracker(ABC, Generic[ConfigT]):
         Accepts a tracker-config variant, a dict, or a path to a YAML file.
         """
         if isinstance(config, TrackerConfig):
-            resolved = config
+            resolved = resolve_tracker_config(config.model_dump())
         elif isinstance(config, dict):
             resolved = resolve_tracker_config(config)
         elif isinstance(config, str | Path):

--- a/libraries/getitrack/src/getitrack/core/base.py
+++ b/libraries/getitrack/src/getitrack/core/base.py
@@ -14,31 +14,14 @@ from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
+from getitrack.core.registry import ALGORITHM_REGISTRY
 from getitrack.logger import LOGGER, enable_logging
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     import numpy as np
 
     from getitrack.config import TrackerConfig
     from getitrack.core.detection import Detections, TrackedDetections
-
-
-ALGORITHM_REGISTRY: dict[str, type[BaseTracker]] = {}
-
-
-def register_algorithm(name: str) -> Callable[[type[BaseTracker]], type[BaseTracker]]:
-    """Return a decorator that registers a `BaseTracker` subclass under ``name``."""
-
-    def _wrap(cls: type[BaseTracker]) -> type[BaseTracker]:
-        if name in ALGORITHM_REGISTRY:
-            msg = f"algorithm '{name}' is already registered by {ALGORITHM_REGISTRY[name].__name__}"
-            raise ValueError(msg)
-        ALGORITHM_REGISTRY[name] = cls
-        return cls
-
-    return _wrap
 
 
 class BaseTracker(ABC):

--- a/libraries/getitrack/src/getitrack/core/base.py
+++ b/libraries/getitrack/src/getitrack/core/base.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import replace
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from getitrack.logger import LOGGER, enable_logging
 
@@ -127,7 +127,7 @@ class BaseTracker(ABC):
         return new_id
 
     @classmethod
-    def from_config(cls, config: TrackerConfig | dict | str | Path) -> BaseTracker:
+    def from_config(cls, config: TrackerConfig | dict[str, Any] | str | Path) -> BaseTracker:
         """Instantiate a tracker dispatched on ``config.algorithm``.
 
         Accepts a `TrackerConfig`, a dict, or a path to a YAML file.

--- a/libraries/getitrack/src/getitrack/core/detection.py
+++ b/libraries/getitrack/src/getitrack/core/detection.py
@@ -30,10 +30,16 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from getitrack.core.validation import (
+    BBOX_COLS,
+    validate_bboxes,
+    validate_dtypes,
+    validate_row_aligned,
+    validate_scores,
+)
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
-
-_BBOX_COLS = 4
 
 
 class TrackState(StrEnum):
@@ -81,15 +87,15 @@ class Detections:
     embeddings: np.ndarray | None = None
 
     def __post_init__(self) -> None:
-        _validate_bboxes(self.bboxes)
-        _validate_row_aligned(
+        validate_bboxes(self.bboxes)
+        validate_row_aligned(
             n=self.bboxes.shape[0],
             scores=self.scores,
             class_ids=self.class_ids,
             embeddings=self.embeddings,
         )
-        _validate_scores(self.scores)
-        _validate_dtypes(
+        validate_scores(self.scores)
+        validate_dtypes(
             bboxes=(self.bboxes, np.float32),
             scores=(self.scores, np.float32),
             class_ids=(self.class_ids, np.int64),
@@ -136,7 +142,7 @@ class Detections:
     def create_empty(cls, frame_id: int) -> Detections:
         """Construct an empty `Detections` for the given frame."""
         return cls(
-            bboxes=np.empty((0, _BBOX_COLS), dtype=np.float32),
+            bboxes=np.empty((0, BBOX_COLS), dtype=np.float32),
             scores=np.empty((0,), dtype=np.float32),
             class_ids=np.empty((0,), dtype=np.int64),
             frame_id=frame_id,
@@ -176,8 +182,8 @@ class TrackedDetections:
     interpolated: np.ndarray | None = field(default=None)
 
     def __post_init__(self) -> None:
-        _validate_bboxes(self.bboxes)
-        _validate_row_aligned(
+        validate_bboxes(self.bboxes)
+        validate_row_aligned(
             n=self.bboxes.shape[0],
             scores=self.scores,
             class_ids=self.class_ids,
@@ -186,9 +192,9 @@ class TrackedDetections:
             det_indices=self.det_indices,
             interpolated=self.interpolated,
         )
-        _validate_scores(self.scores)
+        validate_scores(self.scores)
         _validate_track_states(self.track_states)
-        _validate_dtypes(
+        validate_dtypes(
             bboxes=(self.bboxes, np.float32),
             scores=(self.scores, np.float32),
             class_ids=(self.class_ids, np.int64),
@@ -223,7 +229,7 @@ class TrackedDetections:
     def create_empty(cls, frame_id: int) -> TrackedDetections:
         """Construct an empty `TrackedDetections` for the given frame."""
         return cls(
-            bboxes=np.empty((0, _BBOX_COLS), dtype=np.float32),
+            bboxes=np.empty((0, BBOX_COLS), dtype=np.float32),
             scores=np.empty((0,), dtype=np.float32),
             class_ids=np.empty((0,), dtype=np.int64),
             track_ids=np.empty((0,), dtype=np.int64),
@@ -232,45 +238,11 @@ class TrackedDetections:
         )
 
 
-def _validate_bboxes(bboxes: np.ndarray) -> None:
-    if bboxes.ndim != 2 or bboxes.shape[1] != _BBOX_COLS:
-        msg = f"bboxes must have shape (N, {_BBOX_COLS}); got {bboxes.shape}"
-        raise ValueError(msg)
-
-
-def _validate_row_aligned(*, n: int, **arrays: np.ndarray | None) -> None:
-    for name, arr in arrays.items():
-        if arr is None:
-            continue
-        if arr.shape[0] != n:
-            msg = f"{name} has {arr.shape[0]} rows; expected {n} to match bboxes"
-            raise ValueError(msg)
-
-
-def _validate_scores(scores: np.ndarray) -> None:
-    if scores.size and (scores.min() < 0.0 or scores.max() > 1.0):
-        msg = f"scores must be in [0, 1]; got min={scores.min()} max={scores.max()}"
-        raise ValueError(msg)
-
-
 def _validate_track_states(states: np.ndarray) -> None:
+    """Raise if any track-state ordinal is outside the `TrackState` range."""
     if states.size == 0:
         return
     n_states = len(TrackState)
     if states.min() < 0 or states.max() >= n_states:
         msg = f"track_states ordinals must be in [0, {n_states}); got min={states.min()} max={states.max()}"
         raise ValueError(msg)
-
-
-def _validate_dtypes(**checks: tuple[np.ndarray, type] | None) -> None:
-    """Raise if any ``(array, expected_dtype)`` pair has a mismatched dtype.
-
-    Pass ``None`` for absent optional fields to keep the call site flat.
-    """
-    for name, item in checks.items():
-        if item is None:
-            continue
-        arr, expected = item
-        if arr.dtype != expected:
-            msg = f"{name} must have dtype {np.dtype(expected).name}; got {arr.dtype.name}"
-            raise TypeError(msg)

--- a/libraries/getitrack/src/getitrack/core/detection.py
+++ b/libraries/getitrack/src/getitrack/core/detection.py
@@ -1,0 +1,271 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Per-frame detection and tracker-output containers.
+
+`Detections` and `TrackedDetections` are framework-agnostic numpy
+dataclasses with eager shape, dtype, and value validation in
+``__post_init__``.
+
+Bounding boxes are always ``(N, 4)`` in ``xyxy`` order
+(``[x1, y1, x2, y2]`` with ``x1 < x2`` and ``y1 < y2``) in absolute pixel
+coordinates of the source image. Other formats (``cxcywh``, normalised,
+etc.) are converted at the boundary.
+
+Required dtypes (enforced, not coerced, so silent casts cannot mask
+precision drift downstream):
+
+- ``bboxes``: float32
+- ``scores``: float32
+- ``class_ids``: int64
+- ``track_ids``: int64
+- ``track_states``: int8
+- ``embeddings``: float32
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+_BBOX_COLS = 4
+
+
+class TrackState(StrEnum):
+    """Lifecycle states of a single track.
+
+    State transitions are defined in `getitrack.core.track`.
+    `TrackedDetections.track_states` stores values as int8 ordinals where
+    the ordinal is the member's 0-based position in declaration order.
+    """
+
+    TENTATIVE = "tentative"
+    ACTIVE = "active"
+    LOST = "lost"
+    REMOVED = "removed"
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int) -> TrackState:
+        """Return the member at a given 0-based ordinal."""
+        return list(cls)[ordinal]
+
+    def ordinal(self) -> int:
+        """Return this member's 0-based ordinal."""
+        return list(type(self)).index(self)
+
+
+@dataclass
+class Detections:
+    """One frame's detector output, before tracking.
+
+    A tracker consumes a `Detections` and emits a `TrackedDetections`
+    that adds track ids and lifecycle states.
+
+    Attributes:
+        bboxes: ``(N, 4)`` float32 array in ``xyxy`` order.
+        scores: ``(N,)`` float32 confidence scores in ``[0, 1]``.
+        class_ids: ``(N,)`` int64 class identifiers.
+        frame_id: Index of the frame this batch belongs to.
+        embeddings: Optional ``(N, D)`` float32 appearance features.
+    """
+
+    bboxes: np.ndarray
+    scores: np.ndarray
+    class_ids: np.ndarray
+    frame_id: int
+    embeddings: np.ndarray | None = None
+
+    def __post_init__(self) -> None:
+        _validate_bboxes(self.bboxes)
+        _validate_row_aligned(
+            n=self.bboxes.shape[0],
+            scores=self.scores,
+            class_ids=self.class_ids,
+            embeddings=self.embeddings,
+        )
+        _validate_scores(self.scores)
+        _validate_dtypes(
+            bboxes=(self.bboxes, np.float32),
+            scores=(self.scores, np.float32),
+            class_ids=(self.class_ids, np.int64),
+            embeddings=(self.embeddings, np.float32) if self.embeddings is not None else None,
+        )
+
+    def __len__(self) -> int:
+        return int(self.bboxes.shape[0])
+
+    def filter_by_score(self, threshold: float) -> Detections:
+        """Return rows whose score is at least ``threshold``."""
+        keep = self.scores >= threshold
+        return self._index(keep)
+
+    def split_by_score(self, threshold: float) -> tuple[Detections, Detections]:
+        """Return ``(high, low)`` partitions split at ``threshold``.
+
+        Used by ByteTrack's two-stage association.
+        """
+        high = self.scores >= threshold
+        return self._index(high), self._index(~high)
+
+    def filter_by_class(self, class_ids: Sequence[int]) -> Detections:
+        """Return rows whose class id appears in ``class_ids``."""
+        wanted = np.asarray(list(class_ids), dtype=np.int64)
+        keep = np.isin(self.class_ids, wanted)
+        return self._index(keep)
+
+    def _index(self, mask: np.ndarray) -> Detections:
+        return Detections(
+            bboxes=self.bboxes[mask],
+            scores=self.scores[mask],
+            class_ids=self.class_ids[mask],
+            frame_id=self.frame_id,
+            embeddings=None if self.embeddings is None else self.embeddings[mask],
+        )
+
+    @classmethod
+    def create_empty(cls, frame_id: int) -> Detections:
+        """Construct an empty `Detections` for the given frame."""
+        return cls(
+            bboxes=np.empty((0, _BBOX_COLS), dtype=np.float32),
+            scores=np.empty((0,), dtype=np.float32),
+            class_ids=np.empty((0,), dtype=np.int64),
+            frame_id=frame_id,
+        )
+
+
+@dataclass
+class TrackedDetections:
+    """One frame's tracker output.
+
+    Each row carries a track id and a lifecycle state in addition to the
+    detection fields. The ``interpolated`` flag is set by the
+    post-processing interpolator.
+
+    Attributes:
+        bboxes: ``(N, 4)`` float32 array in ``xyxy`` order.
+        scores: ``(N,)`` float32 confidence scores in ``[0, 1]``.
+        class_ids: ``(N,)`` int64 class identifiers.
+        track_ids: ``(N,)`` int64 stable per-object identifiers.
+        track_states: ``(N,)`` int8 ordinals of `TrackState`.
+        frame_id: Index of the frame this batch belongs to.
+        det_indices: Optional ``(N,)`` int64 row indices into the frame's
+            input `Detections`, identifying the detection that produced
+            each row. -1 marks rows without a source detection (e.g.
+            interpolated boxes). Lets callers re-attach per-detection data
+            such as embeddings or masks to tracks.
+        interpolated: Optional ``(N,)`` bool flag marking interpolated bboxes.
+    """
+
+    bboxes: np.ndarray
+    scores: np.ndarray
+    class_ids: np.ndarray
+    track_ids: np.ndarray
+    track_states: np.ndarray
+    frame_id: int
+    det_indices: np.ndarray | None = field(default=None)
+    interpolated: np.ndarray | None = field(default=None)
+
+    def __post_init__(self) -> None:
+        _validate_bboxes(self.bboxes)
+        _validate_row_aligned(
+            n=self.bboxes.shape[0],
+            scores=self.scores,
+            class_ids=self.class_ids,
+            track_ids=self.track_ids,
+            track_states=self.track_states,
+            det_indices=self.det_indices,
+            interpolated=self.interpolated,
+        )
+        _validate_scores(self.scores)
+        _validate_track_states(self.track_states)
+        _validate_dtypes(
+            bboxes=(self.bboxes, np.float32),
+            scores=(self.scores, np.float32),
+            class_ids=(self.class_ids, np.int64),
+            track_ids=(self.track_ids, np.int64),
+            track_states=(self.track_states, np.int8),
+            det_indices=(self.det_indices, np.int64) if self.det_indices is not None else None,
+            interpolated=(self.interpolated, np.bool_) if self.interpolated is not None else None,
+        )
+
+    def __len__(self) -> int:
+        return int(self.bboxes.shape[0])
+
+    def active_only(self) -> TrackedDetections:
+        """Return rows whose state is ``TrackState.ACTIVE``."""
+        keep = self.track_states == TrackState.ACTIVE.ordinal()
+        return TrackedDetections(
+            bboxes=self.bboxes[keep],
+            scores=self.scores[keep],
+            class_ids=self.class_ids[keep],
+            track_ids=self.track_ids[keep],
+            track_states=self.track_states[keep],
+            frame_id=self.frame_id,
+            det_indices=None if self.det_indices is None else self.det_indices[keep],
+            interpolated=None if self.interpolated is None else self.interpolated[keep],
+        )
+
+    def to_string_states(self) -> list[str]:
+        """Return per-row state names as lowercase strings."""
+        return [TrackState.from_ordinal(int(o)).value for o in self.track_states]
+
+    @classmethod
+    def create_empty(cls, frame_id: int) -> TrackedDetections:
+        """Construct an empty `TrackedDetections` for the given frame."""
+        return cls(
+            bboxes=np.empty((0, _BBOX_COLS), dtype=np.float32),
+            scores=np.empty((0,), dtype=np.float32),
+            class_ids=np.empty((0,), dtype=np.int64),
+            track_ids=np.empty((0,), dtype=np.int64),
+            track_states=np.empty((0,), dtype=np.int8),
+            frame_id=frame_id,
+        )
+
+
+def _validate_bboxes(bboxes: np.ndarray) -> None:
+    if bboxes.ndim != 2 or bboxes.shape[1] != _BBOX_COLS:
+        msg = f"bboxes must have shape (N, {_BBOX_COLS}); got {bboxes.shape}"
+        raise ValueError(msg)
+
+
+def _validate_row_aligned(*, n: int, **arrays: np.ndarray | None) -> None:
+    for name, arr in arrays.items():
+        if arr is None:
+            continue
+        if arr.shape[0] != n:
+            msg = f"{name} has {arr.shape[0]} rows; expected {n} to match bboxes"
+            raise ValueError(msg)
+
+
+def _validate_scores(scores: np.ndarray) -> None:
+    if scores.size and (scores.min() < 0.0 or scores.max() > 1.0):
+        msg = f"scores must be in [0, 1]; got min={scores.min()} max={scores.max()}"
+        raise ValueError(msg)
+
+
+def _validate_track_states(states: np.ndarray) -> None:
+    if states.size == 0:
+        return
+    n_states = len(TrackState)
+    if states.min() < 0 or states.max() >= n_states:
+        msg = f"track_states ordinals must be in [0, {n_states}); got min={states.min()} max={states.max()}"
+        raise ValueError(msg)
+
+
+def _validate_dtypes(**checks: tuple[np.ndarray, type] | None) -> None:
+    """Raise if any ``(array, expected_dtype)`` pair has a mismatched dtype.
+
+    Pass ``None`` for absent optional fields to keep the call site flat.
+    """
+    for name, item in checks.items():
+        if item is None:
+            continue
+        arr, expected = item
+        if arr.dtype != expected:
+            msg = f"{name} must have dtype {np.dtype(expected).name}; got {arr.dtype.name}"
+            raise TypeError(msg)

--- a/libraries/getitrack/src/getitrack/core/detection.py
+++ b/libraries/getitrack/src/getitrack/core/detection.py
@@ -24,7 +24,7 @@ precision drift downstream):
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
@@ -178,8 +178,8 @@ class TrackedDetections:
     track_ids: np.ndarray
     track_states: np.ndarray
     frame_id: int
-    det_indices: np.ndarray | None = field(default=None)
-    interpolated: np.ndarray | None = field(default=None)
+    det_indices: np.ndarray | None = None
+    interpolated: np.ndarray | None = None
 
     def __post_init__(self) -> None:
         validate_bboxes(self.bboxes)

--- a/libraries/getitrack/src/getitrack/core/detection.py
+++ b/libraries/getitrack/src/getitrack/core/detection.py
@@ -112,11 +112,16 @@ class Detections:
         high = self.scores >= threshold
         return self._index(high), self._index(~high)
 
-    def filter_by_class(self, class_ids: Sequence[int]) -> Detections:
-        """Return rows whose class id appears in ``class_ids``."""
+    def filter_by_class(self, class_ids: Sequence[int]) -> tuple[Detections, np.ndarray]:
+        """Return ``(filtered, source_rows)`` for rows whose class is in ``class_ids``.
+
+        ``source_rows`` holds the indices of the kept rows in this
+        `Detections`, letting callers map filtered-row positions back to
+        input rows without recomputing the membership test.
+        """
         wanted = np.asarray(list(class_ids), dtype=np.int64)
-        keep = np.isin(self.class_ids, wanted)
-        return self._index(keep)
+        source_rows = np.flatnonzero(np.isin(self.class_ids, wanted))
+        return self._index(source_rows), source_rows
 
     def _index(self, mask: np.ndarray) -> Detections:
         return Detections(

--- a/libraries/getitrack/src/getitrack/core/detection.py
+++ b/libraries/getitrack/src/getitrack/core/detection.py
@@ -11,8 +11,7 @@ Bounding boxes are always ``(N, 4)`` in ``xyxy`` order
 coordinates of the source image. Other formats (``cxcywh``, normalised,
 etc.) are converted at the boundary.
 
-Required dtypes (enforced, not coerced, so silent casts cannot mask
-precision drift downstream):
+Required dtypes (enforced, not coerced):
 
 - ``bboxes``: float32
 - ``scores``: float32

--- a/libraries/getitrack/src/getitrack/core/detection.py
+++ b/libraries/getitrack/src/getitrack/core/detection.py
@@ -25,44 +25,22 @@ precision drift downstream):
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import StrEnum
 from typing import TYPE_CHECKING
 
 import numpy as np
 
+from getitrack.core.track import TrackState
 from getitrack.core.validation import (
     BBOX_COLS,
     validate_bboxes,
     validate_dtypes,
     validate_row_aligned,
     validate_scores,
+    validate_value_range,
 )
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-
-
-class TrackState(StrEnum):
-    """Lifecycle states of a single track.
-
-    State transitions are defined in `getitrack.core.track`.
-    `TrackedDetections.track_states` stores values as int8 ordinals where
-    the ordinal is the member's 0-based position in declaration order.
-    """
-
-    TENTATIVE = "tentative"
-    ACTIVE = "active"
-    LOST = "lost"
-    REMOVED = "removed"
-
-    @classmethod
-    def from_ordinal(cls, ordinal: int) -> TrackState:
-        """Return the member at a given 0-based ordinal."""
-        return list(cls)[ordinal]
-
-    def ordinal(self) -> int:
-        """Return this member's 0-based ordinal."""
-        return list(type(self)).index(self)
 
 
 @dataclass
@@ -162,7 +140,7 @@ class TrackedDetections:
         scores: ``(N,)`` float32 confidence scores in ``[0, 1]``.
         class_ids: ``(N,)`` int64 class identifiers.
         track_ids: ``(N,)`` int64 stable per-object identifiers.
-        track_states: ``(N,)`` int8 ordinals of `TrackState`.
+        track_states: ``(N,)`` int8 `TrackState` values.
         frame_id: Index of the frame this batch belongs to.
         det_indices: Optional ``(N,)`` int64 row indices into the frame's
             input `Detections`, identifying the detection that produced
@@ -193,7 +171,7 @@ class TrackedDetections:
             interpolated=self.interpolated,
         )
         validate_scores(self.scores)
-        _validate_track_states(self.track_states)
+        validate_value_range(self.track_states, high=len(TrackState), name="track_states")
         validate_dtypes(
             bboxes=(self.bboxes, np.float32),
             scores=(self.scores, np.float32),
@@ -209,21 +187,23 @@ class TrackedDetections:
 
     def active_only(self) -> TrackedDetections:
         """Return rows whose state is ``TrackState.ACTIVE``."""
-        keep = self.track_states == TrackState.ACTIVE.ordinal()
+        return self._index(self.track_states == TrackState.ACTIVE)
+
+    def _index(self, mask: np.ndarray) -> TrackedDetections:
         return TrackedDetections(
-            bboxes=self.bboxes[keep],
-            scores=self.scores[keep],
-            class_ids=self.class_ids[keep],
-            track_ids=self.track_ids[keep],
-            track_states=self.track_states[keep],
+            bboxes=self.bboxes[mask],
+            scores=self.scores[mask],
+            class_ids=self.class_ids[mask],
+            track_ids=self.track_ids[mask],
+            track_states=self.track_states[mask],
             frame_id=self.frame_id,
-            det_indices=None if self.det_indices is None else self.det_indices[keep],
-            interpolated=None if self.interpolated is None else self.interpolated[keep],
+            det_indices=None if self.det_indices is None else self.det_indices[mask],
+            interpolated=None if self.interpolated is None else self.interpolated[mask],
         )
 
     def to_string_states(self) -> list[str]:
         """Return per-row state names as lowercase strings."""
-        return [TrackState.from_ordinal(int(o)).value for o in self.track_states]
+        return [TrackState(int(o)).name.lower() for o in self.track_states]
 
     @classmethod
     def create_empty(cls, frame_id: int) -> TrackedDetections:
@@ -236,13 +216,3 @@ class TrackedDetections:
             track_states=np.empty((0,), dtype=np.int8),
             frame_id=frame_id,
         )
-
-
-def _validate_track_states(states: np.ndarray) -> None:
-    """Raise if any track-state ordinal is outside the `TrackState` range."""
-    if states.size == 0:
-        return
-    n_states = len(TrackState)
-    if states.min() < 0 or states.max() >= n_states:
-        msg = f"track_states ordinals must be in [0, {n_states}); got min={states.min()} max={states.max()}"
-        raise ValueError(msg)

--- a/libraries/getitrack/src/getitrack/core/registry.py
+++ b/libraries/getitrack/src/getitrack/core/registry.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Name-to-class registry for tracker algorithms.
+
+Maps algorithm names to `BaseTracker` subclasses. Subclasses register
+via `register_algorithm`; `BaseTracker.from_config` looks them up by name.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from getitrack.core.base import BaseTracker
+
+
+ALGORITHM_REGISTRY: dict[str, type[BaseTracker]] = {}
+
+
+def register_algorithm(name: str) -> Callable[[type[BaseTracker]], type[BaseTracker]]:
+    """Return a decorator that registers a `BaseTracker` subclass under ``name``."""
+
+    def _wrap(cls: type[BaseTracker]) -> type[BaseTracker]:
+        if name in ALGORITHM_REGISTRY:
+            msg = f"algorithm '{name}' is already registered by {ALGORITHM_REGISTRY[name].__name__}"
+            raise ValueError(msg)
+        ALGORITHM_REGISTRY[name] = cls
+        return cls
+
+    return _wrap

--- a/libraries/getitrack/src/getitrack/core/registry.py
+++ b/libraries/getitrack/src/getitrack/core/registry.py
@@ -2,8 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Name-to-class registry for tracker algorithms.
 
-Maps algorithm names to `BaseTracker` subclasses. Subclasses register
-via `register_algorithm`; `BaseTracker.from_config` looks them up by name.
+Maps algorithm names to `BaseTracker` subclasses and their config classes.
+Subclasses register via `register_algorithm`; `BaseTracker.from_config` looks
+up the tracker by name and `resolve_tracker_config` resolves raw data to the
+matching config variant.
 """
 
 from __future__ import annotations
@@ -13,20 +15,45 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from getitrack.config import TrackerConfig
     from getitrack.core.base import BaseTracker
 
 
 ALGORITHM_REGISTRY: dict[str, type[BaseTracker]] = {}
 
+_DEFAULT_ALGORITHM = "bytetrack"
 
-def register_algorithm(name: str) -> Callable[[type[BaseTracker]], type[BaseTracker]]:
-    """Return a decorator that registers a `BaseTracker` subclass under ``name``."""
+
+def register_algorithm(
+    name: str,
+    config: type[TrackerConfig],
+) -> Callable[[type[BaseTracker]], type[BaseTracker]]:
+    """Return a decorator that registers a `BaseTracker` subclass under ``name``.
+
+    ``config`` is the algorithm's `TrackerConfig` subclass; it is attached
+    to the tracker as ``config_cls`` and used to validate raw configuration.
+    """
 
     def _wrap(cls: type[BaseTracker]) -> type[BaseTracker]:
         if name in ALGORITHM_REGISTRY:
             msg = f"algorithm '{name}' is already registered by {ALGORITHM_REGISTRY[name].__name__}"
             raise ValueError(msg)
+        cls.config_cls = config
         ALGORITHM_REGISTRY[name] = cls
         return cls
 
     return _wrap
+
+
+def resolve_tracker_config(data: object) -> TrackerConfig:
+    """Resolve a raw configuration mapping to the registered algorithm's config.
+
+    Dispatches on the ``algorithm`` key (default ``bytetrack``) and validates
+    the data against that algorithm's `config_cls`.
+    """
+    name = data.get("algorithm", _DEFAULT_ALGORITHM) if isinstance(data, dict) else _DEFAULT_ALGORITHM
+    if name not in ALGORITHM_REGISTRY:
+        known = sorted(ALGORITHM_REGISTRY) or ["<none registered>"]
+        msg = f"unknown algorithm '{name}'; registered: {known}"
+        raise KeyError(msg)
+    return ALGORITHM_REGISTRY[name].config_cls.model_validate(data)

--- a/libraries/getitrack/src/getitrack/core/registry.py
+++ b/libraries/getitrack/src/getitrack/core/registry.py
@@ -38,6 +38,10 @@ def register_algorithm(
         if name in ALGORITHM_REGISTRY:
             msg = f"algorithm '{name}' is already registered by {ALGORITHM_REGISTRY[name].__name__}"
             raise ValueError(msg)
+        declared = config.model_fields["algorithm"].default
+        if declared != name:
+            msg = f"config {config.__name__} pins algorithm={declared!r}, but is registered as '{name}'"
+            raise ValueError(msg)
         cls.config_cls = config
         ALGORITHM_REGISTRY[name] = cls
         return cls

--- a/libraries/getitrack/src/getitrack/core/track.py
+++ b/libraries/getitrack/src/getitrack/core/track.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Per-track lifecycle state machine.
+
+A `Track` captures the lifecycle of one tracked object across frames.
+Concrete trackers hold a collection of `Track` instances and decide
+associations; the transitions implemented here are algorithm-agnostic.
+
+State transitions::
+
+    TENTATIVE --(min_hits hits)--> ACTIVE
+    ACTIVE    --(miss)----------> LOST
+    LOST      --(hit)-----------> ACTIVE
+    LOST      --(time_since_update > max_age)--> REMOVED
+    TENTATIVE --(time_since_update > tentative_max_age)--> REMOVED
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from getitrack.core.detection import TrackState
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from getitrack.config import LifecycleConfig
+
+
+@dataclass
+class Track:
+    """Per-id state machine maintained by a concrete tracker.
+
+    Algorithm-specific extensions (e.g. Kalman state) live alongside the
+    `Track`, typically as parallel dicts keyed by ``track_id``, so the
+    lifecycle transitions stay algorithm-agnostic.
+
+    Attributes:
+        track_id: Stable identifier assigned at creation.
+        class_id: Class label associated with this track.
+        bbox: Last observed bbox in ``[x1, y1, x2, y2]`` (float32).
+        score: Last observed detection score.
+        state: Current lifecycle state.
+        age: Total frames since the track was created.
+        hits: Total observed detections.
+        time_since_update: Consecutive frames missed (0 on a hit).
+    """
+
+    track_id: int
+    class_id: int
+    bbox: np.ndarray
+    score: float
+    state: TrackState = TrackState.TENTATIVE
+    age: int = 0
+    hits: int = 1
+    time_since_update: int = 0
+    _start_frame: int = field(default=0, repr=False)
+
+    def mark_hit(self, bbox: np.ndarray, score: float, lifecycle: LifecycleConfig) -> None:
+        """Record an observed detection on this frame and update state."""
+        self.bbox = bbox
+        self.score = float(score)
+        self.hits += 1
+        self.age += 1
+        self.time_since_update = 0
+        if (self.state == TrackState.TENTATIVE and self.hits >= lifecycle.min_hits) or (self.state == TrackState.LOST):
+            self.state = TrackState.ACTIVE
+
+    def mark_miss(self, lifecycle: LifecycleConfig) -> None:
+        """Record a missed observation on this frame and advance state."""
+        self.age += 1
+        self.time_since_update += 1
+        if self.state == TrackState.TENTATIVE and self.time_since_update > lifecycle.tentative_max_age:
+            self.state = TrackState.REMOVED
+            return
+        if self.state == TrackState.ACTIVE:
+            self.state = TrackState.LOST
+        if self.state == TrackState.LOST and self.time_since_update > lifecycle.max_age:
+            self.state = TrackState.REMOVED
+
+    @property
+    def should_remove(self) -> bool:
+        """True once this track has transitioned to ``REMOVED``."""
+        return self.state == TrackState.REMOVED

--- a/libraries/getitrack/src/getitrack/core/track.py
+++ b/libraries/getitrack/src/getitrack/core/track.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from getitrack.core.detection import TrackState
+from getitrack.logger import LOGGER
 
 if TYPE_CHECKING:
     import numpy as np
@@ -59,6 +60,7 @@ class Track:
 
     def mark_hit(self, bbox: np.ndarray, score: float, lifecycle: LifecycleConfig) -> None:
         """Record an observed detection on this frame and update state."""
+        prev_state = self.state
         self.bbox = bbox
         self.score = float(score)
         self.hits += 1
@@ -66,18 +68,28 @@ class Track:
         self.time_since_update = 0
         if (self.state == TrackState.TENTATIVE and self.hits >= lifecycle.min_hits) or (self.state == TrackState.LOST):
             self.state = TrackState.ACTIVE
+        if self.state != prev_state:
+            LOGGER.debug("track %d: %s -> %s on hit (hits=%d)", self.track_id, prev_state, self.state, self.hits)
 
     def mark_miss(self, lifecycle: LifecycleConfig) -> None:
         """Record a missed observation on this frame and advance state."""
+        prev_state = self.state
         self.age += 1
         self.time_since_update += 1
         if self.state == TrackState.TENTATIVE and self.time_since_update > lifecycle.tentative_max_age:
             self.state = TrackState.REMOVED
-            return
         if self.state == TrackState.ACTIVE:
             self.state = TrackState.LOST
         if self.state == TrackState.LOST and self.time_since_update > lifecycle.max_age:
             self.state = TrackState.REMOVED
+        if self.state != prev_state:
+            LOGGER.debug(
+                "track %d: %s -> %s on miss (time_since_update=%d)",
+                self.track_id,
+                prev_state,
+                self.state,
+                self.time_since_update,
+            )
 
     @property
     def should_remove(self) -> bool:

--- a/libraries/getitrack/src/getitrack/core/track.py
+++ b/libraries/getitrack/src/getitrack/core/track.py
@@ -18,7 +18,7 @@ State transitions::
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_never
 
 from getitrack.core.detection import TrackState
 from getitrack.logger import LOGGER
@@ -66,8 +66,16 @@ class Track:
         self.hits += 1
         self.age += 1
         self.time_since_update = 0
-        if (self.state == TrackState.TENTATIVE and self.hits >= lifecycle.min_hits) or (self.state == TrackState.LOST):
-            self.state = TrackState.ACTIVE
+        match self.state:
+            case TrackState.TENTATIVE:
+                if self.hits >= lifecycle.min_hits:
+                    self.state = TrackState.ACTIVE
+            case TrackState.LOST:
+                self.state = TrackState.ACTIVE
+            case TrackState.ACTIVE | TrackState.REMOVED:
+                pass
+            case _:
+                assert_never(self.state)
         if self.state != prev_state:
             LOGGER.debug("track %d: %s -> %s on hit (hits=%d)", self.track_id, prev_state, self.state, self.hits)
 
@@ -76,12 +84,19 @@ class Track:
         prev_state = self.state
         self.age += 1
         self.time_since_update += 1
-        if self.state == TrackState.TENTATIVE and self.time_since_update > lifecycle.tentative_max_age:
-            self.state = TrackState.REMOVED
-        if self.state == TrackState.ACTIVE:
-            self.state = TrackState.LOST
-        if self.state == TrackState.LOST and self.time_since_update > lifecycle.max_age:
-            self.state = TrackState.REMOVED
+        match self.state:
+            case TrackState.TENTATIVE:
+                if self.time_since_update > lifecycle.tentative_max_age:
+                    self.state = TrackState.REMOVED
+            case TrackState.ACTIVE:
+                self.state = TrackState.LOST
+            case TrackState.LOST:
+                if self.time_since_update > lifecycle.max_age:
+                    self.state = TrackState.REMOVED
+            case TrackState.REMOVED:
+                pass
+            case _:
+                assert_never(self.state)
         if self.state != prev_state:
             LOGGER.debug(
                 "track %d: %s -> %s on miss (time_since_update=%d)",

--- a/libraries/getitrack/src/getitrack/core/track.py
+++ b/libraries/getitrack/src/getitrack/core/track.py
@@ -77,7 +77,7 @@ class Track:
             case _:
                 assert_never(self.state)
         if self.state != prev_state:
-            LOGGER.debug("track %d: %s -> %s on hit (hits=%d)", self.track_id, prev_state, self.state, self.hits)
+            LOGGER.debug("track {}: {} -> {} on hit (hits={})", self.track_id, prev_state, self.state, self.hits)
 
     def mark_miss(self, lifecycle: LifecycleConfig) -> None:
         """Record a missed observation on this frame and advance state."""
@@ -99,7 +99,7 @@ class Track:
                 assert_never(self.state)
         if self.state != prev_state:
             LOGGER.debug(
-                "track %d: %s -> %s on miss (time_since_update=%d)",
+                "track {}: {} -> {} on miss (time_since_update={})",
                 self.track_id,
                 prev_state,
                 self.state,

--- a/libraries/getitrack/src/getitrack/core/track.py
+++ b/libraries/getitrack/src/getitrack/core/track.py
@@ -18,15 +18,28 @@ State transitions::
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import IntEnum
 from typing import TYPE_CHECKING, assert_never
 
-from getitrack.core.detection import TrackState
 from getitrack.logger import LOGGER
 
 if TYPE_CHECKING:
     import numpy as np
 
     from getitrack.config import LifecycleConfig
+
+
+class TrackState(IntEnum):
+    """Lifecycle state of a single track.
+
+    Values are assigned explicitly so `TrackedDetections.track_states` can
+    store them as int8 without depending on declaration order.
+    """
+
+    TENTATIVE = 0
+    ACTIVE = 1
+    LOST = 2
+    REMOVED = 3
 
 
 @dataclass
@@ -77,7 +90,9 @@ class Track:
             case _:
                 assert_never(self.state)
         if self.state != prev_state:
-            LOGGER.debug("track {}: {} -> {} on hit (hits={})", self.track_id, prev_state, self.state, self.hits)
+            LOGGER.debug(
+                "track {}: {} -> {} on hit (hits={})", self.track_id, prev_state.name, self.state.name, self.hits
+            )
 
     def mark_miss(self, lifecycle: LifecycleConfig) -> None:
         """Record a missed observation on this frame and advance state."""
@@ -101,8 +116,8 @@ class Track:
             LOGGER.debug(
                 "track {}: {} -> {} on miss (time_since_update={})",
                 self.track_id,
-                prev_state,
-                self.state,
+                prev_state.name,
+                self.state.name,
                 self.time_since_update,
             )
 

--- a/libraries/getitrack/src/getitrack/core/validation.py
+++ b/libraries/getitrack/src/getitrack/core/validation.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Array validation helpers for the core data containers.
+
+Domain-agnostic checks (shape, row alignment, value range, dtype) shared
+by the numpy-backed containers in this package.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+BBOX_COLS = 4
+
+
+def validate_bboxes(bboxes: np.ndarray) -> None:
+    """Raise if ``bboxes`` is not an ``(N, 4)`` array."""
+    if bboxes.ndim != 2 or bboxes.shape[1] != BBOX_COLS:
+        msg = f"bboxes must have shape (N, {BBOX_COLS}); got {bboxes.shape}"
+        raise ValueError(msg)
+
+
+def validate_row_aligned(*, n: int, **arrays: np.ndarray | None) -> None:
+    """Raise if any named array's row count differs from ``n``.
+
+    ``None`` arrays (absent optional fields) are skipped.
+    """
+    for name, arr in arrays.items():
+        if arr is None:
+            continue
+        if arr.shape[0] != n:
+            msg = f"{name} has {arr.shape[0]} rows; expected {n} to match bboxes"
+            raise ValueError(msg)
+
+
+def validate_scores(scores: np.ndarray) -> None:
+    """Raise if any score falls outside ``[0, 1]``."""
+    if scores.size and (scores.min() < 0.0 or scores.max() > 1.0):
+        msg = f"scores must be in [0, 1]; got min={scores.min()} max={scores.max()}"
+        raise ValueError(msg)
+
+
+def validate_dtypes(**checks: tuple[np.ndarray, type] | None) -> None:
+    """Raise if any ``(array, expected_dtype)`` pair has a mismatched dtype.
+
+    Pass ``None`` for absent optional fields to keep the call site flat.
+    """
+    for name, item in checks.items():
+        if item is None:
+            continue
+        arr, expected = item
+        if arr.dtype != expected:
+            msg = f"{name} must have dtype {np.dtype(expected).name}; got {arr.dtype.name}"
+            raise TypeError(msg)

--- a/libraries/getitrack/src/getitrack/core/validation.py
+++ b/libraries/getitrack/src/getitrack/core/validation.py
@@ -50,7 +50,7 @@ def validate_value_range(values: np.ndarray, *, high: int, name: str) -> None:
 def validate_dtypes(**checks: tuple[np.ndarray, type] | None) -> None:
     """Raise if any ``(array, expected_dtype)`` pair has a mismatched dtype.
 
-    Pass ``None`` for absent optional fields to keep the call site flat.
+    Pass ``None`` for absent optional fields.
     """
     for name, item in checks.items():
         if item is None:

--- a/libraries/getitrack/src/getitrack/core/validation.py
+++ b/libraries/getitrack/src/getitrack/core/validation.py
@@ -40,6 +40,13 @@ def validate_scores(scores: np.ndarray) -> None:
         raise ValueError(msg)
 
 
+def validate_value_range(values: np.ndarray, *, high: int, name: str) -> None:
+    """Raise if any entry of ``values`` falls outside ``[0, high)``."""
+    if values.size and (values.min() < 0 or values.max() >= high):
+        msg = f"{name} values must be in [0, {high}); got min={values.min()} max={values.max()}"
+        raise ValueError(msg)
+
+
 def validate_dtypes(**checks: tuple[np.ndarray, type] | None) -> None:
     """Raise if any ``(array, expected_dtype)`` pair has a mismatched dtype.
 

--- a/libraries/getitrack/src/getitrack/logger.py
+++ b/libraries/getitrack/src/getitrack/logger.py
@@ -1,37 +1,19 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-"""Package-wide logger.
+"""Package-wide loguru logger.
 
-Import `LOGGER` instead of ``print`` or per-module loggers::
-
-    from getitrack.logger import LOGGER
-    LOGGER.info("...")
-
-Libraries must not configure the root logger, so output stays invisible
-until either the application configures logging or `enable_console_output`
-runs (the tracker calls it automatically when ``verbose`` is enabled).
+Logging is disabled for ``getitrack`` by default (see
+``getitrack/__init__.py``); the library stays silent until the application
+calls ``logger.enable("getitrack")`` or a tracker runs with ``verbose``.
 """
 
 from __future__ import annotations
 
-import logging
+from loguru import logger
 
-LOGGER = logging.getLogger("getitrack")
+LOGGER = logger
 
 
-def enable_console_output() -> None:
-    """Make INFO-level getitrack logs visible when nothing configured logging.
-
-    Attaches a plain stream handler to the ``getitrack`` logger, and only
-    when the application has not configured logging itself. Applications
-    that did configure logging keep full control over the output.
-    """
-    if logging.getLogger().handlers:
-        return  # the application configured logging; respect it
-    if LOGGER.handlers:
-        return  # already enabled
-    handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter("%(message)s"))
-    LOGGER.addHandler(handler)
-    LOGGER.setLevel(logging.INFO)
-    LOGGER.propagate = False
+def enable_logging() -> None:
+    """Lift the default suppression of getitrack log records."""
+    logger.enable("getitrack")

--- a/libraries/getitrack/src/getitrack/logger.py
+++ b/libraries/getitrack/src/getitrack/logger.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Package-wide logger.
+
+Import `LOGGER` instead of ``print`` or per-module loggers::
+
+    from getitrack.logger import LOGGER
+    LOGGER.info("...")
+
+Libraries must not configure the root logger, so output stays invisible
+until either the application configures logging or `enable_console_output`
+runs (the tracker calls it automatically when ``verbose`` is enabled).
+"""
+
+from __future__ import annotations
+
+import logging
+
+LOGGER = logging.getLogger("getitrack")
+
+
+def enable_console_output() -> None:
+    """Make INFO-level getitrack logs visible when nothing configured logging.
+
+    Attaches a plain stream handler to the ``getitrack`` logger, and only
+    when the application has not configured logging itself. Applications
+    that did configure logging keep full control over the output.
+    """
+    if logging.getLogger().handlers:
+        return  # the application configured logging; respect it
+    if LOGGER.handlers:
+        return  # already enabled
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    LOGGER.addHandler(handler)
+    LOGGER.setLevel(logging.INFO)
+    LOGGER.propagate = False

--- a/libraries/getitrack/tests/unit/test_base.py
+++ b/libraries/getitrack/tests/unit/test_base.py
@@ -11,10 +11,16 @@ import numpy as np
 import pytest
 from loguru import logger
 
-from getitrack.config import AlgorithmType, TrackerConfig
+from getitrack.config import AlgorithmType, LifecycleConfig, TrackerConfig
 from getitrack.core.base import BaseTracker
 from getitrack.core.detection import Detections, TrackedDetections
 from getitrack.core.registry import ALGORITHM_REGISTRY, register_algorithm
+
+
+class _DummyConfig(TrackerConfig):
+    """Minimal config for the dummy tracker used across these tests."""
+
+    algorithm: AlgorithmType = AlgorithmType.BYTETRACK
 
 
 class _Recording(BaseTracker):
@@ -50,7 +56,7 @@ def _clean_registry() -> Iterator[None]:
 
 
 def _register_dummy(name: str = "bytetrack") -> type[BaseTracker]:
-    @register_algorithm(name)
+    @register_algorithm(name, config=_DummyConfig)
     class _Dummy(_Recording):
         algorithm_name = name
 
@@ -71,7 +77,7 @@ class TestRegistry:
 class TestFromConfig:
     def test_from_trackerconfig(self):
         _register_dummy("bytetrack")
-        tracker = BaseTracker.from_config(TrackerConfig())
+        tracker = BaseTracker.from_config(_DummyConfig())
         assert isinstance(tracker, BaseTracker)
 
     def test_from_dict(self):
@@ -82,20 +88,27 @@ class TestFromConfig:
     def test_from_yaml_path(self, tmp_path: Path):
         _register_dummy("bytetrack")
         p = tmp_path / "c.yaml"
-        TrackerConfig().to_yaml(p)
+        _DummyConfig().to_yaml(p)
         tracker = BaseTracker.from_config(p)
         assert isinstance(tracker, BaseTracker)
 
     def test_from_yaml_str_path(self, tmp_path: Path):
         _register_dummy("bytetrack")
         p = tmp_path / "c.yaml"
-        TrackerConfig().to_yaml(p)
+        _DummyConfig().to_yaml(p)
         tracker = BaseTracker.from_config(str(p))
         assert isinstance(tracker, BaseTracker)
 
+    def test_yaml_round_trip_dispatches_to_registered_config(self, tmp_path: Path):
+        _register_dummy("bytetrack")
+        cfg = _DummyConfig(lifecycle=LifecycleConfig(max_age=42))
+        p = tmp_path / "rt.yaml"
+        cfg.to_yaml(p)
+        assert TrackerConfig.from_yaml(p) == cfg
+
     def test_unknown_algorithm_raises(self):
         with pytest.raises(KeyError, match="unknown algorithm"):
-            BaseTracker.from_config(TrackerConfig(algorithm=AlgorithmType.OCSORT))
+            BaseTracker.from_config({"algorithm": "ocsort"})
 
     def test_bad_config_type_raises(self):
         with pytest.raises(TypeError, match="unsupported config type"):
@@ -105,7 +118,7 @@ class TestFromConfig:
 class TestUpdateAndReset:
     def test_update_assigns_monotonic_ids(self):
         _register_dummy("bytetrack")
-        t = BaseTracker.from_config(TrackerConfig())
+        t = BaseTracker.from_config(_DummyConfig())
         dets = Detections(
             bboxes=np.zeros((2, 4), dtype=np.float32),
             scores=np.array([0.9, 0.5], dtype=np.float32),
@@ -119,7 +132,7 @@ class TestUpdateAndReset:
 
     def test_reset_resets_id_counter(self):
         _register_dummy("bytetrack")
-        t = BaseTracker.from_config(TrackerConfig())
+        t = BaseTracker.from_config(_DummyConfig())
         t.update(Detections.create_empty(0))
         t._next_id = 7
         t.reset()
@@ -128,7 +141,7 @@ class TestUpdateAndReset:
 
     def test_abstract_update_cannot_be_instantiated_directly(self):
         with pytest.raises(TypeError):
-            BaseTracker(TrackerConfig())  # type: ignore[abstract]
+            BaseTracker(_DummyConfig())  # type: ignore[abstract]
 
 
 class TestClassFilter:
@@ -142,8 +155,8 @@ class TestClassFilter:
 
     def _tracker(self, class_filter) -> BaseTracker:
         _register_dummy("bytetrack")
-        cfg = TrackerConfig()
-        cfg.association.class_filter = class_filter
+        cfg = _DummyConfig()
+        cfg.class_filter = class_filter
         return BaseTracker.from_config(cfg)
 
     def test_excluded_classes_never_reach_algorithm(self):
@@ -186,20 +199,20 @@ class TestVerboseLogging:
         _register_dummy("bytetrack")
         messages, sink_id = self._capture()
         try:
-            BaseTracker.from_config(TrackerConfig(verbose=True)).update(self._dets())
+            BaseTracker.from_config(_DummyConfig(verbose=True)).update(self._dets())
         finally:
             logger.remove(sink_id)
         assert len(messages) == 1
         msg = messages[0]
         assert "frame    4" in msg
-        assert "2 detections (1 high-score)" in msg
+        assert "2 detections" in msg
         assert "1:3:0.90, 2:8:0.30" in msg
 
     def test_default_is_silent(self):
         _register_dummy("bytetrack")
         messages, sink_id = self._capture(level="DEBUG")
         try:
-            BaseTracker.from_config(TrackerConfig()).update(self._dets())
+            BaseTracker.from_config(_DummyConfig()).update(self._dets())
         finally:
             logger.remove(sink_id)
         assert not messages
@@ -209,10 +222,10 @@ class TestVerboseLogging:
         messages, sink_id = self._capture()
         try:
             # A non-verbose tracker stays suppressed even with a sink attached.
-            BaseTracker.from_config(TrackerConfig()).update(self._dets())
+            BaseTracker.from_config(_DummyConfig()).update(self._dets())
             assert not messages
             # A verbose tracker lifts the package-level suppression.
-            BaseTracker.from_config(TrackerConfig(verbose=True)).update(self._dets())
+            BaseTracker.from_config(_DummyConfig(verbose=True)).update(self._dets())
             assert len(messages) == 1
         finally:
             logger.remove(sink_id)

--- a/libraries/getitrack/tests/unit/test_base.py
+++ b/libraries/getitrack/tests/unit/test_base.py
@@ -73,6 +73,13 @@ class TestRegistry:
         with pytest.raises(ValueError, match="already registered"):
             _register_dummy("bytetrack")
 
+    def test_config_name_mismatch_raises(self):
+        class _OcsortConfig(TrackerConfig):
+            algorithm: AlgorithmType = AlgorithmType.OCSORT
+
+        with pytest.raises(ValueError, match="pins algorithm"):
+            register_algorithm("bytetrack", config=_OcsortConfig)(_Recording)
+
 
 class TestFromConfig:
     def test_from_trackerconfig(self):
@@ -84,6 +91,12 @@ class TestFromConfig:
         _register_dummy("bytetrack")
         tracker = BaseTracker.from_config({"algorithm": "bytetrack"})
         assert isinstance(tracker, BaseTracker)
+
+    def test_base_instance_is_upgraded_to_registered_config(self):
+        _register_dummy("bytetrack")
+        tracker = BaseTracker.from_config(TrackerConfig(algorithm=AlgorithmType.BYTETRACK))
+        # A plain base instance is re-resolved to the algorithm's concrete config.
+        assert type(tracker.config) is _DummyConfig
 
     def test_from_yaml_path(self, tmp_path: Path):
         _register_dummy("bytetrack")

--- a/libraries/getitrack/tests/unit/test_base.py
+++ b/libraries/getitrack/tests/unit/test_base.py
@@ -162,7 +162,8 @@ class TestClassFilter:
         assert out.det_indices.tolist() == [0, 1, 2]
 
     def test_remap_preserves_unmatched_rows(self):
-        remapped = BaseTracker._remap_det_indices(self._dets(), [1], np.array([0, -1, 1], dtype=np.int64))
+        source_rows = np.array([0, 2], dtype=np.int64)
+        remapped = BaseTracker._remap_det_indices(source_rows, np.array([0, -1, 1], dtype=np.int64))
         assert remapped.tolist() == [0, -1, 2]
 
 

--- a/libraries/getitrack/tests/unit/test_base.py
+++ b/libraries/getitrack/tests/unit/test_base.py
@@ -1,0 +1,224 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the BaseTracker ABC and the algorithm registry."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from getitrack.config import AlgorithmType, TrackerConfig
+from getitrack.core.base import ALGORITHM_REGISTRY, BaseTracker, register_algorithm
+from getitrack.core.detection import Detections, TrackedDetections
+
+
+class _Recording(BaseTracker):
+    """Trivial tracker that echoes inputs back with sequential ids."""
+
+    def _update_impl(self, detections: Detections) -> TrackedDetections:
+        n = len(detections)
+        return TrackedDetections(
+            bboxes=detections.bboxes,
+            scores=detections.scores,
+            class_ids=detections.class_ids,
+            track_ids=np.array([self._allocate_id() for _ in range(n)], dtype=np.int64),
+            track_states=np.zeros((n,), dtype=np.int8),
+            frame_id=detections.frame_id,
+            det_indices=np.arange(n, dtype=np.int64),
+        )
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    """Snapshot and restore the registry around each test."""
+    snapshot = dict(ALGORITHM_REGISTRY)
+    ALGORITHM_REGISTRY.clear()
+    yield
+    ALGORITHM_REGISTRY.clear()
+    ALGORITHM_REGISTRY.update(snapshot)
+
+
+def _register_dummy(name: str = "bytetrack") -> type[BaseTracker]:
+    @register_algorithm(name)
+    class _Dummy(_Recording):
+        algorithm_name = name
+
+    return _Dummy
+
+
+class TestRegistry:
+    def test_register_and_lookup(self):
+        cls = _register_dummy("bytetrack")
+        assert ALGORITHM_REGISTRY["bytetrack"] is cls
+
+    def test_duplicate_registration_raises(self):
+        _register_dummy("bytetrack")
+        with pytest.raises(ValueError, match="already registered"):
+            _register_dummy("bytetrack")
+
+
+class TestFromConfig:
+    def test_from_trackerconfig(self):
+        _register_dummy("bytetrack")
+        tracker = BaseTracker.from_config(TrackerConfig())
+        assert isinstance(tracker, BaseTracker)
+
+    def test_from_dict(self):
+        _register_dummy("bytetrack")
+        tracker = BaseTracker.from_config({"algorithm": "bytetrack"})
+        assert isinstance(tracker, BaseTracker)
+
+    def test_from_yaml_path(self, tmp_path: Path):
+        _register_dummy("bytetrack")
+        p = tmp_path / "c.yaml"
+        TrackerConfig().to_yaml(p)
+        tracker = BaseTracker.from_config(p)
+        assert isinstance(tracker, BaseTracker)
+
+    def test_from_yaml_str_path(self, tmp_path: Path):
+        _register_dummy("bytetrack")
+        p = tmp_path / "c.yaml"
+        TrackerConfig().to_yaml(p)
+        tracker = BaseTracker.from_config(str(p))
+        assert isinstance(tracker, BaseTracker)
+
+    def test_unknown_algorithm_raises(self):
+        with pytest.raises(KeyError, match="unknown algorithm"):
+            BaseTracker.from_config(TrackerConfig(algorithm=AlgorithmType.OCSORT))
+
+    def test_bad_config_type_raises(self):
+        with pytest.raises(TypeError, match="unsupported config type"):
+            BaseTracker.from_config(123)  # type: ignore[arg-type]
+
+
+class TestUpdateAndReset:
+    def test_update_assigns_monotonic_ids(self):
+        _register_dummy("bytetrack")
+        t = BaseTracker.from_config(TrackerConfig())
+        dets = Detections(
+            bboxes=np.zeros((2, 4), dtype=np.float32),
+            scores=np.array([0.9, 0.5], dtype=np.float32),
+            class_ids=np.array([0, 0], dtype=np.int64),
+            frame_id=0,
+        )
+        out = t.update(dets)
+        assert out.track_ids.tolist() == [1, 2]
+        out2 = t.update(dets)
+        assert out2.track_ids.tolist() == [3, 4]
+
+    def test_reset_resets_id_counter(self):
+        _register_dummy("bytetrack")
+        t = BaseTracker.from_config(TrackerConfig())
+        t.update(Detections.create_empty(0))
+        t._next_id = 7
+        t.reset()
+        assert t._next_id == 1
+        assert t._frame_id is None
+
+    def test_abstract_update_cannot_be_instantiated_directly(self):
+        with pytest.raises(TypeError):
+            BaseTracker(TrackerConfig())  # type: ignore[abstract]
+
+
+class TestClassFilter:
+    def _dets(self) -> Detections:
+        return Detections(
+            bboxes=np.array([[0, 0, 1, 1], [1, 1, 2, 2], [2, 2, 3, 3]], dtype=np.float32),
+            scores=np.array([0.9, 0.8, 0.7], dtype=np.float32),
+            class_ids=np.array([1, 2, 1], dtype=np.int64),
+            frame_id=0,
+        )
+
+    def _tracker(self, class_filter) -> BaseTracker:
+        _register_dummy("bytetrack")
+        cfg = TrackerConfig()
+        cfg.association.class_filter = class_filter
+        return BaseTracker.from_config(cfg)
+
+    def test_excluded_classes_never_reach_algorithm(self):
+        out = self._tracker([1]).update(self._dets())
+        assert len(out) == 2
+        assert out.class_ids.tolist() == [1, 1]
+
+    def test_det_indices_remap_to_input_rows(self):
+        out = self._tracker([1]).update(self._dets())
+        assert out.det_indices is not None
+        assert out.det_indices.tolist() == [0, 2]
+
+    def test_none_filter_tracks_all(self):
+        out = self._tracker(None).update(self._dets())
+        assert len(out) == 3
+        assert out.det_indices is not None
+        assert out.det_indices.tolist() == [0, 1, 2]
+
+    def test_remap_preserves_unmatched_rows(self):
+        remapped = BaseTracker._remap_det_indices(self._dets(), [1], np.array([0, -1, 1], dtype=np.int64))
+        assert remapped.tolist() == [0, -1, 2]
+
+
+class TestVerboseLogging:
+    def _dets(self) -> Detections:
+        return Detections(
+            bboxes=np.zeros((2, 4), dtype=np.float32),
+            scores=np.array([0.9, 0.3], dtype=np.float32),
+            class_ids=np.array([3, 8], dtype=np.int64),
+            frame_id=4,
+        )
+
+    def test_verbose_logs_frame_summary(self, caplog):
+        _register_dummy("bytetrack")
+        t = BaseTracker.from_config(TrackerConfig(verbose=True))
+        with caplog.at_level("INFO", logger="getitrack"):
+            t.update(self._dets())
+        assert len(caplog.records) == 1
+        msg = caplog.records[0].getMessage()
+        assert "frame    4" in msg
+        assert "2 detections (1 high-score)" in msg
+        assert "1:3:0.90, 2:8:0.30" in msg
+
+    def test_default_is_silent(self, caplog):
+        _register_dummy("bytetrack")
+        t = BaseTracker.from_config(TrackerConfig())
+        with caplog.at_level("INFO", logger="getitrack"):
+            t.update(self._dets())
+        assert not caplog.records
+
+
+class TestVerboseHandler:
+    def _clean(self) -> None:
+        pkg = logging.getLogger("getitrack")
+        for h in list(pkg.handlers):
+            pkg.removeHandler(h)
+        pkg.propagate = True
+        pkg.setLevel(logging.NOTSET)
+
+    def test_attaches_handler_when_logging_unconfigured(self, monkeypatch):
+        self._clean()
+        monkeypatch.setattr(logging.getLogger(), "handlers", [])
+        _register_dummy("bytetrack")
+        BaseTracker.from_config(TrackerConfig(verbose=True))
+        pkg = logging.getLogger("getitrack")
+        assert len(pkg.handlers) == 1
+        assert pkg.level == logging.INFO
+        assert pkg.propagate is False
+        self._clean()
+
+    def test_respects_application_logging_config(self, monkeypatch):
+        self._clean()
+        monkeypatch.setattr(logging.getLogger(), "handlers", [logging.NullHandler()])
+        _register_dummy("bytetrack")
+        BaseTracker.from_config(TrackerConfig(verbose=True))
+        assert not logging.getLogger("getitrack").handlers
+        self._clean()
+
+    def test_no_handler_when_not_verbose(self, monkeypatch):
+        self._clean()
+        monkeypatch.setattr(logging.getLogger(), "handlers", [])
+        _register_dummy("bytetrack")
+        BaseTracker.from_config(TrackerConfig())
+        assert not logging.getLogger("getitrack").handlers
+        self._clean()

--- a/libraries/getitrack/tests/unit/test_base.py
+++ b/libraries/getitrack/tests/unit/test_base.py
@@ -4,12 +4,12 @@
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Iterator
 from pathlib import Path
 
 import numpy as np
 import pytest
+from loguru import logger
 
 from getitrack.config import AlgorithmType, TrackerConfig
 from getitrack.core.base import ALGORITHM_REGISTRY, BaseTracker, register_algorithm
@@ -34,12 +34,18 @@ class _Recording(BaseTracker):
 
 @pytest.fixture(autouse=True)
 def _clean_registry() -> Iterator[None]:
-    """Snapshot and restore the registry around each test."""
+    """Snapshot and restore the registry around each test.
+
+    Also restores loguru's default-disabled state for ``getitrack``, since
+    a ``verbose`` tracker enables it process-wide.
+    """
     snapshot = dict(ALGORITHM_REGISTRY)
     ALGORITHM_REGISTRY.clear()
+    logger.disable("getitrack")
     yield
     ALGORITHM_REGISTRY.clear()
     ALGORITHM_REGISTRY.update(snapshot)
+    logger.disable("getitrack")
 
 
 def _register_dummy(name: str = "bytetrack") -> type[BaseTracker]:
@@ -169,56 +175,42 @@ class TestVerboseLogging:
             frame_id=4,
         )
 
-    def test_verbose_logs_frame_summary(self, caplog):
+    def _capture(self, level: str = "INFO") -> tuple[list[str], int]:
+        messages: list[str] = []
+        sink_id = logger.add(messages.append, level=level, format="{message}")
+        return messages, sink_id
+
+    def test_verbose_logs_frame_summary(self):
         _register_dummy("bytetrack")
-        t = BaseTracker.from_config(TrackerConfig(verbose=True))
-        with caplog.at_level("INFO", logger="getitrack"):
-            t.update(self._dets())
-        assert len(caplog.records) == 1
-        msg = caplog.records[0].getMessage()
+        messages, sink_id = self._capture()
+        try:
+            BaseTracker.from_config(TrackerConfig(verbose=True)).update(self._dets())
+        finally:
+            logger.remove(sink_id)
+        assert len(messages) == 1
+        msg = messages[0]
         assert "frame    4" in msg
         assert "2 detections (1 high-score)" in msg
         assert "1:3:0.90, 2:8:0.30" in msg
 
-    def test_default_is_silent(self, caplog):
+    def test_default_is_silent(self):
         _register_dummy("bytetrack")
-        t = BaseTracker.from_config(TrackerConfig())
-        with caplog.at_level("INFO", logger="getitrack"):
-            t.update(self._dets())
-        assert not caplog.records
+        messages, sink_id = self._capture(level="DEBUG")
+        try:
+            BaseTracker.from_config(TrackerConfig()).update(self._dets())
+        finally:
+            logger.remove(sink_id)
+        assert not messages
 
-
-class TestVerboseHandler:
-    def _clean(self) -> None:
-        pkg = logging.getLogger("getitrack")
-        for h in list(pkg.handlers):
-            pkg.removeHandler(h)
-        pkg.propagate = True
-        pkg.setLevel(logging.NOTSET)
-
-    def test_attaches_handler_when_logging_unconfigured(self, monkeypatch):
-        self._clean()
-        monkeypatch.setattr(logging.getLogger(), "handlers", [])
+    def test_verbose_enables_package_logging(self):
         _register_dummy("bytetrack")
-        BaseTracker.from_config(TrackerConfig(verbose=True))
-        pkg = logging.getLogger("getitrack")
-        assert len(pkg.handlers) == 1
-        assert pkg.level == logging.INFO
-        assert pkg.propagate is False
-        self._clean()
-
-    def test_respects_application_logging_config(self, monkeypatch):
-        self._clean()
-        monkeypatch.setattr(logging.getLogger(), "handlers", [logging.NullHandler()])
-        _register_dummy("bytetrack")
-        BaseTracker.from_config(TrackerConfig(verbose=True))
-        assert not logging.getLogger("getitrack").handlers
-        self._clean()
-
-    def test_no_handler_when_not_verbose(self, monkeypatch):
-        self._clean()
-        monkeypatch.setattr(logging.getLogger(), "handlers", [])
-        _register_dummy("bytetrack")
-        BaseTracker.from_config(TrackerConfig())
-        assert not logging.getLogger("getitrack").handlers
-        self._clean()
+        messages, sink_id = self._capture()
+        try:
+            # A non-verbose tracker stays suppressed even with a sink attached.
+            BaseTracker.from_config(TrackerConfig()).update(self._dets())
+            assert not messages
+            # A verbose tracker lifts the package-level suppression.
+            BaseTracker.from_config(TrackerConfig(verbose=True)).update(self._dets())
+            assert len(messages) == 1
+        finally:
+            logger.remove(sink_id)

--- a/libraries/getitrack/tests/unit/test_base.py
+++ b/libraries/getitrack/tests/unit/test_base.py
@@ -12,8 +12,9 @@ import pytest
 from loguru import logger
 
 from getitrack.config import AlgorithmType, TrackerConfig
-from getitrack.core.base import ALGORITHM_REGISTRY, BaseTracker, register_algorithm
+from getitrack.core.base import BaseTracker
 from getitrack.core.detection import Detections, TrackedDetections
+from getitrack.core.registry import ALGORITHM_REGISTRY, register_algorithm
 
 
 class _Recording(BaseTracker):

--- a/libraries/getitrack/tests/unit/test_config.py
+++ b/libraries/getitrack/tests/unit/test_config.py
@@ -1,102 +1,73 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for the Pydantic configuration models."""
-
-from pathlib import Path
+"""Tests for the shared Pydantic configuration models."""
 
 import pytest
+import yaml
 from pydantic import ValidationError
 
 from getitrack.config import (
     AlgorithmType,
-    AssociationConfig,
+    InterpolationConfig,
     InterpolationMethod,
     LifecycleConfig,
+    MotionConfig,
     TrackerConfig,
 )
 
 
-class TestDefaults:
-    def test_top_level_defaults(self):
-        c = TrackerConfig()
+class _DemoConfig(TrackerConfig):
+    """Minimal concrete config for exercising the shared base."""
+
+    algorithm: AlgorithmType = AlgorithmType.BYTETRACK
+
+
+class TestSubConfigDefaults:
+    def test_lifecycle_defaults(self):
+        lc = LifecycleConfig()
+        assert (lc.min_hits, lc.tentative_max_age, lc.max_age) == (2, 0, 30)
+
+    def test_motion_default(self):
+        assert MotionConfig().velocity_decay == pytest.approx(0.99)
+
+    def test_interpolation_defaults(self):
+        ic = InterpolationConfig()
+        assert ic.enabled is True
+        assert ic.method == InterpolationMethod.LINEAR
+
+
+class TestBaseConfig:
+    def test_shared_defaults(self):
+        c = _DemoConfig()
         assert c.algorithm == AlgorithmType.BYTETRACK
-        assert c.interpolation.method == InterpolationMethod.LINEAR
-
-    def test_subconfig_defaults_match_plan(self):
-        c = TrackerConfig()
-        assert c.association.match_threshold == pytest.approx(0.8)
-        assert c.association.class_filter is None
+        assert c.class_filter is None
+        assert c.score_threshold == pytest.approx(0.1)
         assert c.lifecycle.min_hits == 2
-        assert c.lifecycle.tentative_max_age == 0
-        assert c.lifecycle.max_age == 30
-        assert c.motion.velocity_decay == pytest.approx(0.99)
-        assert c.appearance.enabled is False
-        assert c.interpolation.enabled is True
 
-
-class TestValidation:
-    def test_match_threshold_out_of_range_raises(self):
-        with pytest.raises(ValidationError, match="match_threshold"):
-            AssociationConfig(match_threshold=2.0)
+    def test_unknown_field_raises(self):
+        with pytest.raises(ValidationError, match="bogus"):
+            _DemoConfig(bogus=1)
 
     def test_negative_max_age_raises(self):
         with pytest.raises(ValidationError, match="max_age"):
             LifecycleConfig(max_age=0)
 
-    def test_unknown_field_raises(self):
-        with pytest.raises(ValidationError, match="bogus"):
-            TrackerConfig.model_validate({"algorithm": "bytetrack", "bogus": 1})
-
-    def test_unknown_algorithm_raises(self):
-        with pytest.raises(ValidationError):
-            TrackerConfig.model_validate({"algorithm": "no-such-algo"})
+    def test_score_threshold_out_of_range_raises(self):
+        with pytest.raises(ValidationError, match="score_threshold"):
+            _DemoConfig(score_threshold=2.0)
 
 
-class TestYAMLRoundTrip:
-    def test_round_trip_lossless(self, tmp_path: Path):
-        cfg = TrackerConfig(
-            algorithm=AlgorithmType.OCSORT,
-            lifecycle=LifecycleConfig(max_age=42),
-        )
-        p = tmp_path / "cfg.yaml"
+class TestYAML:
+    def test_to_yaml_serialises_fields(self, tmp_path):
+        cfg = _DemoConfig(lifecycle=LifecycleConfig(max_age=42))
+        p = tmp_path / "c.yaml"
         cfg.to_yaml(p)
-        loaded = TrackerConfig.from_yaml(p)
-        assert loaded == cfg
+        data = yaml.safe_load(p.read_text())
+        assert data["algorithm"] == "bytetrack"
+        assert data["lifecycle"]["max_age"] == 42
 
-    def test_from_empty_yaml_returns_defaults(self, tmp_path: Path):
-        p = tmp_path / "empty.yaml"
-        p.write_text("")
-        loaded = TrackerConfig.from_yaml(p)
-        assert loaded == TrackerConfig()
-
-    def test_default_config_loads(self):
-        p = Path(__file__).resolve().parents[2] / "configs" / "default.yaml"
-        loaded = TrackerConfig.from_yaml(p)
-        assert loaded == TrackerConfig()
-
-
-class TestModelValidate:
-    def test_from_dict(self):
-        cfg = TrackerConfig.model_validate(
-            {
-                "algorithm": "ocsort",
-                "association": {"match_threshold": 0.4},
-                "lifecycle": {"max_age": 50},
-            },
-        )
-        assert cfg.algorithm == AlgorithmType.OCSORT
-        assert cfg.association.match_threshold == pytest.approx(0.4)
-        assert cfg.lifecycle.max_age == 50
-
-    def test_json_schema_export_contains_subconfigs(self):
-        schema = TrackerConfig.model_json_schema()
+    def test_json_schema_exports_subconfigs_and_descriptions(self):
+        schema = _DemoConfig.model_json_schema()
         names = set(schema.get("$defs", {}).keys())
-        assert {"AssociationConfig", "LifecycleConfig", "MotionConfig"} <= names
-
-    def test_json_schema_includes_field_descriptions(self):
-        """Pydantic should harvest the attribute docstrings as field descriptions."""
-        schema = TrackerConfig.model_json_schema()
-        assoc = schema["$defs"]["AssociationConfig"]["properties"]
-        assert "match_threshold" in assoc
-        assert "description" in assoc["match_threshold"]
-        assert "IoU" in assoc["match_threshold"]["description"]
+        assert {"LifecycleConfig", "MotionConfig", "InterpolationConfig"} <= names
+        assert "description" in schema["properties"]["score_threshold"]

--- a/libraries/getitrack/tests/unit/test_config.py
+++ b/libraries/getitrack/tests/unit/test_config.py
@@ -1,0 +1,102 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Pydantic configuration models."""
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from getitrack.config import (
+    AlgorithmType,
+    AssociationConfig,
+    InterpolationMethod,
+    LifecycleConfig,
+    TrackerConfig,
+)
+
+
+class TestDefaults:
+    def test_top_level_defaults(self):
+        c = TrackerConfig()
+        assert c.algorithm == AlgorithmType.BYTETRACK
+        assert c.interpolation.method == InterpolationMethod.LINEAR
+
+    def test_subconfig_defaults_match_plan(self):
+        c = TrackerConfig()
+        assert c.association.match_threshold == pytest.approx(0.8)
+        assert c.association.class_filter is None
+        assert c.lifecycle.min_hits == 2
+        assert c.lifecycle.tentative_max_age == 0
+        assert c.lifecycle.max_age == 30
+        assert c.motion.velocity_decay == pytest.approx(0.99)
+        assert c.appearance.enabled is False
+        assert c.interpolation.enabled is True
+
+
+class TestValidation:
+    def test_match_threshold_out_of_range_raises(self):
+        with pytest.raises(ValidationError, match="match_threshold"):
+            AssociationConfig(match_threshold=2.0)
+
+    def test_negative_max_age_raises(self):
+        with pytest.raises(ValidationError, match="max_age"):
+            LifecycleConfig(max_age=0)
+
+    def test_unknown_field_raises(self):
+        with pytest.raises(ValidationError, match="bogus"):
+            TrackerConfig.model_validate({"algorithm": "bytetrack", "bogus": 1})
+
+    def test_unknown_algorithm_raises(self):
+        with pytest.raises(ValidationError):
+            TrackerConfig.model_validate({"algorithm": "no-such-algo"})
+
+
+class TestYAMLRoundTrip:
+    def test_round_trip_lossless(self, tmp_path: Path):
+        cfg = TrackerConfig(
+            algorithm=AlgorithmType.OCSORT,
+            lifecycle=LifecycleConfig(max_age=42),
+        )
+        p = tmp_path / "cfg.yaml"
+        cfg.to_yaml(p)
+        loaded = TrackerConfig.from_yaml(p)
+        assert loaded == cfg
+
+    def test_from_empty_yaml_returns_defaults(self, tmp_path: Path):
+        p = tmp_path / "empty.yaml"
+        p.write_text("")
+        loaded = TrackerConfig.from_yaml(p)
+        assert loaded == TrackerConfig()
+
+    def test_default_config_loads(self):
+        p = Path(__file__).resolve().parents[2] / "configs" / "default.yaml"
+        loaded = TrackerConfig.from_yaml(p)
+        assert loaded == TrackerConfig()
+
+
+class TestModelValidate:
+    def test_from_dict(self):
+        cfg = TrackerConfig.model_validate(
+            {
+                "algorithm": "ocsort",
+                "association": {"match_threshold": 0.4},
+                "lifecycle": {"max_age": 50},
+            },
+        )
+        assert cfg.algorithm == AlgorithmType.OCSORT
+        assert cfg.association.match_threshold == pytest.approx(0.4)
+        assert cfg.lifecycle.max_age == 50
+
+    def test_json_schema_export_contains_subconfigs(self):
+        schema = TrackerConfig.model_json_schema()
+        names = set(schema.get("$defs", {}).keys())
+        assert {"AssociationConfig", "LifecycleConfig", "MotionConfig"} <= names
+
+    def test_json_schema_includes_field_descriptions(self):
+        """Pydantic should harvest the attribute docstrings as field descriptions."""
+        schema = TrackerConfig.model_json_schema()
+        assoc = schema["$defs"]["AssociationConfig"]["properties"]
+        assert "match_threshold" in assoc
+        assert "description" in assoc["match_threshold"]
+        assert "IoU" in assoc["match_threshold"]["description"]

--- a/libraries/getitrack/tests/unit/test_config.py
+++ b/libraries/getitrack/tests/unit/test_config.py
@@ -46,7 +46,7 @@ class TestBaseConfig:
 
     def test_unknown_field_raises(self):
         with pytest.raises(ValidationError, match="bogus"):
-            _DemoConfig(bogus=1)
+            _DemoConfig.model_validate({"bogus": 1})
 
     def test_negative_max_age_raises(self):
         with pytest.raises(ValidationError, match="max_age"):
@@ -55,6 +55,11 @@ class TestBaseConfig:
     def test_score_threshold_out_of_range_raises(self):
         with pytest.raises(ValidationError, match="score_threshold"):
             _DemoConfig(score_threshold=2.0)
+
+    def test_variant_rejects_foreign_algorithm(self):
+        # A subclass pins ``algorithm``; a different value must be rejected.
+        with pytest.raises(ValidationError, match="pins algorithm"):
+            _DemoConfig(algorithm=AlgorithmType.OCSORT)
 
 
 class TestYAML:

--- a/libraries/getitrack/tests/unit/test_detection.py
+++ b/libraries/getitrack/tests/unit/test_detection.py
@@ -5,7 +5,8 @@
 import numpy as np
 import pytest
 
-from getitrack.core.detection import Detections, TrackedDetections, TrackState
+from getitrack.core.detection import Detections, TrackedDetections
+from getitrack.core.track import TrackState
 
 
 def _dets(n: int = 3, frame_id: int = 0) -> Detections:
@@ -18,13 +19,12 @@ def _dets(n: int = 3, frame_id: int = 0) -> Detections:
 
 
 class TestTrackState:
-    def test_ordinals_are_dense_zero_based(self):
-        ordinals = [s.ordinal() for s in TrackState]
-        assert ordinals == list(range(len(TrackState)))
+    def test_values_are_explicit_and_dense(self):
+        assert [int(s) for s in TrackState] == list(range(len(TrackState)))
 
-    def test_from_ordinal_roundtrip(self):
-        for s in TrackState:
-            assert TrackState.from_ordinal(s.ordinal()) is s
+    def test_values_are_locked(self):
+        # Values are part of the on-disk track_states contract; pin them.
+        assert (TrackState.TENTATIVE, TrackState.ACTIVE, TrackState.LOST, TrackState.REMOVED) == (0, 1, 2, 3)
 
 
 class TestDetections:
@@ -152,7 +152,7 @@ class TestTrackedDetections:
             scores=np.array([0.9, 0.5][:n], dtype=np.float32),
             class_ids=np.array([0, 1][:n], dtype=np.int64),
             track_ids=np.array([1, 2][:n], dtype=np.int64),
-            track_states=np.array([TrackState.ACTIVE.ordinal(), TrackState.LOST.ordinal()][:n], dtype=np.int8),
+            track_states=np.array([TrackState.ACTIVE, TrackState.LOST][:n], dtype=np.int8),
             frame_id=0,
         )
 
@@ -174,8 +174,8 @@ class TestTrackedDetections:
         td = self._td(2)
         assert td.to_string_states() == ["active", "lost"]
 
-    def test_invalid_state_ordinal_raises(self):
-        with pytest.raises(ValueError, match="track_states ordinals"):
+    def test_invalid_state_value_raises(self):
+        with pytest.raises(ValueError, match="track_states values"):
             TrackedDetections(
                 bboxes=np.zeros((1, 4), dtype=np.float32),
                 scores=np.zeros(1, dtype=np.float32),
@@ -213,7 +213,7 @@ class TestTrackedDetections:
             scores=np.array([0.9, 0.5], dtype=np.float32),
             class_ids=np.array([0, 1], dtype=np.int64),
             track_ids=np.array([1, 2], dtype=np.int64),
-            track_states=np.array([TrackState.ACTIVE.ordinal(), TrackState.LOST.ordinal()], dtype=np.int8),
+            track_states=np.array([TrackState.ACTIVE, TrackState.LOST], dtype=np.int8),
             frame_id=0,
             interpolated=np.array([False, True]),
         )
@@ -253,7 +253,7 @@ class TestDetIndices:
             scores=np.array([0.9, 0.5], dtype=np.float32),
             class_ids=np.array([0, 1], dtype=np.int64),
             track_ids=np.array([1, 2], dtype=np.int64),
-            track_states=np.array([TrackState.ACTIVE.ordinal(), TrackState.LOST.ordinal()], dtype=np.int8),
+            track_states=np.array([TrackState.ACTIVE, TrackState.LOST], dtype=np.int8),
             frame_id=0,
             det_indices=np.array([5, -1], dtype=np.int64),
         )

--- a/libraries/getitrack/tests/unit/test_detection.py
+++ b/libraries/getitrack/tests/unit/test_detection.py
@@ -78,9 +78,10 @@ class TestDetections:
         assert low.scores[0] == pytest.approx(0.2)
 
     def test_filter_by_class(self):
-        d = _dets(3).filter_by_class([1])
+        d, source_rows = _dets(3).filter_by_class([1])
         assert len(d) == 1
         assert d.class_ids[0] == 1
+        assert source_rows.tolist() == [1]
 
     def test_embeddings_roundtrip_through_filter(self):
         embeds = np.random.default_rng(0).random((3, 8), dtype=np.float32)

--- a/libraries/getitrack/tests/unit/test_detection.py
+++ b/libraries/getitrack/tests/unit/test_detection.py
@@ -1,0 +1,261 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for Detections / TrackedDetections / TrackState."""
+
+import numpy as np
+import pytest
+
+from getitrack.core.detection import Detections, TrackedDetections, TrackState
+
+
+def _dets(n: int = 3, frame_id: int = 0) -> Detections:
+    return Detections(
+        bboxes=np.array([[i, i, i + 10, i + 10] for i in range(n)], dtype=np.float32),
+        scores=np.array([0.9, 0.5, 0.2][:n], dtype=np.float32),
+        class_ids=np.array([0, 1, 0][:n], dtype=np.int64),
+        frame_id=frame_id,
+    )
+
+
+class TestTrackState:
+    def test_ordinals_are_dense_zero_based(self):
+        ordinals = [s.ordinal() for s in TrackState]
+        assert ordinals == list(range(len(TrackState)))
+
+    def test_from_ordinal_roundtrip(self):
+        for s in TrackState:
+            assert TrackState.from_ordinal(s.ordinal()) is s
+
+
+class TestDetections:
+    def test_construct_valid(self):
+        d = _dets(3)
+        assert len(d) == 3
+        assert d.frame_id == 0
+        assert d.embeddings is None
+
+    def test_create_empty(self):
+        d = Detections.create_empty(frame_id=7)
+        assert len(d) == 0
+        assert d.frame_id == 7
+
+    def test_bbox_wrong_shape_raises(self):
+        with pytest.raises(ValueError, match="bboxes must have shape"):
+            Detections(
+                bboxes=np.array([1, 2, 3, 4], dtype=np.float32),
+                scores=np.array([0.5], dtype=np.float32),
+                class_ids=np.array([0], dtype=np.int64),
+                frame_id=0,
+            )
+
+    def test_row_mismatch_raises(self):
+        with pytest.raises(ValueError, match="scores has"):
+            Detections(
+                bboxes=np.zeros((3, 4), dtype=np.float32),
+                scores=np.array([0.5, 0.5], dtype=np.float32),
+                class_ids=np.array([0, 0, 0], dtype=np.int64),
+                frame_id=0,
+            )
+
+    def test_score_out_of_range_raises(self):
+        with pytest.raises(ValueError, match="scores must be in"):
+            Detections(
+                bboxes=np.zeros((1, 4), dtype=np.float32),
+                scores=np.array([1.5], dtype=np.float32),
+                class_ids=np.array([0], dtype=np.int64),
+                frame_id=0,
+            )
+
+    def test_filter_by_score(self):
+        d = _dets(3).filter_by_score(0.4)
+        assert len(d) == 2
+        assert d.scores.min() >= 0.4
+
+    def test_split_by_score(self):
+        high, low = _dets(3).split_by_score(0.4)
+        assert len(high) == 2
+        assert len(low) == 1
+        assert low.scores[0] == pytest.approx(0.2)
+
+    def test_filter_by_class(self):
+        d = _dets(3).filter_by_class([1])
+        assert len(d) == 1
+        assert d.class_ids[0] == 1
+
+    def test_embeddings_roundtrip_through_filter(self):
+        embeds = np.random.default_rng(0).random((3, 8), dtype=np.float32)
+        d = Detections(
+            bboxes=np.zeros((3, 4), dtype=np.float32),
+            scores=np.array([0.9, 0.1, 0.9], dtype=np.float32),
+            class_ids=np.array([0, 0, 0], dtype=np.int64),
+            frame_id=0,
+            embeddings=embeds,
+        )
+        kept = d.filter_by_score(0.5)
+        assert kept.embeddings is not None
+        assert kept.embeddings.shape == (2, 8)
+        np.testing.assert_array_equal(kept.embeddings, embeds[[0, 2]])
+
+    def test_embeddings_row_mismatch_raises(self):
+        with pytest.raises(ValueError, match="embeddings has"):
+            Detections(
+                bboxes=np.zeros((2, 4), dtype=np.float32),
+                scores=np.zeros(2, dtype=np.float32),
+                class_ids=np.zeros(2, dtype=np.int64),
+                frame_id=0,
+                embeddings=np.zeros((3, 4), dtype=np.float32),
+            )
+
+    def test_bboxes_wrong_dtype_raises(self):
+        with pytest.raises(TypeError, match="bboxes must have dtype float32"):
+            Detections(
+                bboxes=np.zeros((1, 4), dtype=np.float64),
+                scores=np.zeros(1, dtype=np.float32),
+                class_ids=np.zeros(1, dtype=np.int64),
+                frame_id=0,
+            )
+
+    def test_scores_wrong_dtype_raises(self):
+        with pytest.raises(TypeError, match="scores must have dtype float32"):
+            Detections(
+                bboxes=np.zeros((1, 4), dtype=np.float32),
+                scores=np.zeros(1, dtype=np.float64),
+                class_ids=np.zeros(1, dtype=np.int64),
+                frame_id=0,
+            )
+
+    def test_class_ids_wrong_dtype_raises(self):
+        with pytest.raises(TypeError, match="class_ids must have dtype int64"):
+            Detections(
+                bboxes=np.zeros((1, 4), dtype=np.float32),
+                scores=np.zeros(1, dtype=np.float32),
+                class_ids=np.zeros(1, dtype=np.int32),
+                frame_id=0,
+            )
+
+    def test_embeddings_wrong_dtype_raises(self):
+        with pytest.raises(TypeError, match="embeddings must have dtype float32"):
+            Detections(
+                bboxes=np.zeros((1, 4), dtype=np.float32),
+                scores=np.zeros(1, dtype=np.float32),
+                class_ids=np.zeros(1, dtype=np.int64),
+                frame_id=0,
+                embeddings=np.zeros((1, 8), dtype=np.float64),
+            )
+
+
+class TestTrackedDetections:
+    def _td(self, n: int = 2) -> TrackedDetections:
+        return TrackedDetections(
+            bboxes=np.zeros((n, 4), dtype=np.float32),
+            scores=np.array([0.9, 0.5][:n], dtype=np.float32),
+            class_ids=np.array([0, 1][:n], dtype=np.int64),
+            track_ids=np.array([1, 2][:n], dtype=np.int64),
+            track_states=np.array([TrackState.ACTIVE.ordinal(), TrackState.LOST.ordinal()][:n], dtype=np.int8),
+            frame_id=0,
+        )
+
+    def test_construct_valid(self):
+        td = self._td(2)
+        assert len(td) == 2
+
+    def test_create_empty(self):
+        td = TrackedDetections.create_empty(frame_id=4)
+        assert len(td) == 0
+        assert td.frame_id == 4
+
+    def test_active_only(self):
+        td = self._td(2).active_only()
+        assert len(td) == 1
+        assert td.track_ids[0] == 1
+
+    def test_to_string_states(self):
+        td = self._td(2)
+        assert td.to_string_states() == ["active", "lost"]
+
+    def test_invalid_state_ordinal_raises(self):
+        with pytest.raises(ValueError, match="track_states ordinals"):
+            TrackedDetections(
+                bboxes=np.zeros((1, 4), dtype=np.float32),
+                scores=np.zeros(1, dtype=np.float32),
+                class_ids=np.zeros(1, dtype=np.int64),
+                track_ids=np.zeros(1, dtype=np.int64),
+                track_states=np.array([99], dtype=np.int8),
+                frame_id=0,
+            )
+
+    def test_track_ids_wrong_dtype_raises(self):
+        with pytest.raises(TypeError, match="track_ids must have dtype int64"):
+            TrackedDetections(
+                bboxes=np.zeros((1, 4), dtype=np.float32),
+                scores=np.zeros(1, dtype=np.float32),
+                class_ids=np.zeros(1, dtype=np.int64),
+                track_ids=np.zeros(1, dtype=np.int32),
+                track_states=np.zeros(1, dtype=np.int8),
+                frame_id=0,
+            )
+
+    def test_track_states_wrong_dtype_raises(self):
+        with pytest.raises(TypeError, match="track_states must have dtype int8"):
+            TrackedDetections(
+                bboxes=np.zeros((1, 4), dtype=np.float32),
+                scores=np.zeros(1, dtype=np.float32),
+                class_ids=np.zeros(1, dtype=np.int64),
+                track_ids=np.zeros(1, dtype=np.int64),
+                track_states=np.zeros(1, dtype=np.int16),
+                frame_id=0,
+            )
+
+    def test_interpolated_propagates_through_active_only(self):
+        td = TrackedDetections(
+            bboxes=np.zeros((2, 4), dtype=np.float32),
+            scores=np.array([0.9, 0.5], dtype=np.float32),
+            class_ids=np.array([0, 1], dtype=np.int64),
+            track_ids=np.array([1, 2], dtype=np.int64),
+            track_states=np.array([TrackState.ACTIVE.ordinal(), TrackState.LOST.ordinal()], dtype=np.int8),
+            frame_id=0,
+            interpolated=np.array([False, True]),
+        )
+        active = td.active_only()
+        assert active.interpolated is not None
+        assert active.interpolated.tolist() == [False]
+
+
+class TestDetIndices:
+    def test_det_indices_wrong_dtype_raises(self):
+        with pytest.raises(TypeError, match="det_indices must have dtype int64"):
+            TrackedDetections(
+                bboxes=np.zeros((1, 4), dtype=np.float32),
+                scores=np.zeros(1, dtype=np.float32),
+                class_ids=np.zeros(1, dtype=np.int64),
+                track_ids=np.zeros(1, dtype=np.int64),
+                track_states=np.zeros(1, dtype=np.int8),
+                frame_id=0,
+                det_indices=np.zeros(1, dtype=np.int32),
+            )
+
+    def test_det_indices_row_mismatch_raises(self):
+        with pytest.raises(ValueError, match="det_indices"):
+            TrackedDetections(
+                bboxes=np.zeros((2, 4), dtype=np.float32),
+                scores=np.zeros(2, dtype=np.float32),
+                class_ids=np.zeros(2, dtype=np.int64),
+                track_ids=np.zeros(2, dtype=np.int64),
+                track_states=np.zeros(2, dtype=np.int8),
+                frame_id=0,
+                det_indices=np.zeros(3, dtype=np.int64),
+            )
+
+    def test_det_indices_propagate_through_active_only(self):
+        td = TrackedDetections(
+            bboxes=np.zeros((2, 4), dtype=np.float32),
+            scores=np.array([0.9, 0.5], dtype=np.float32),
+            class_ids=np.array([0, 1], dtype=np.int64),
+            track_ids=np.array([1, 2], dtype=np.int64),
+            track_states=np.array([TrackState.ACTIVE.ordinal(), TrackState.LOST.ordinal()], dtype=np.int8),
+            frame_id=0,
+            det_indices=np.array([5, -1], dtype=np.int64),
+        )
+        active = td.active_only()
+        assert active.det_indices is not None
+        assert active.det_indices.tolist() == [5]

--- a/libraries/getitrack/tests/unit/test_track.py
+++ b/libraries/getitrack/tests/unit/test_track.py
@@ -1,0 +1,84 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the per-track lifecycle state machine."""
+
+import numpy as np
+import pytest
+
+from getitrack.config import LifecycleConfig
+from getitrack.core.detection import TrackState
+from getitrack.core.track import Track
+
+
+@pytest.fixture
+def lifecycle() -> LifecycleConfig:
+    return LifecycleConfig(max_age=5, min_hits=3, tentative_max_age=2)
+
+
+@pytest.fixture
+def track() -> Track:
+    return Track(
+        track_id=1,
+        class_id=0,
+        bbox=np.array([0, 0, 10, 10], dtype=np.float32),
+        score=0.9,
+    )
+
+
+class TestTrackInit:
+    def test_initial_state_is_tentative(self, track: Track):
+        assert track.state == TrackState.TENTATIVE
+        assert track.hits == 1
+        assert track.age == 0
+        assert track.time_since_update == 0
+
+
+class TestPromotion:
+    def test_promotes_to_active_at_min_hits(self, track: Track, lifecycle: LifecycleConfig):
+        track.mark_hit(np.array([1, 1, 11, 11], dtype=np.float32), 0.8, lifecycle)
+        assert track.state == TrackState.TENTATIVE
+        track.mark_hit(np.array([2, 2, 12, 12], dtype=np.float32), 0.8, lifecycle)
+        assert track.state == TrackState.ACTIVE
+        assert track.hits == 3
+
+    def test_hit_resets_time_since_update(self, track: Track, lifecycle: LifecycleConfig):
+        track.mark_miss(lifecycle)
+        assert track.time_since_update == 1
+        track.mark_hit(np.zeros(4, dtype=np.float32), 0.9, lifecycle)
+        assert track.time_since_update == 0
+
+
+class TestLossAndRemoval:
+    def test_active_miss_transitions_to_lost(self, track: Track, lifecycle: LifecycleConfig):
+        track.mark_hit(np.zeros(4, dtype=np.float32), 0.9, lifecycle)
+        track.mark_hit(np.zeros(4, dtype=np.float32), 0.9, lifecycle)
+        assert track.state == TrackState.ACTIVE
+        track.mark_miss(lifecycle)
+        assert track.state == TrackState.LOST
+
+    def test_lost_track_recovers_on_hit(self, track: Track, lifecycle: LifecycleConfig):
+        track.mark_hit(np.zeros(4, dtype=np.float32), 0.9, lifecycle)
+        track.mark_hit(np.zeros(4, dtype=np.float32), 0.9, lifecycle)
+        track.mark_miss(lifecycle)
+        assert track.state == TrackState.LOST
+        track.mark_hit(np.zeros(4, dtype=np.float32), 0.9, lifecycle)
+        assert track.state == TrackState.ACTIVE
+
+    def test_lost_track_removed_after_max_age(self, track: Track, lifecycle: LifecycleConfig):
+        track.mark_hit(np.zeros(4, dtype=np.float32), 0.9, lifecycle)
+        track.mark_hit(np.zeros(4, dtype=np.float32), 0.9, lifecycle)
+        for _ in range(lifecycle.max_age + 1):
+            track.mark_miss(lifecycle)
+        assert track.state == TrackState.REMOVED
+        assert track.should_remove is True
+
+    def test_tentative_removed_after_tentative_max_age(self, track: Track, lifecycle: LifecycleConfig):
+        for _ in range(lifecycle.tentative_max_age + 1):
+            track.mark_miss(lifecycle)
+        assert track.state == TrackState.REMOVED
+        assert track.should_remove is True
+
+    def test_age_increments_on_hit_and_miss(self, track: Track, lifecycle: LifecycleConfig):
+        track.mark_hit(np.zeros(4, dtype=np.float32), 0.9, lifecycle)
+        track.mark_miss(lifecycle)
+        assert track.age == 2

--- a/libraries/getitrack/tests/unit/test_track.py
+++ b/libraries/getitrack/tests/unit/test_track.py
@@ -6,8 +6,7 @@ import numpy as np
 import pytest
 
 from getitrack.config import LifecycleConfig
-from getitrack.core.detection import TrackState
-from getitrack.core.track import Track
+from getitrack.core.track import Track, TrackState
 
 
 @pytest.fixture

--- a/libraries/getitrack/uv.lock
+++ b/libraries/getitrack/uv.lock
@@ -24,6 +24,7 @@ wheels = [
 name = "getitrack"
 source = { editable = "." }
 dependencies = [
+    { name = "loguru" },
     { name = "numpy" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -42,6 +43,7 @@ lint = [
 
 [package.metadata]
 requires-dist = [
+    { name = "loguru", specifier = ">=0.7" },
     { name = "numpy", specifier = ">=2.0" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pyyaml", specifier = "==6.0.3" },
@@ -65,6 +67,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "loguru"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
 ]
 
 [[package]]
@@ -442,4 +457,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
 ]


### PR DESCRIPTION
### Summary

- `getitrack.core.detection`. `Detections` and `TrackedDetections` as numpy-backed dataclasses with row-shape and value-range validation in `__post_init__`. `TrackState` is a StrEnum. `track_states` is stored as int8 ordinals for compactness, and `to_string_states()` returns the JSON-friendly form.
- `getitrack.core.track`. `Track` per-id state machine. Transitions TENTATIVE to ACTIVE to LOST to REMOVED driven by hits, misses, and `LifecycleConfig` thresholds.
- `getitrack.core.base`. `BaseTracker` ABC. `ALGORITHM_REGISTRY` plus `register_algorithm` decorator. `from_config` factory accepting `TrackerConfig`, a dict, or a YAML path. Per-instance `_next_id` so parallel trackers do not collide on ids. `update()` is a template method that applies the optional `association.class_filter` (remapping `det_indices` back to input rows) and verbose logging around the abstract `_update_impl()`.
- `getitrack.config`. Pydantic models for `TrackerConfig`, `AssociationConfig`, `LifecycleConfig`, `MotionConfig`, `AppearanceConfig`, `InterpolationConfig`. All set `extra = "forbid"` so YAML typos fail loudly. `from_yaml` / `to_yaml` are lossless.
- `getitrack.logger`. Package logger plus `enable_console_output()`, attached only when the host application has not configured root logging. `core.base` uses it for the verbose per-frame summary.
- `configs/default.yaml`. Reference config matching the Pydantic defaults.

### How to test
```bash
cd libraries/getitrack
just venv
just lint
just test-unit
```

67 unit tests covering shape/range validation, lifecycle transitions, registry dispatch, class-filter remapping, verbose logging, YAML round-trip, and JSON Schema export. Lint clean (ruff + pyrefly).
### Checklist

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
