### PR TITLE
 Add zip extension to model download

### DIFF
--- a/application/ui/package-lock.json
+++ b/application/ui/package-lock.json
@@ -18362,7 +18362,8 @@
         },
         "packages/config": {
             "name": "@geti/config",
-            "version": "1.0.0"
+            "version": "1.0.0",
+            "dev": true
         },
         "packages/smart-tools": {
             "name": "@geti/smart-tools",

--- a/application/ui/src/features/models/model-listing/model-variants/model-variant-table.component.test.tsx
+++ b/application/ui/src/features/models/model-listing/model-variants/model-variant-table.component.test.tsx
@@ -188,7 +188,7 @@ describe('ModelVariantTable', () => {
 
         expect(downloadFile).toHaveBeenCalledWith(
             expect.stringContaining(`/api/projects/project-123/models/${model.id}/variants/ov-1/binary`),
-            undefined,
+            `${model.name}_openvino.zip`,
             'Model download started'
         );
     });

--- a/application/ui/src/features/models/model-listing/model-variants/model-variant-table.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-variants/model-variant-table.component.tsx
@@ -100,7 +100,7 @@ export const ModelVariantTable = ({ model, format }: ModelVariantTableProps) => 
 
     const handleDownloadModel = (modelVariantId: string) => {
         const url = `${API_BASE_URL}/api/projects/${projectId}/models/${model.id}/variants/${modelVariantId}/binary`;
-        downloadFile(url, undefined, 'Model download started');
+        downloadFile(url, `${model.name}_${format}.zip`, 'Model download started');
     };
 
     return (


### PR DESCRIPTION
### Summary
The model variant download "Save as" dialog on Windows (MSIX package via Tauri) did not suggest a `.zip` extension because no filename was provided. This caused the downloaded zip to be saved without an extension. We now pass `${model.name}_${format}.zip` as a explicit filename argument to `downloadFile` in the `ModelVariantTable` component.

Closes : #6785 

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [x] Documentation has been updated (if applicable)
