### PR TITLE
fix: Saving training logs in tauri

### DIFF
--- a/application/ui/src/features/models/model-listing/components/model-actions/model-actions.component.test.tsx
+++ b/application/ui/src/features/models/model-listing/components/model-actions/model-actions.component.test.tsx
@@ -123,11 +123,10 @@ describe('ModelActions', () => {
         await userEvent.click(await screen.findByRole('button', { name: 'Download logs' }));
 
         expect(downloadFile).toHaveBeenCalledWith(
-            expect.stringMatching(/^blob:/),
+            expect.stringMatching(/models\/[^/]+\/logs/),
             `training-logs-${mockModel.id}.log`,
             'Training logs download started'
         );
-        expect(await screen.findByText('Training logs downloaded successfully')).toBeInTheDocument();
     });
 
     it('should disable "Rename" when model is currently training', async () => {

--- a/application/ui/src/features/models/model-listing/components/model-actions/model-actions.component.test.tsx
+++ b/application/ui/src/features/models/model-listing/components/model-actions/model-actions.component.test.tsx
@@ -96,20 +96,12 @@ describe('ModelActions', () => {
     it('should show download logs action in training logs dialog', async () => {
         server.use(
             http.get('/api/projects/{project_id}/models/{model_id}/logs', () => {
-                return new HttpResponse(
-                    new Blob(
-                        ['[2025-01-10 10:00:00][INFO ] Initializing\n[2025-01-10 10:00:01][INFO ] Training started'],
-                        {
-                            type: 'text/plain',
-                        }
-                    ),
-                    {
-                        status: 200,
-                        headers: {
-                            'content-type': 'text/plain',
-                        },
-                    }
-                );
+                return new HttpResponse('Training started\nEpoch 1/10 complete\n', {
+                    status: 200,
+                    headers: {
+                        'content-type': 'text/plain',
+                    },
+                });
             })
         );
 

--- a/application/ui/src/features/models/training-logs/hooks/use-model-logs.hook.ts
+++ b/application/ui/src/features/models/training-logs/hooks/use-model-logs.hook.ts
@@ -4,8 +4,7 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
-import { fetchClient } from '../../../../api/client';
-import { toast } from '../../../../components/toast/toast.component';
+import { API_BASE_URL, fetchClient } from '../../../../api/client';
 import { getQueryKey } from '../../../../query-client/query-client';
 import { downloadFile } from '../../../../shared/util';
 import { type LogEntry } from '../log-types';
@@ -45,20 +44,8 @@ export const useModelLogs = (modelId: string | undefined) => {
     });
 };
 
-const downloadModelLogsFile = async (projectId: string, modelId: string) => {
-    const { data, error, response } = await fetchClient.GET('/api/projects/{project_id}/models/{model_id}/logs', {
-        params: {
-            path: { project_id: projectId, model_id: modelId },
-            header: { accept: 'text/plain' },
-        },
-        parseAs: 'blob',
-    });
-
-    if (error || !data) {
-        throw new Error(`Failed to download model logs: ${response.status} ${response.statusText}`);
-    }
-
-    const url = URL.createObjectURL(data);
+const downloadModelLogsFile = (projectId: string, modelId: string) => {
+    const url = `${API_BASE_URL}/api/projects/${projectId}/models/${modelId}/logs`;
     downloadFile(url, `training-logs-${modelId}.log`, 'Training logs download started');
 };
 
@@ -72,12 +59,6 @@ export const useDownloadModelLogs = (modelId: string) => {
             }
 
             await downloadModelLogsFile(projectId, modelId);
-        },
-        onSuccess: () => {
-            toast({ type: 'success', message: 'Training logs downloaded successfully' });
-        },
-        onError: () => {
-            toast({ type: 'error', message: 'Failed to download training logs' });
         },
     });
 

--- a/application/ui/src/platform/download-file.tauri.ts
+++ b/application/ui/src/platform/download-file.tauri.ts
@@ -18,7 +18,6 @@ const saveDownload = async (url: string, name?: string, startedMessage?: string)
             filters: [{ name: 'All Files', extensions: ['*'] }],
         });
 
-
         if (selectedPath === null) {
             return;
         }

--- a/application/ui/src/platform/download-file.tauri.ts
+++ b/application/ui/src/platform/download-file.tauri.ts
@@ -7,19 +7,17 @@ import { writeFile } from '@tauri-apps/plugin-fs';
 import { toast } from '../components/toast/toast.component';
 
 export const downloadFile = (url: string, name?: string, startedMessage?: string): void => {
-    void saveDownload(url, name, startedMessage).catch((error: unknown) => {
-        console.error('[tauri downloadFile] failed', error);
-    });
+    void saveDownload(url, name, startedMessage);
 };
 
 const saveDownload = async (url: string, name?: string, startedMessage?: string): Promise<void> => {
-    const shouldRevokeObjectUrl = url.startsWith('blob:');
-
     try {
         const filename = name ?? getFallbackFilename(url);
         const selectedPath = await save({
             defaultPath: filename,
+            filters: [{ name: 'All Files', extensions: ['*'] }],
         });
+
 
         if (selectedPath === null) {
             return;
@@ -36,10 +34,9 @@ const saveDownload = async (url: string, name?: string, startedMessage?: string)
 
         const fileData = new Uint8Array(await response.arrayBuffer());
         await writeFile(selectedPath, fileData);
-    } finally {
-        if (shouldRevokeObjectUrl) {
-            URL.revokeObjectURL(url);
-        }
+    } catch (error: unknown) {
+        console.error('[tauri downloadFile] failed', error);
+        toast({ type: 'error', message: 'Failed to download file' });
     }
 };
 

--- a/application/ui/src/platform/download-file.ts
+++ b/application/ui/src/platform/download-file.ts
@@ -16,8 +16,4 @@ export const downloadFile = (url: string, name?: string, startedMessage?: string
     if (startedMessage !== undefined) {
         toast({ type: 'info', message: startedMessage });
     }
-
-    if (url.startsWith('blob:')) {
-        URL.revokeObjectURL(url);
-    }
 };


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

The issue was that first we downloaded logs as a binary, created URL for that binary and asked tauri download to fetch that binary again (even tho that binary was already stored in the memory). After the fix we fetch the logs only once.
Moreover there was an issue that when there was a popup that allowed user to select a path and that popup was closed without selecting a path, we showed toast that logs were downloaded successfully. For now decided just to remove that message and stay consistent with other downloads where we show only "Download x started", without a message when it finishes. It's the thing to improve.

Fix #6785
Fix #6786 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
