### PR TITLE
Add a MaskSafeRandomErasing wrapper to resolve an issue with Kornia RandomErrasing

### DIFF
--- a/application/backend/app/execution/common/geti_config_converter.py
+++ b/application/backend/app/execution/common/geti_config_converter.py
@@ -312,6 +312,7 @@ class TransformsUpdater:
         },
         "random_erasing": {
             "class_paths": [
+                "getitune.data.augmentation.transforms.MaskSafeRandomErasing",
                 "kornia.augmentation.RandomErasing",
                 "torchvision.transforms.v2.RandomErasing",
             ],
@@ -469,7 +470,8 @@ class TransformsUpdater:
     def _choose_variant(cls, registry_entry: dict, is_ultralytics: bool) -> tuple[str, str]:
         """Choose class_path and target stage for a new augmentation.
 
-        For Ultralytics backends, prefers torchvision / getitune CPU variants.
+        For Ultralytics backends, prefers torchvision CPU variants over
+        getitune custom variants (which may include kornia GPU subclasses).
         For other backends, uses the registry default (typically kornia GPU).
 
         Returns:
@@ -477,7 +479,10 @@ class TransformsUpdater:
         """
         if is_ultralytics:
             for cp in registry_entry["class_paths"]:
-                if cp.startswith(("torchvision.", "getitune.")):
+                if cp.startswith("torchvision."):
+                    return cp, "cpu"
+            for cp in registry_entry["class_paths"]:
+                if cp.startswith("getitune."):
                     return cp, "cpu"
         return registry_entry["class_paths"][0], registry_entry["stage"]
 

--- a/application/backend/tests/unit/execution/common/test_geti_config_converter.py
+++ b/application/backend/tests/unit/execution/common/test_geti_config_converter.py
@@ -609,6 +609,12 @@ class TestTransformsUpdater:
         assert "std" in noise[0]["init_args"]
         assert noise[0]["init_args"]["std"] == 0.1
 
+    def test_random_erasing_uses_mask_safe_class(self) -> None:
+        """random_erasing must map to MaskSafeRandomErasing, not raw kornia class."""
+        registry_entry = TransformsUpdater.AUGMENTATION_REGISTRY["random_erasing"]
+        assert "getitune.data.augmentation.transforms.MaskSafeRandomErasing" in registry_entry["class_paths"]
+        assert registry_entry["stage"] == "gpu"
+
 
 class TestGetCallbackIdx:
     def test_found(self) -> None:

--- a/library/src/getitune/data/augmentation/transforms.py
+++ b/library/src/getitune/data/augmentation/transforms.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 import typing
 from typing import TYPE_CHECKING, Any, cast
 
+import kornia.augmentation as K  # noqa: N812
 import torch
 import torchvision.transforms.v2 as tvt_v2
-import kornia.augmentation as K  # noqa: N812
 from torchvision import tv_tensors
 from torchvision.transforms.v2 import functional as F  # noqa: N812
 
@@ -1088,7 +1088,7 @@ class MaskSafeRandomErasing(K.RandomErasing):
 
     def apply_transform_mask(
         self,
-        input: torch.Tensor,
+        input: torch.Tensor,  # noqa: A002  # matches parent class kornia signature
         params: dict[str, torch.Tensor],
         flags: dict[str, Any],
         transform: torch.Tensor | None = None,

--- a/library/src/getitune/data/augmentation/transforms.py
+++ b/library/src/getitune/data/augmentation/transforms.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import torch
 import torchvision.transforms.v2 as tvt_v2
+import kornia.augmentation as K  # noqa: N812
 from torchvision import tv_tensors
 from torchvision.transforms.v2 import functional as F  # noqa: N812
 
@@ -1070,3 +1071,27 @@ class RandomIoUCrop(tvt_v2.RandomIoUCrop):
             return inputs if len(inputs) > 1 else inputs[0]
 
         return super().__call__(*inputs)
+
+
+class MaskSafeRandomErasing(K.RandomErasing):
+    """RandomErasing that erases images only, leaving masks unchanged.
+
+    Kornia's RandomErasing overrides :meth:`apply_transform_mask` to also erase
+    mask regions. This causes a shape mismatch in the GPU augmentation pipeline
+    when used with instance segmentation because per-sample mask tensors have
+    ``(N_instances, ...)`` dimensions while the inherited kornia params carry
+    the full batch dimension ``(B, ...)``.
+
+    Semantically, random erasing fills a rectangle on the image with a constant
+    value — object boundaries (masks) are not changed.
+    """
+
+    def apply_transform_mask(
+        self,
+        input: torch.Tensor,
+        params: dict[str, torch.Tensor],
+        flags: dict[str, Any],
+        transform: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Passthrough — masks are not affected by RandomErasing."""
+        return input

--- a/library/tests/unit/data/augmentation/test_pipeline.py
+++ b/library/tests/unit/data/augmentation/test_pipeline.py
@@ -673,6 +673,34 @@ class TestGPUAugmentationPipelineForward:
         assert result["images"] is not None
         assert result["masks"] is not None
 
+    def test_mask_safe_random_erasing_preserves_instance_masks(self):
+        """MaskSafeRandomErasing must not modify instance segmentation masks.
+
+        Regression test for kornia RandomErasing that erases mask regions with
+        incorrectly-shaped batch params, causing dimension mismatch errors.
+        """
+        from getitune.data.augmentation.transforms import MaskSafeRandomErasing
+
+        pipeline = GPUAugmentationPipeline(
+            [MaskSafeRandomErasing(p=1.0)],
+            data_keys=["input", "mask"],
+        )
+        images = _make_batched_images(2, h=32, w=32)
+        # Instance seg: different N_instances per sample
+        masks = [
+            torch.randint(0, 2, (3, 32, 32), dtype=torch.float32),  # 3 instances
+            torch.randint(0, 2, (5, 32, 32), dtype=torch.float32),  # 5 instances
+        ]
+        original_masks = [m.clone() for m in masks]
+        result = pipeline(images, masks=masks)
+
+        # Images should be changed (erasing was applied with p=1.0)
+        assert result["images"] is not None
+        assert not torch.equal(result["images"], images)
+        # Masks must be unchanged
+        for orig, out in zip(original_masks, result["masks"]):
+            assert torch.equal(orig, out), "masks must not be modified by MaskSafeRandomErasing"
+
     def test_forward_preserves_batch_size(self):
         pipeline = GPUAugmentationPipeline(
             [kornia_aug.RandomHorizontalFlip(p=0.5)],


### PR DESCRIPTION
Add a MaskSafeRandomErasing wrapper class in the library that overrides apply_transform_mask to passthrough (masks unchanged), fixing the shape mismatch between per-sample instance masks (N_instances, 1, H, W) and full-batch kornia params (B, ...).

<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
