### PR TITLE
Patch rfdetr export and remove fork

### DIFF
--- a/application/backend/pyproject.toml
+++ b/application/backend/pyproject.toml
@@ -95,6 +95,27 @@ override-dependencies = [
     "idna>=3.15",
 ]
 
+# getitune depends on rfdetr==1.4.3 which declares torch<=2.8.0. We relax that
+# bound here so the resolver doesn't reject torch 2.10 (pulled in via getitune[xpu]).
+[[tool.uv.dependency-metadata]]
+name = "rfdetr"
+version = "1.4.3"
+requires-dist = [
+    "requests",
+    "pycocotools",
+    "torch>=1.13.0",
+    "torchvision>=0.14.0",
+    "scipy",
+    "tqdm",
+    "transformers>4.0.0, <5.0.0",
+    "peft",
+    "rf100vl",
+    "pydantic",
+    "supervision",
+    "matplotlib",
+    "roboflow",
+]
+
 [tool.hatch.version]
 path = "../VERSION"
 pattern = "(?P<version>.+)"

--- a/application/backend/uv.lock
+++ b/application/backend/uv.lock
@@ -49,6 +49,11 @@ overrides = [
 ]
 excludes = ["opencv-python"]
 
+[[manifest.dependency-metadata]]
+name = "rfdetr"
+version = "1.4.3"
+requires-dist = ["requests", "pycocotools", "torch>=1.13.0", "torchvision>=0.14.0", "scipy", "tqdm", "transformers>4.0.0,<5.0.0", "peft", "rf100vl", "pydantic", "supervision", "matplotlib", "roboflow"]
+
 [[package]]
 name = "absl-py"
 version = "2.4.0"
@@ -1027,7 +1032,7 @@ requires-dist = [
     { name = "pytorchcv", specifier = "==0.0.74" },
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "regex", specifier = "==2026.1.15" },
-    { name = "rfdetr", git = "https://github.com/kprokofi/rf-detr.git?rev=bf69fe2d11ee6b7e0698e4a27af2081134f9b483" },
+    { name = "rfdetr", specifier = "==1.4.3" },
     { name = "rich", specifier = "==14.0.0" },
     { name = "rich-argparse", specifier = "==1.7.0" },
     { name = "roboflow", specifier = "~=1.2" },
@@ -2596,14 +2601,6 @@ wheels = [
 ]
 
 [[package]]
-name = "polygraphy"
-version = "0.49.26"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/25/e92af58cca8f8f8833d3346506a186938148b7156671c8154d94b8985d35/polygraphy-0.49.26-py2.py3-none-any.whl", hash = "sha256:5787d218a133163b42c92800134afaba6b266127646efb77416a9530137d1a45", size = 372849, upload-time = "2025-07-16T18:26:21.446Z" },
-]
-
-[[package]]
 name = "propcache"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3251,16 +3248,14 @@ wheels = [
 
 [[package]]
 name = "rfdetr"
-version = "1.4.1"
-source = { git = "https://github.com/kprokofi/rf-detr.git?rev=bf69fe2d11ee6b7e0698e4a27af2081134f9b483#bf69fe2d11ee6b7e0698e4a27af2081134f9b483" }
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "matplotlib", marker = "(extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-cuda') or (extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cpu' and extra == 'extra-8-getitune-cpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-4-geti-xpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cuda' and extra == 'extra-8-getitune-xpu')" },
-    { name = "numpy", marker = "(extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-cuda') or (extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cpu' and extra == 'extra-8-getitune-cpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-4-geti-xpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cuda' and extra == 'extra-8-getitune-xpu')" },
     { name = "peft", marker = "(extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-cuda') or (extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cpu' and extra == 'extra-8-getitune-cpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-4-geti-xpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cuda' and extra == 'extra-8-getitune-xpu')" },
-    { name = "pillow-avif-plugin", marker = "(extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-cuda') or (extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cpu' and extra == 'extra-8-getitune-cpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-4-geti-xpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cuda' and extra == 'extra-8-getitune-xpu')" },
-    { name = "polygraphy", marker = "(extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-cuda') or (extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cpu' and extra == 'extra-8-getitune-cpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-4-geti-xpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cuda' and extra == 'extra-8-getitune-xpu')" },
     { name = "pycocotools", marker = "(extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-cuda') or (extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cpu' and extra == 'extra-8-getitune-cpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-4-geti-xpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cuda' and extra == 'extra-8-getitune-xpu')" },
     { name = "pydantic", marker = "(extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-cuda') or (extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cpu' and extra == 'extra-8-getitune-cpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-4-geti-xpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cuda' and extra == 'extra-8-getitune-xpu')" },
+    { name = "requests", marker = "(extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-cuda') or (extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cpu' and extra == 'extra-8-getitune-cpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-4-geti-xpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cuda' and extra == 'extra-8-getitune-xpu')" },
     { name = "rf100vl", marker = "(extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-cuda') or (extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cpu' and extra == 'extra-8-getitune-cpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-4-geti-xpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cuda' and extra == 'extra-8-getitune-xpu')" },
     { name = "roboflow", marker = "(extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-cuda') or (extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cpu' and extra == 'extra-8-getitune-cpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-4-geti-xpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cuda' and extra == 'extra-8-getitune-xpu')" },
     { name = "scipy", marker = "(extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-cuda') or (extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cpu' and extra == 'extra-8-getitune-cpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-4-geti-xpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cuda' and extra == 'extra-8-getitune-xpu')" },
@@ -3275,6 +3270,10 @@ dependencies = [
     { name = "torchvision", version = "0.25.0+xpu", source = { registry = "https://download.pytorch.org/whl/xpu" }, marker = "(extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-cuda') or (extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-xpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cuda' and extra == 'extra-8-getitune-xpu')" },
     { name = "tqdm", marker = "(extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-cuda') or (extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cpu' and extra == 'extra-8-getitune-cpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-4-geti-xpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cuda' and extra == 'extra-8-getitune-xpu')" },
     { name = "transformers", marker = "(extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-cuda') or (extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cpu' and extra == 'extra-8-getitune-cpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-4-geti-xpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cuda' and extra == 'extra-8-getitune-xpu')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/ec/791445593e90fd1ac35f922cdbbd5303b43cf93d28fb305253e21578f764/rfdetr-1.4.3.tar.gz", hash = "sha256:7595655930576cb3c2bccd5fa9fa7b3a3b3526f09e42450af143debaaa15ab53", size = 145383, upload-time = "2026-02-16T13:25:40.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/9c/5744b2669e16874595abdf4a546b85a3d0274e6dcfb286904f6d9a9f6869/rfdetr-1.4.3-py3-none-any.whl", hash = "sha256:e893bc7096ca105fddd5213ca8ae5187daf06ee57ea5f65e19d7c4e5f1c5403f", size = 168100, upload-time = "2026-02-16T13:25:39.191Z" },
 ]
 
 [[package]]

--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -50,11 +50,7 @@ dependencies = [
     "tensorboard==2.20.0",
     "tensorboardx==2.6.4",
     "kornia~=0.8.2",
-    # NOTE: rf-detr is consumed from a specific commit that includes export fixes
-    # for torch>=2.10 and dynamo export support. Once the upstream roboflow/rf-detr
-    # repository publishes a tagged release with these changes, migrate to the
-    # official version pin.
-    "rfdetr @ git+https://github.com/kprokofi/rf-detr.git@bf69fe2d11ee6b7e0698e4a27af2081134f9b483",
+    "rfdetr==1.4.3",
     "certifi>=2026",
     "roboflow~=1.2",
 ]
@@ -175,6 +171,27 @@ torchvision = [
     { index = "torch-cpu", extra = "cpu", marker = "sys_platform == 'linux' or sys_platform == 'win32'"},
     { index = "torch-xpu", extra = "xpu"},
     { index = "torch-cuda", extra = "cuda"},
+]
+
+# rfdetr 1.4.3 declares torch<=2.8.0; override removes the bound since
+# we provide a fix for the export issue that motivated the upper bound and have verified that 2.10 works fine.
+[[tool.uv.dependency-metadata]]
+name = "rfdetr"
+version = "1.4.3"
+requires-dist = [
+    "requests",
+    "pycocotools",
+    "torch>=1.13.0",
+    "torchvision>=0.14.0",
+    "scipy",
+    "tqdm",
+    "transformers>4.0.0, <5.0.0",
+    "peft",
+    "rf100vl",
+    "pydantic",
+    "supervision",
+    "matplotlib",
+    "roboflow",
 ]
 
 [[tool.uv.index]]
@@ -422,6 +439,11 @@ notice-rgx = """
 "src/getitune/**/*.py" = [
     "ERA001",
 ]
+"src/getitune/backend/lightning/models/detection/layers/_rfdetr_export_patch.py" = [
+    "N806",     # Vendored rfdetr code uses trailing-underscore variable names
+    "PLW2901",  # Vendored rfdetr code reuses for-loop variables
+    "S101",     # Vendored rfdetr code uses assert
+]
 # See https://github.com/openvinotoolkit/training_extensions/actions/runs/7109500350/job/19354528819?pr=2700
 "src/getitune/core/config/**/*.py" = [
     "UP007"
@@ -441,4 +463,5 @@ python_files = "tests/**/*.py"
 [tool.pyrefly]
 python-version = "3.11.0"
 project-includes = ["src/getitune/**/*.py*", "tests/**/*.py*"]
+project-excludes = ["src/getitune/backend/lightning/models/detection/layers/_rfdetr_export_patch.py*"]
 ignore-missing-imports = ["*"]

--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -439,11 +439,6 @@ notice-rgx = """
 "src/getitune/**/*.py" = [
     "ERA001",
 ]
-"src/getitune/backend/lightning/models/detection/layers/_rfdetr_export_patch.py" = [
-    "N806",     # Vendored rfdetr code uses trailing-underscore variable names
-    "PLW2901",  # Vendored rfdetr code reuses for-loop variables
-    "S101",     # Vendored rfdetr code uses assert
-]
 # See https://github.com/openvinotoolkit/training_extensions/actions/runs/7109500350/job/19354528819?pr=2700
 "src/getitune/core/config/**/*.py" = [
     "UP007"

--- a/library/src/getitune/backend/lightning/models/common/rfdetr_mixin.py
+++ b/library/src/getitune/backend/lightning/models/common/rfdetr_mixin.py
@@ -19,6 +19,9 @@ from torchvision import tv_tensors
 from torchvision.ops import box_convert
 
 from getitune.backend.lightning.models.detection.detectors.rfdetr import RFDETRDetector
+from getitune.backend.lightning.models.detection.layers._rfdetr_export_patch import (
+    patched_rfdetr_transformer_for_export,
+)
 from getitune.backend.lightning.models.detection.utils import limit_batch_objects
 from getitune.backend.lightning.models.utils.utils import load_checkpoint
 from getitune.data.entity.base import BatchLoss
@@ -325,7 +328,8 @@ class RFDETRMixin:
         lwdetr = self.model.lwdetr  # pyrefly: ignore[missing-attribute]
         lwdetr.export()  # pyrefly: ignore[missing-attribute]
         try:
-            return super().export(output_dir, base_name, export_format, precision)  # type: ignore[misc]
+            with patched_rfdetr_transformer_for_export():
+                return super().export(output_dir, base_name, export_format, precision)  # type: ignore[misc]
         except Exception:
             self._restore_forward_methods(lwdetr)
             raise

--- a/library/src/getitune/backend/lightning/models/detection/layers/_rfdetr_export_patch.py
+++ b/library/src/getitune/backend/lightning/models/detection/layers/_rfdetr_export_patch.py
@@ -1,0 +1,273 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Monkey-patches for rfdetr's transformer during torch.export.
+
+rfdetr 1.4.3 lacks the export fix for dynamic batch shapes
+(first released in 1.6.4, post-API refactor).  The patched functions below are
+vendored from rfdetr 1.5.2's ``rfdetr/models/transformer.py`` (functionally identical
+to 1.4.3 for these two functions) with the minimal edits required for tracing.
+
+The patch is activated **only during ``export()``** via a context manager so
+train/eval numerics are completely unchanged.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Generator
+
+import torch
+from torch import Tensor, nn
+
+# ---------------------------------------------------------------------------
+# Patched gen_encoder_output_proposals (rfdetr 1.5.2 baseline)
+# ---------------------------------------------------------------------------
+# Changes from upstream 1.5.2:
+#  1. Parameter ``spatial_shapes`` renamed to ``spatial_shapes_list`` and
+#     iterated directly as Python-int (H,W) tuples.
+#  2. ``torch.tensor([H_ for _ in range(N_)], ...)`` replaced with
+#     ``torch.full((N_,), H_, …)`` to avoid baking a Python-int batch size
+#     into the traced graph (necessary for torch.export / ONNX export with
+#     dynamic dims).
+
+
+def _patched_gen_encoder_output_proposals(
+    memory: Tensor,
+    memory_padding_mask: Tensor | None,
+    spatial_shapes_list: list[tuple[int, int]],
+    unsigmoid: bool = True,
+) -> tuple[Tensor, Tensor]:
+    """Generate encoder output proposals for two-stage RF-DETR.
+
+    This is a modified version of ``gen_encoder_output_proposals`` from
+    ``rfdetr.models.transformer`` (v1.5.2) that is safe for torch.export.
+
+    Args:
+        memory: Encoder memory, shape ``(bs, sum_hw, d_model)``.
+        memory_padding_mask: Padding mask, shape ``(bs, sum_hw)``.
+        spatial_shapes_list: List of ``(H, W)`` Python-int tuples per
+            feature level.
+        unsigmoid: Whether to apply inverse-sigmoid to output proposals.
+
+    Returns:
+        output_memory, output_proposals
+    """
+    N_, S_, C_ = memory.shape
+    proposals = []
+    _cur = 0
+    for _lvl, (H_, W_) in enumerate(spatial_shapes_list):
+        if memory_padding_mask is not None:
+            mask_flatten_ = memory_padding_mask[:, _cur : (_cur + H_ * W_)].view(N_, H_, W_, 1)
+            valid_H = torch.sum(~mask_flatten_[:, :, 0, 0], 1)
+            valid_W = torch.sum(~mask_flatten_[:, 0, :, 0], 1)
+        else:
+            valid_H = torch.full((N_,), H_, dtype=torch.float32, device=memory.device)
+            valid_W = torch.full((N_,), W_, dtype=torch.float32, device=memory.device)
+
+        grid_y, grid_x = torch.meshgrid(
+            torch.linspace(0, H_ - 1, H_, dtype=torch.float32, device=memory.device),
+            torch.linspace(0, W_ - 1, W_, dtype=torch.float32, device=memory.device),
+            indexing="ij",
+        )
+        grid = torch.cat([grid_x.unsqueeze(-1), grid_y.unsqueeze(-1)], -1)
+
+        scale = torch.cat([valid_W.unsqueeze(-1), valid_H.unsqueeze(-1)], 1).view(N_, 1, 1, 2)
+        grid = (grid.unsqueeze(0).expand(N_, -1, -1, -1) + 0.5) / scale
+
+        wh = torch.ones_like(grid) * 0.05 * (2.0**_lvl)
+
+        proposal = torch.cat((grid, wh), -1).view(N_, -1, 4)
+        proposals.append(proposal)
+        _cur += H_ * W_
+
+    output_proposals = torch.cat(proposals, 1)
+    output_proposals_valid = ((output_proposals > 0.01) & (output_proposals < 0.99)).all(-1, keepdim=True)
+
+    if unsigmoid:
+        output_proposals = torch.log(output_proposals / (1 - output_proposals))
+        if memory_padding_mask is not None:
+            output_proposals = output_proposals.masked_fill(memory_padding_mask.unsqueeze(-1), float("inf"))
+        output_proposals = output_proposals.masked_fill(~output_proposals_valid, float("inf"))
+    else:
+        if memory_padding_mask is not None:
+            output_proposals = output_proposals.masked_fill(memory_padding_mask.unsqueeze(-1), float(0))
+        output_proposals = output_proposals.masked_fill(~output_proposals_valid, float(0))
+
+    output_memory = memory
+    if memory_padding_mask is not None:
+        output_memory = output_memory.masked_fill(memory_padding_mask.unsqueeze(-1), float(0))
+    output_memory = output_memory.masked_fill(~output_proposals_valid, float(0))
+
+    return output_memory.to(memory.dtype), output_proposals.to(memory.dtype)
+
+
+# ---------------------------------------------------------------------------
+# Patched Transformer.forward (rfdetr 1.5.2 baseline)
+# ---------------------------------------------------------------------------
+# Change from upstream 1.5.2:
+#   Build ``spatial_shapes_list`` (Python-int (h,w) tuples) before converting
+#   to tensor, and pass the **list** into ``gen_encoder_output_proposals``
+#   instead of the tensor.
+
+
+def _patched_transformer_forward(
+    self: nn.Module,
+    srcs: list[Tensor],
+    masks: list[Tensor] | None,
+    pos_embeds: list[Tensor],
+    refpoint_embed: Tensor,
+    query_feat: Tensor,
+) -> tuple[Tensor | None, Tensor | None, Tensor | None, Tensor | None]:
+    """Patched ``Transformer.forward`` from rfdetr 1.5.2.
+
+    Identical to upstream 1.5.2 except ``spatial_shapes_list`` is passed
+    to ``gen_encoder_output_proposals`` instead of the tensor.
+    """
+    src_flatten: list[Tensor] = []
+    mask_flatten: list[Tensor] | None = [] if masks is not None else None
+    lvl_pos_embed_flatten: list[Tensor] = []
+    spatial_shapes: list[tuple[int, int]] = []
+    valid_ratios: list[Tensor] | None = [] if masks is not None else None
+    for lvl, (src, pos_embed) in enumerate(zip(srcs, pos_embeds)):
+        bs, c, h, w = src.shape
+        spatial_shape = (h, w)
+        spatial_shapes.append(spatial_shape)
+
+        src = src.flatten(2).transpose(1, 2)
+        pos_embed = pos_embed.flatten(2).transpose(1, 2)
+        lvl_pos_embed_flatten.append(pos_embed)
+        src_flatten.append(src)
+        if masks is not None:
+            assert mask_flatten is not None
+            mask = masks[lvl].flatten(1)
+            mask_flatten.append(mask)
+    memory = torch.cat(src_flatten, 1)
+    if masks is not None:
+        mask_flatten = torch.cat(mask_flatten, 1)  # type: ignore[arg-type]
+        valid_ratios = torch.stack([self.get_valid_ratio(m) for m in masks], 1)  # type: ignore[union-attr]
+    lvl_pos_embed_flatten = torch.cat(lvl_pos_embed_flatten, 1)
+
+    # --- PATCH: keep spatial_shapes_list (Python-int tuples) for export ---
+    spatial_shapes_list = spatial_shapes
+    spatial_shapes = torch.as_tensor(spatial_shapes, dtype=torch.long, device=memory.device)  # type: ignore[assignment]
+    # --------------------------------------------------------------------
+
+    level_start_index = torch.cat((spatial_shapes.new_zeros((1,)), spatial_shapes.prod(1).cumsum(0)[:-1]))
+
+    if self.two_stage:  # type: ignore[union-attr]
+        output_memory, output_proposals = _patched_gen_encoder_output_proposals(
+            memory,
+            mask_flatten,
+            spatial_shapes_list,
+            unsigmoid=not self.bbox_reparam,  # type: ignore[union-attr]
+        )
+        refpoint_embed_ts, memory_ts, boxes_ts = [], [], []
+        group_detr = self.group_detr if self.training else 1  # type: ignore[union-attr]
+        for g_idx in range(group_detr):
+            output_memory_gidx = self.enc_output_norm[g_idx](self.enc_output[g_idx](output_memory))  # type: ignore[union-attr]
+
+            enc_outputs_class_unselected_gidx = self.enc_out_class_embed[g_idx](output_memory_gidx)  # type: ignore[union-attr]
+            if self.bbox_reparam:  # type: ignore[union-attr]
+                enc_outputs_coord_delta_gidx = self.enc_out_bbox_embed[g_idx](output_memory_gidx)  # type: ignore[union-attr]
+                enc_outputs_coord_cxcy_gidx = (
+                    enc_outputs_coord_delta_gidx[..., :2] * output_proposals[..., 2:] + output_proposals[..., :2]
+                )
+                enc_outputs_coord_wh_gidx = enc_outputs_coord_delta_gidx[..., 2:].exp() * output_proposals[..., 2:]
+                enc_outputs_coord_unselected_gidx = torch.concat(
+                    [enc_outputs_coord_cxcy_gidx, enc_outputs_coord_wh_gidx], dim=-1
+                )
+            else:
+                enc_outputs_coord_unselected_gidx = (
+                    self.enc_out_bbox_embed[g_idx](output_memory_gidx) + output_proposals  # type: ignore[union-attr]
+                )
+
+            topk = min(self.num_queries, enc_outputs_class_unselected_gidx.shape[-2])  # type: ignore[union-attr]
+            topk_proposals_gidx = torch.topk(enc_outputs_class_unselected_gidx.max(-1)[0], topk, dim=1)[1]
+
+            refpoint_embed_gidx_undetach = torch.gather(
+                enc_outputs_coord_unselected_gidx, 1, topk_proposals_gidx.unsqueeze(-1).repeat(1, 1, 4)
+            )
+            refpoint_embed_gidx = refpoint_embed_gidx_undetach.detach()
+
+            tgt_undetach_gidx = torch.gather(
+                output_memory_gidx,
+                1,
+                topk_proposals_gidx.unsqueeze(-1).repeat(1, 1, self.d_model),  # type: ignore[union-attr]
+            )
+
+            refpoint_embed_ts.append(refpoint_embed_gidx)
+            memory_ts.append(tgt_undetach_gidx)
+            boxes_ts.append(refpoint_embed_gidx_undetach)
+        refpoint_embed_ts = torch.cat(refpoint_embed_ts, dim=1)
+        memory_ts = torch.cat(memory_ts, dim=1)
+        boxes_ts = torch.cat(boxes_ts, dim=1)
+
+    if self.dec_layers > 0:  # type: ignore[union-attr]
+        tgt = query_feat.unsqueeze(0).repeat(bs, 1, 1)
+        refpoint_embed = refpoint_embed.unsqueeze(0).repeat(bs, 1, 1)
+        if self.two_stage:  # type: ignore[union-attr]
+            ts_len = refpoint_embed_ts.shape[-2]
+            refpoint_embed_ts_subset = refpoint_embed[..., :ts_len, :]
+            refpoint_embed_subset = refpoint_embed[..., ts_len:, :]
+
+            if self.bbox_reparam:  # type: ignore[union-attr]
+                refpoint_embed_cxcy = refpoint_embed_ts_subset[..., :2] * refpoint_embed_ts[..., 2:]
+                refpoint_embed_cxcy = refpoint_embed_cxcy + refpoint_embed_ts[..., :2]
+                refpoint_embed_wh = refpoint_embed_ts_subset[..., 2:].exp() * refpoint_embed_ts[..., 2:]
+                refpoint_embed_ts_subset = torch.concat([refpoint_embed_cxcy, refpoint_embed_wh], dim=-1)
+            else:
+                refpoint_embed_ts_subset = refpoint_embed_ts_subset + refpoint_embed_ts
+
+            refpoint_embed = torch.concat([refpoint_embed_ts_subset, refpoint_embed_subset], dim=-2)
+
+        hs, references = self.decoder(  # type: ignore[union-attr]
+            tgt,
+            memory,
+            memory_key_padding_mask=mask_flatten,
+            pos=lvl_pos_embed_flatten,
+            refpoints_unsigmoid=refpoint_embed,
+            level_start_index=level_start_index,
+            spatial_shapes=spatial_shapes,
+            valid_ratios=valid_ratios.to(memory.dtype) if valid_ratios is not None else valid_ratios,
+        )
+    else:
+        hs = None
+        references = None
+
+    if self.two_stage:  # type: ignore[union-attr]
+        if self.bbox_reparam:  # type: ignore[union-attr]
+            return hs, references, memory_ts, boxes_ts
+        return hs, references, memory_ts, boxes_ts.sigmoid()
+    return hs, references, None, None
+
+
+# ---------------------------------------------------------------------------
+# Context manager
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def patched_rfdetr_transformer_for_export() -> Generator[None, None, None]:
+    """Context manager that swaps rfdetr's transformer with export-safe versions.
+
+    Monkey-patches ``rfdetr.models.transformer.gen_encoder_output_proposals``
+    and ``rfdetr.models.transformer.Transformer.forward`` for the duration
+    of the context, restoring the originals on exit.
+
+    Intended to wrap the ``super().export()`` call inside the mixin's
+    ``export()`` override so the patch is active only during export tracing.
+    """
+    import rfdetr.models.transformer as _t
+
+    _orig_gen = _t.gen_encoder_output_proposals
+    _orig_forward = _t.Transformer.forward
+
+    _t.gen_encoder_output_proposals = _patched_gen_encoder_output_proposals  # type: ignore[assignment]
+    _t.Transformer.forward = _patched_transformer_forward  # type: ignore[assignment]
+
+    try:
+        yield
+    finally:
+        _t.gen_encoder_output_proposals = _orig_gen  # type: ignore[assignment]
+        _t.Transformer.forward = _orig_forward  # type: ignore[assignment]

--- a/library/src/getitune/backend/lightning/models/detection/layers/_rfdetr_export_patch.py
+++ b/library/src/getitune/backend/lightning/models/detection/layers/_rfdetr_export_patch.py
@@ -53,33 +53,35 @@ def _patched_gen_encoder_output_proposals(
     Returns:
         output_memory, output_proposals
     """
-    N_, S_, C_ = memory.shape
+    n_batch, s_spatial, c_dim = memory.shape
     proposals = []
     _cur = 0
-    for _lvl, (H_, W_) in enumerate(spatial_shapes_list):
+    for _lvl, (h_spatial, w_spatial) in enumerate(spatial_shapes_list):
         if memory_padding_mask is not None:
-            mask_flatten_ = memory_padding_mask[:, _cur : (_cur + H_ * W_)].view(N_, H_, W_, 1)
-            valid_H = torch.sum(~mask_flatten_[:, :, 0, 0], 1)
-            valid_W = torch.sum(~mask_flatten_[:, 0, :, 0], 1)
+            mask_flatten_ = memory_padding_mask[:, _cur : (_cur + h_spatial * w_spatial)].view(
+                n_batch, h_spatial, w_spatial, 1
+            )
+            valid_h = torch.sum(~mask_flatten_[:, :, 0, 0], 1)
+            valid_w = torch.sum(~mask_flatten_[:, 0, :, 0], 1)
         else:
-            valid_H = torch.full((N_,), H_, dtype=torch.float32, device=memory.device)
-            valid_W = torch.full((N_,), W_, dtype=torch.float32, device=memory.device)
+            valid_h = torch.full((n_batch,), h_spatial, dtype=torch.float32, device=memory.device)
+            valid_w = torch.full((n_batch,), w_spatial, dtype=torch.float32, device=memory.device)
 
         grid_y, grid_x = torch.meshgrid(
-            torch.linspace(0, H_ - 1, H_, dtype=torch.float32, device=memory.device),
-            torch.linspace(0, W_ - 1, W_, dtype=torch.float32, device=memory.device),
+            torch.linspace(0, h_spatial - 1, h_spatial, dtype=torch.float32, device=memory.device),
+            torch.linspace(0, w_spatial - 1, w_spatial, dtype=torch.float32, device=memory.device),
             indexing="ij",
         )
         grid = torch.cat([grid_x.unsqueeze(-1), grid_y.unsqueeze(-1)], -1)
 
-        scale = torch.cat([valid_W.unsqueeze(-1), valid_H.unsqueeze(-1)], 1).view(N_, 1, 1, 2)
-        grid = (grid.unsqueeze(0).expand(N_, -1, -1, -1) + 0.5) / scale
+        scale = torch.cat([valid_w.unsqueeze(-1), valid_h.unsqueeze(-1)], 1).view(n_batch, 1, 1, 2)
+        grid = (grid.unsqueeze(0).expand(n_batch, -1, -1, -1) + 0.5) / scale
 
         wh = torch.ones_like(grid) * 0.05 * (2.0**_lvl)
 
-        proposal = torch.cat((grid, wh), -1).view(N_, -1, 4)
+        proposal = torch.cat((grid, wh), -1).view(n_batch, -1, 4)
         proposals.append(proposal)
-        _cur += H_ * W_
+        _cur += h_spatial * w_spatial
 
     output_proposals = torch.cat(proposals, 1)
     output_proposals_valid = ((output_proposals > 0.01) & (output_proposals < 0.99)).all(-1, keepdim=True)
@@ -129,18 +131,19 @@ def _patched_transformer_forward(
     lvl_pos_embed_flatten: list[Tensor] = []
     spatial_shapes: list[tuple[int, int]] = []
     valid_ratios: list[Tensor] | None = [] if masks is not None else None
-    for lvl, (src, pos_embed) in enumerate(zip(srcs, pos_embeds)):
+    for _lvl, (src, pos_embed) in enumerate(zip(srcs, pos_embeds)):
         bs, c, h, w = src.shape
         spatial_shape = (h, w)
         spatial_shapes.append(spatial_shape)
 
-        src = src.flatten(2).transpose(1, 2)
-        pos_embed = pos_embed.flatten(2).transpose(1, 2)
-        lvl_pos_embed_flatten.append(pos_embed)
-        src_flatten.append(src)
+        src_flat = src.flatten(2).transpose(1, 2)
+        pos_embed_flat = pos_embed.flatten(2).transpose(1, 2)
+        lvl_pos_embed_flatten.append(pos_embed_flat)
+        src_flatten.append(src_flat)
         if masks is not None:
-            assert mask_flatten is not None
-            mask = masks[lvl].flatten(1)
+            if mask_flatten is None:
+                raise RuntimeError  # unreachable — kept to satisfy type-checker
+            mask = masks[_lvl].flatten(1)
             mask_flatten.append(mask)
     memory = torch.cat(src_flatten, 1)
     if masks is not None:

--- a/library/uv.lock
+++ b/library/uv.lock
@@ -47,6 +47,11 @@ overrides = [
 ]
 excludes = ["opencv-python"]
 
+[[manifest.dependency-metadata]]
+name = "rfdetr"
+version = "1.4.3"
+requires-dist = ["requests", "pycocotools", "torch>=1.13.0", "torchvision>=0.14.0", "scipy", "tqdm", "transformers>4.0.0,<5.0.0", "peft", "rf100vl", "pydantic", "supervision", "matplotlib", "roboflow"]
+
 [[package]]
 name = "absl-py"
 version = "2.4.0"
@@ -1389,7 +1394,7 @@ requires-dist = [
     { name = "pytorchcv", specifier = "==0.0.74" },
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "regex", specifier = "==2026.1.15" },
-    { name = "rfdetr", git = "https://github.com/kprokofi/rf-detr.git?rev=bf69fe2d11ee6b7e0698e4a27af2081134f9b483" },
+    { name = "rfdetr", specifier = "==1.4.3" },
     { name = "rich", specifier = "==14.0.0" },
     { name = "rich-argparse", specifier = "==1.7.0" },
     { name = "roboflow", specifier = "~=1.2" },
@@ -3884,14 +3889,6 @@ wheels = [
 ]
 
 [[package]]
-name = "polygraphy"
-version = "0.49.26"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/25/e92af58cca8f8f8833d3346506a186938148b7156671c8154d94b8985d35/polygraphy-0.49.26-py2.py3-none-any.whl", hash = "sha256:5787d218a133163b42c92800134afaba6b266127646efb77416a9530137d1a45", size = 372849, upload-time = "2025-07-16T18:26:21.446Z" },
-]
-
-[[package]]
 name = "prettytable"
 version = "3.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4863,16 +4860,14 @@ wheels = [
 
 [[package]]
 name = "rfdetr"
-version = "1.4.1"
-source = { git = "https://github.com/kprokofi/rf-detr.git?rev=bf69fe2d11ee6b7e0698e4a27af2081134f9b483#bf69fe2d11ee6b7e0698e4a27af2081134f9b483" }
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "matplotlib" },
-    { name = "numpy" },
     { name = "peft" },
-    { name = "pillow-avif-plugin" },
-    { name = "polygraphy" },
     { name = "pycocotools" },
     { name = "pydantic" },
+    { name = "requests" },
     { name = "rf100vl" },
     { name = "roboflow" },
     { name = "scipy" },
@@ -4887,6 +4882,10 @@ dependencies = [
     { name = "torchvision", version = "0.25.0+xpu", source = { registry = "https://download.pytorch.org/whl/xpu" }, marker = "(extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-cuda') or (extra != 'extra-8-getitune-cuda' and extra == 'extra-8-getitune-xpu') or (extra != 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-xpu')" },
     { name = "tqdm" },
     { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/ec/791445593e90fd1ac35f922cdbbd5303b43cf93d28fb305253e21578f764/rfdetr-1.4.3.tar.gz", hash = "sha256:7595655930576cb3c2bccd5fa9fa7b3a3b3526f09e42450af143debaaa15ab53", size = 145383, upload-time = "2026-02-16T13:25:40.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/9c/5744b2669e16874595abdf4a546b85a3d0274e6dcfb286904f6d9a9f6869/rfdetr-1.4.3-py3-none-any.whl", hash = "sha256:e893bc7096ca105fddd5213ca8ae5187daf06ee57ea5f65e19d7c4e5f1c5403f", size = 168100, upload-time = "2026-02-16T13:25:39.191Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

This PR removes fork usage and moves an export fix directly to library. In the develop I will try to migrate to 1.8 version of the RFDETR properly which introduce major API changes and too risky to migrate for this release.

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
