### PR TITLE
 Display architecture in running optimization job card

### DIFF
--- a/application/ui/src/features/models/model-listing/current-model-running/running-model-row.component.tsx
+++ b/application/ui/src/features/models/model-listing/current-model-running/running-model-row.component.tsx
@@ -104,7 +104,9 @@ export const RunningModelRow = ({
     const device = isTrainJob(job) ? job.metadata.device.name : null;
 
     const modelArchitectureId =
-        'model' in job.metadata && 'architecture' in job.metadata.model && job.metadata.model.architecture;
+        'model' in job.metadata && 'architecture' in job.metadata.model
+            ? job.metadata.model.architecture
+            : trainingModel?.architecture;
     const modelName = trainingModel?.name;
 
     const modelArchitecture = modelArchitectures.find(({ id }) => id === modelArchitectureId);


### PR DESCRIPTION


<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
Update `RunningModelRow` to fallback to `trainingModel?.architecture` if the job metadata (`job.metadata.model`) does not explicitly contain the architecture. This fixes the issue where optimization (quantization) jobs would show "Unknown" instead of the target architecture.

Closes:#6827
<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Closes:
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
