### PR TITLE
Fix cannot create a classification project from a detection dataset

### DIFF
--- a/application/backend/app/execution/dataset_import/base_import.py
+++ b/application/backend/app/execution/dataset_import/base_import.py
@@ -104,6 +104,7 @@ class BaseDatasetImport(Execution[JobParamsT], ABC):
             ):
                 raise ValueError(
                     f"Dataset type {dataset_type.__name__} conversion to {target_type.__name__} is not supported."
+                    f"Supported conversions are {list(self.SUPPORTED_CONVERSIONS[dataset_type])}"
                 )
             dataset = dataset.convert_to_schema(target_type)
         return dataset

--- a/application/backend/app/execution/dataset_import/base_import.py
+++ b/application/backend/app/execution/dataset_import/base_import.py
@@ -103,7 +103,7 @@ class BaseDatasetImport(Execution[JobParamsT], ABC):
                 and target_type not in self.SUPPORTED_CONVERSIONS[dataset_type]
             ):
                 raise ValueError(
-                    f"Dataset type {dataset_type.__name__} conversion to {target_type.__name__} is not supported."
+                    f"Dataset type {dataset_type.__name__} conversion to {target_type.__name__} is not supported. "
                     f"Supported conversions are {list(self.SUPPORTED_CONVERSIONS[dataset_type])}"
                 )
             dataset = dataset.convert_to_schema(target_type)

--- a/application/backend/app/execution/dataset_import/import_as_new_project.py
+++ b/application/backend/app/execution/dataset_import/import_as_new_project.py
@@ -161,13 +161,11 @@ class ImportDatasetAsNewProject(BaseDatasetImport[ImportDatasetAsNewProjectJobPa
 
         label_type = dataset.schema.attributes["label"].type
 
-        # 1. Direct match with numpy.ndarray
-        if label_type is np.ndarray:
-            return True
+        def _is_numpy_array_type(tp: object) -> bool:
+            return tp is np.ndarray or get_origin(tp) is np.ndarray
 
-        # 2. Check within Union types (such as np.ndarray | None)
         origin = get_origin(label_type)
         if origin in (Union, types.UnionType):
-            return any(arg is np.ndarray for arg in get_args(label_type))
+            return any(_is_numpy_array_type(arg) for arg in get_args(label_type))
 
-        return False
+        return _is_numpy_array_type(label_type)

--- a/application/backend/app/execution/dataset_import/import_as_new_project.py
+++ b/application/backend/app/execution/dataset_import/import_as_new_project.py
@@ -2,11 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import secrets
+import types
 from collections.abc import Callable
 from contextlib import AbstractContextManager
 from pathlib import Path
+from typing import Union, get_args, get_origin
 from uuid import uuid4
 
+import numpy as np
 import polars as pl
 from datumaro.experimental import Dataset
 from datumaro.experimental.fields import Subset
@@ -129,14 +132,42 @@ class ImportDatasetAsNewProject(BaseDatasetImport[ImportDatasetAsNewProjectJobPa
 
     def execute(self, params: ImportDatasetAsNewProjectJobParams) -> None:
         dataset = self.import_dataset(params=params)
-        multilabel = self._is_multilabel_dataset(dataset=dataset)
-        project = self.create_project(params=params, exclusive_labels=not multilabel)
+        has_array_label = self._has_array_label(dataset=dataset)
+        project = self.create_project(params=params, exclusive_labels=not has_array_label)
         self.update_metadata({"project_id": project.id})
         dataset = self.prepare_dataset(dataset=dataset, params=params, task=project.task)
         self.create_items(dataset=dataset, project=project, include_unannotated=params.include_unannotated)
 
     @staticmethod
-    def _is_multilabel_dataset(dataset: Dataset) -> bool:
-        if "label" in dataset.schema.attributes:
-            return getattr(dataset.schema.attributes["label"].field, "multi_label", False)
+    def _has_array_label(dataset: Dataset) -> bool:
+        """
+        Check if the dataset's 'label' attribute is represented as a NumPy array.
+
+        This method inspects the schema definition of the 'label' attribute to check if its type is or contains
+        `np.ndarray` (such as `np.ndarray | None`).
+
+        The result impacts how the project is created: if the dataset has array labels, the newly created project will
+        configure its task with non-exclusive labels (i.e., a multi-label classification project).
+
+        Args:
+            dataset: The Datumaro dataset to analyze.
+
+        Returns:
+            True if the dataset's 'label' attribute schema type contains `np.ndarray`,
+            False otherwise.
+        """
+        if "label" not in dataset.schema.attributes:
+            return False
+
+        label_type = dataset.schema.attributes["label"].type
+
+        # 1. Direct match with numpy.ndarray
+        if label_type is np.ndarray:
+            return True
+
+        # 2. Check within Union types (such as np.ndarray | None)
+        origin = get_origin(label_type)
+        if origin in (Union, types.UnionType):
+            return any(arg is np.ndarray for arg in get_args(label_type))
+
         return False

--- a/application/backend/pyproject.toml
+++ b/application/backend/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "aiofiles==25.1.0",
     "pydantic-settings~=2.12.0",
     "aiortc~=1.14.0",
-    "datumaro[experimental]~=1.13.1",
+    "datumaro[experimental]~=1.13.2",
     "scikit-learn~=1.7.2",
     "faster-coco-eval~=1.7.0",
     "scikit-multilearn~=0.2.0",

--- a/application/backend/tests/bdd/features/import_dataset_as_new_project.feature
+++ b/application/backend/tests/bdd/features/import_dataset_as_new_project.feature
@@ -6,8 +6,8 @@ Feature: Import Dataset As New Project
   So that I can create new projects from external datasets
 
   @import_as_new_project @detection
-  Scenario: Import detection dataset as a new project
-    Given A detection dataset with labels ["Chardonnay", "Sauvignon Blanc", "Cabernet Franc"] exists
+  Scenario Outline: Import detection dataset as a new project
+    Given A <dataset_type> dataset with labels ["Chardonnay", "Sauvignon Blanc", "Cabernet Franc"] exists
     And the dataset contains the following image distribution:
       | Label           | Training | Validation |
       | Chardonnay      | 5        | 2          |
@@ -25,6 +25,11 @@ Feature: Import Dataset As New Project
       | Label           | Instances |
       | Chardonnay      | 7         |
       | Sauvignon Blanc | 7         |
+
+    Examples:
+        | dataset_type          |
+        | detection             |
+        | instance_segmentation |
 
   @import_as_new_project @classification
   Scenario: Import classification dataset as a new project
@@ -46,8 +51,8 @@ Feature: Import Dataset As New Project
       | cat   | 5         |
 
   @import_as_new_project @multilabel
-  Scenario: Import multilabel classification dataset as a new project
-    Given A multilabel dataset with labels ["cat", "dog"] exists
+  Scenario Outline: Import multilabel classification dataset as a new project
+    Given A <dataset_type> dataset with labels ["cat", "dog"] exists
     And the dataset contains the following image distribution:
       | Label | Training |
       | cat   | 3        |
@@ -65,9 +70,15 @@ Feature: Import Dataset As New Project
       | cat   | 3         |
       | dog   | 3         |
 
+    Examples:
+        | dataset_type          |
+        | multilabel            |
+        | detection             |
+        | instance_segmentation |
+
   @import_as_new_project @segmentation
-  Scenario: Import segmentation dataset as a new project
-    Given An instance_segmentation dataset with labels ["car", "person"] exists
+  Scenario Outline: Import segmentation dataset as a new project
+    Given A <dataset_type> dataset with labels ["car", "person"] exists
     And the dataset contains the following image distribution:
       | Label  | Training | Testing |
       | car    | 3        | 3       |
@@ -84,3 +95,8 @@ Feature: Import Dataset As New Project
       | Label  | Instances |
       | car    | 6         |
       | person | 6         |
+
+    Examples:
+        | dataset_type          |
+        | detection             |
+        | instance_segmentation |

--- a/application/backend/tests/bdd/features/import_dataset_as_new_project.feature
+++ b/application/backend/tests/bdd/features/import_dataset_as_new_project.feature
@@ -6,7 +6,7 @@ Feature: Import Dataset As New Project
   So that I can create new projects from external datasets
 
   @import_as_new_project @detection
-  Scenario Outline: Import detection dataset as a new project
+  Scenario Outline: Import dataset as a new detection project
     Given A <dataset_type> dataset with labels ["Chardonnay", "Sauvignon Blanc", "Cabernet Franc"] exists
     And the dataset contains the following image distribution:
       | Label           | Training | Validation |
@@ -51,7 +51,7 @@ Feature: Import Dataset As New Project
       | cat   | 5         |
 
   @import_as_new_project @multilabel
-  Scenario Outline: Import multilabel classification dataset as a new project
+  Scenario Outline: Import dataset as a new multilabel project
     Given A <dataset_type> dataset with labels ["cat", "dog"] exists
     And the dataset contains the following image distribution:
       | Label | Training |
@@ -77,7 +77,7 @@ Feature: Import Dataset As New Project
         | instance_segmentation |
 
   @import_as_new_project @segmentation
-  Scenario Outline: Import segmentation dataset as a new project
+  Scenario Outline: Import dataset as a new instance_segmentation project
     Given A <dataset_type> dataset with labels ["car", "person"] exists
     And the dataset contains the following image distribution:
       | Label  | Training | Testing |

--- a/application/backend/tests/unit/execution/dataset_import/test_import_as_new_project.py
+++ b/application/backend/tests/unit/execution/dataset_import/test_import_as_new_project.py
@@ -176,7 +176,7 @@ class TestImportDatasetAsNewProject:
         project.task = Mock(spec=Task)
         with (
             patch.object(fxt_import, "import_dataset", return_value=dataset) as mock_import_dataset,
-            patch.object(fxt_import, "_is_multilabel_dataset", return_value=False) as mock_multilabel_dataset,
+            patch.object(fxt_import, "_has_array_label", return_value=False) as mock_multilabel_dataset,
             patch.object(fxt_import, "create_project", return_value=project) as mock_create_project,
             patch.object(fxt_import, "prepare_dataset", return_value=dataset) as mock_prepare_dataset,
             patch.object(fxt_import, "create_items") as mock_create,

--- a/application/backend/uv.lock
+++ b/application/backend/uv.lock
@@ -513,7 +513,7 @@ wheels = [
 
 [[package]]
 name = "datumaro"
-version = "1.13.1"
+version = "1.13.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -535,13 +535,13 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/c4/eddec919235d33cac7e49bf5e239c97ca22f4cf4480e6c93565b32d7d143/datumaro-1.13.1.tar.gz", hash = "sha256:cf0befdb90f3103390ae77ea16826826021072f19d64428c06497925f9a59f88", size = 622721, upload-time = "2026-06-15T15:26:59.256Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/4e/cc7046853ac7292df08283bef31cfd6b58e5fb8f87f4c682b89c9d6ccd65/datumaro-1.13.2.tar.gz", hash = "sha256:42a2bddb8f8cfbcaaf3d3c0ecada3637801ca901891c9b79a8a8d96532adda84", size = 622803, upload-time = "2026-06-18T13:42:27.122Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/53/d2e2d2c522b9510367f95d2c498445addd8aa48fb76fe3a6e6146fb208b5/datumaro-1.13.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:820500f6a73e73e5cd17ddb4ef26eb430f8a5ceb07c1b54926135e177d386754", size = 1061935, upload-time = "2026-06-15T15:26:50.929Z" },
-    { url = "https://files.pythonhosted.org/packages/55/80/a560ad12ba0e529ff092893d748f7e8ac0c662411d9181fc2fce7b11a738/datumaro-1.13.1-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:250121d9d869f8b36004f8ae3cb32dd5677638a901e0ced32c26619e917bfc2a", size = 1076281, upload-time = "2026-06-15T15:26:52.505Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/1c/9abf4dd34b7205c125d92feb2bac96ad219aa28b0ce40cdbbb114e44c48f/datumaro-1.13.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:7ca6c9f31ca5bc4e8b38bc495bfbdc3f401d7bc9af884b89e8064fafeaa88cc4", size = 1121384, upload-time = "2026-06-15T15:26:54.308Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/f9/d3ee9c84b387ae47355ae1d48fb2d5d5623c355a48ed186b006724d21574/datumaro-1.13.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:28f6a53b88529f696ead8f639de39307f134d5eb580b4ab9e741973988f6b4d8", size = 1193645, upload-time = "2026-06-15T15:26:56.043Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/a7/94504235bba7dc3456d23ff51b1e33cc9c9f8ffb8a9510937b2897c9f723/datumaro-1.13.1-cp313-cp313-win_amd64.whl", hash = "sha256:b7a7b07183eb272b8e0c4cd06d5df813ce20a9cdb517089091a5af2476eb9585", size = 968947, upload-time = "2026-06-15T15:26:57.685Z" },
+    { url = "https://files.pythonhosted.org/packages/22/08/3b2a535c6a4074f11a7ea02f733c652f7349e6052f91c8504b4a154b8cbb/datumaro-1.13.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:964c8534ca709b1514f2902631119664caa976dfe63f8ee0f06ffc64ab3efc93", size = 1062075, upload-time = "2026-06-18T13:42:19.271Z" },
+    { url = "https://files.pythonhosted.org/packages/95/8a/075a4505f17519ba7db3d16d1f9ab0d4aabecd6802b26883d279ade4b8bb/datumaro-1.13.2-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:c034ff27f8647f864691d9acd15aa9566bb6071f4076897d92cbbda4ca469d86", size = 1076377, upload-time = "2026-06-18T13:42:20.604Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/59a640bbc807a0e6e0ede7ef1851c851079faf6d5eef39dc4ec6b2fb2956/datumaro-1.13.2-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:4615d63aca90a29c43b356fad31e49a0ed490c499a585a5a0b02917cfdecf830", size = 1121386, upload-time = "2026-06-18T13:42:22.679Z" },
+    { url = "https://files.pythonhosted.org/packages/82/b3/48e996bffa0314a88269f8c59c0143a45479ce4ec0080f9b18b1efa8e40c/datumaro-1.13.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ff519d2b611adfc654cf557e2d6f4dc30ceba1283e3a95adfb467c6c5f94cf27", size = 1193677, upload-time = "2026-06-18T13:42:24.191Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e0/46ab4a936663f70f23b5ec31a736727d0687c14a80dad8ab3f0debdc26e3/datumaro-1.13.2-cp313-cp313-win_amd64.whl", hash = "sha256:8e20a73823ea9032c73cb2c1407c438736abd8aab13ffc9c84d4974f6d40761a", size = 968865, upload-time = "2026-06-18T13:42:25.636Z" },
 ]
 
 [package.optional-dependencies]
@@ -910,7 +910,7 @@ requires-dist = [
     { name = "alembic", specifier = "~=1.17.2" },
     { name = "av", specifier = "~=16.1.0" },
     { name = "cv2-enumerate-cameras", specifier = "==1.3.3" },
-    { name = "datumaro", extras = ["experimental"], specifier = "~=1.13.1" },
+    { name = "datumaro", extras = ["experimental"], specifier = "~=1.13.2" },
     { name = "fastapi", extras = ["standard"], specifier = "~=0.121.2" },
     { name = "faster-coco-eval", specifier = "~=1.7.0" },
     { name = "getitune", extras = ["cpu", "ultralytics"], marker = "extra == 'cpu'", editable = "../../library" },


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

This PR fixes an issue where importing a detection or instance segmentation dataset as classification incorrectly created a single-label classification project instead of a multilabel one. Previously, this incorrect behavior led to an unsupported task conversion error.

- [x] Evaluate label type from dataset schema when choosing `exclusive_labels` for creating project in import task

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
