### PR TITLE
fix: Don't mark media as selected after deletion

### DIFF
--- a/application/ui/src/features/dataset/api/use-delete-media-item.ts
+++ b/application/ui/src/features/dataset/api/use-delete-media-item.ts
@@ -9,6 +9,7 @@ import { isFunction } from 'lodash-es';
 import { $api } from '../../../api/client';
 import { toast } from '../../../components/toast/toast.component';
 import { getQueryKey } from '../../../query-client/query-client';
+import { pluralizeItems } from '../../../shared/util';
 
 const toastId = 'deleting-notification';
 
@@ -67,7 +68,7 @@ export const useDeleteMediaItem = () => {
         toast({
             id: toastId,
             type: 'success',
-            message: `${deletedIds.length} item(s) deleted successfully`,
+            message: `${deletedIds.length} ${pluralizeItems(deletedIds.length)} deleted successfully`,
             duration: 3000,
         });
     };

--- a/application/ui/src/features/dataset/gallery/delete-media-item/delete-media-item.component.test.tsx
+++ b/application/ui/src/features/dataset/gallery/delete-media-item/delete-media-item.component.test.tsx
@@ -29,7 +29,7 @@ describe('DeleteMediaItem', () => {
 
         fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
 
-        expect(await screen.findByText(`1 item(s) deleted successfully`)).toBeVisible();
+        expect(await screen.findByText(`1 item deleted successfully`)).toBeVisible();
         expect(requestBody).toEqual({ media_ids: [itemId] });
         expect(mockedOnDeleted).toHaveBeenCalledWith([itemId]);
     });
@@ -53,7 +53,7 @@ describe('DeleteMediaItem', () => {
 
         fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
 
-        expect(await screen.findByText(`3 item(s) deleted successfully`)).toBeVisible();
+        expect(await screen.findByText(`3 items deleted successfully`)).toBeVisible();
         expect(requestBody).toEqual({ media_ids: itemsIds });
         expect(mockedOnDeleted).toHaveBeenCalledWith(itemsIds);
     });

--- a/application/ui/src/features/dataset/gallery/gallery.component.test.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.test.tsx
@@ -5,13 +5,15 @@ import { ReactNode } from 'react';
 
 import { ViewModes } from '@geti/ui';
 import { screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { getMockedMediaImage } from 'mocks/mock-media';
 import { getMockedProject } from 'mocks/mock-project';
 import { HttpResponse } from 'msw';
 import { render } from 'test-utils/render';
 
 import { http } from '../../../api/utils';
 import { server } from '../../../msw-node-setup';
-import { SelectedDataProvider } from '../providers/selected-data-provider.component';
+import { SelectedDataProvider, useSelectedData } from '../providers/selected-data-provider.component';
 import { Gallery } from './gallery.component';
 
 const uploadMediaMock = vi.fn();
@@ -20,6 +22,22 @@ let dropFiles: (files: File[]) => void = () => {};
 
 vi.mock('../../../shared/drop-zone.utils', () => ({
     getFilesFromDropEvent: ({ files }: { files: File[] }) => Promise.resolve(files),
+}));
+
+vi.mock('../../../components/virtualizer-grid-layout/virtualizer-grid-layout.component', () => ({
+    VirtualizerGridLayout: ({
+        items,
+        contentItem,
+    }: {
+        items: Array<{ id: string }>;
+        contentItem: (item: unknown) => ReactNode;
+    }) => (
+        <>
+            {items.map((item) => (
+                <div key={item.id}>{contentItem(item)}</div>
+            ))}
+        </>
+    ),
 }));
 
 vi.mock('@geti/ui', async (importOriginal) => {
@@ -97,5 +115,73 @@ describe('Gallery drag-and-drop upload', () => {
         await waitFor(() => expect(uploadMediaMock).toHaveBeenCalledTimes(1));
         expect(uploadMediaMock.mock.calls[0][0].map((f: File) => f.name)).toEqual(['photo.png', 'clip.mp4']);
         expect(screen.queryByLabelText('toast')).not.toBeInTheDocument();
+    });
+});
+
+describe('Gallery item deletion and selection', () => {
+    const item = getMockedMediaImage({ id: 'item-1' });
+
+    const GalleryWithSelectionCount = ({ items }: { items: (typeof item)[] }) => {
+        const { selectedKeys } = useSelectedData();
+        const count = selectedKeys instanceof Set ? selectedKeys.size : 0;
+
+        return (
+            <>
+                {count > 0 && <p>{count} selected</p>}
+                <Gallery
+                    items={items}
+                    viewMode={ViewModes.LARGE}
+                    isPending={false}
+                    hasActiveFilter={false}
+                    isFetchingNextPage={false}
+                    fetchNextPage={vi.fn()}
+                    isMediaItemReviewedById={() => false}
+                />
+            </>
+        );
+    };
+
+    const renderGalleryWithItems = async (items: (typeof item)[]) => {
+        server.use(
+            http.get('/api/projects/{project_id}', () => HttpResponse.json(getMockedProject({ id: 'project-123' }))),
+            http.delete('/api/projects/{project_id}/dataset/media', () => new HttpResponse(null, { status: 204 }))
+        );
+
+        render(
+            <SelectedDataProvider>
+                <GalleryWithSelectionCount items={items} />
+            </SelectedDataProvider>
+        );
+
+        await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'));
+    };
+
+    it('does not show a selected count after deleting a non-selected item', async () => {
+        const user = userEvent.setup();
+        await renderGalleryWithItems([item]);
+
+        expect(screen.queryByText(/\d+ selected/)).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Media actions' }));
+        await user.click(await screen.findByRole('menuitem', { name: 'Delete' }));
+        await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+        await screen.findByText('1 item deleted successfully');
+
+        expect(screen.queryByText(/\d+ selected/)).not.toBeInTheDocument();
+    });
+
+    it('removes the deleted item from the selected count', async () => {
+        const user = userEvent.setup();
+        await renderGalleryWithItems([item]);
+
+        await user.click(screen.getByRole('checkbox', { name: `Select media item ${item.id}` }));
+        expect(screen.getByText('1 selected')).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Media actions' }));
+        await user.click(await screen.findByRole('menuitem', { name: 'Delete' }));
+        await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+        await screen.findByText('1 item deleted successfully');
+
+        expect(screen.queryByText(/\d+ selected/)).not.toBeInTheDocument();
     });
 });

--- a/application/ui/src/features/dataset/gallery/gallery.component.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.tsx
@@ -59,9 +59,7 @@ const GalleryList = ({
     isMediaItemReviewedById,
 }: GalleryListProps) => {
     const projectId = useProjectIdentifier();
-    const { selectedKeys, toggleSelectedKeys } = useSelectedData();
-
-    const isSetSelectedKeys = selectedKeys instanceof Set;
+    const { selectedKeys, toggleSelectedKeys, isSelected } = useSelectedData();
 
     return (
         <VirtualizerGridLayout
@@ -77,6 +75,7 @@ const GalleryList = ({
                 const mediaUrl = getThumbnailUrl(projectId, item.id);
                 const downloadUrl = getMediaDownloadUrl(projectId, item.id);
                 const mediaFileName = `${item.name}.${item.format}`;
+                const selected = isSelected(item.id);
 
                 return (
                     <MediaItem
@@ -99,7 +98,7 @@ const GalleryList = ({
                                 <Checkbox
                                     aria-label={`Select media item ${item.id}`}
                                     onChange={() => toggleSelectedKeys([String(item.id)])}
-                                    isSelected={isSetSelectedKeys && selectedKeys.has(String(item.id))}
+                                    isSelected={selected}
                                 />
                             </Flex>
                         )}
@@ -109,7 +108,7 @@ const GalleryList = ({
 
                                 <MediaItemActions
                                     id={item.id}
-                                    onDeleted={toggleSelectedKeys}
+                                    onDeleted={selected ? toggleSelectedKeys : undefined}
                                     mediaUrl={downloadUrl}
                                     mediaFileName={mediaFileName}
                                     onAnnotate={() => onSelectedMediaItemChange(item)}

--- a/application/ui/src/features/dataset/gallery/media-item-actions/media-item-actions.component.tsx
+++ b/application/ui/src/features/dataset/gallery/media-item-actions/media-item-actions.component.tsx
@@ -20,7 +20,7 @@ type MediaItemActionsProps = {
     id: string;
     mediaUrl: string;
     mediaFileName: string;
-    onDeleted: (deletedIds: string[]) => void;
+    onDeleted?: (deletedIds: string[]) => void;
     onAnnotate: () => void;
 };
 

--- a/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.test.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.test.tsx
@@ -108,6 +108,7 @@ describe('Toolbar', () => {
             selectedKeys: new Set(),
             setSelectedKeys: vi.fn(),
             toggleSelectedKeys: vi.fn(),
+            isSelected: vi.fn().mockReturnValue(false),
         });
     });
 
@@ -147,6 +148,7 @@ describe('Toolbar', () => {
             selectedKeys: new Set([item1.id, item2.id]),
             setSelectedKeys: vi.fn(),
             toggleSelectedKeys: vi.fn(),
+            isSelected: vi.fn().mockReturnValue(false),
         });
 
         await renderToolbar([item1, item2]);
@@ -175,6 +177,7 @@ describe('Toolbar', () => {
             selectedKeys: new Set([firstItem.id]),
             setSelectedKeys: vi.fn(),
             toggleSelectedKeys: vi.fn(),
+            isSelected: vi.fn().mockReturnValue(false),
         });
 
         await renderToolbar([firstItem]);
@@ -192,6 +195,7 @@ describe('Toolbar', () => {
             selectedKeys: new Set(),
             setSelectedKeys: vi.fn(),
             toggleSelectedKeys: vi.fn(),
+            isSelected: vi.fn().mockReturnValue(false),
         });
 
         await renderToolbar([firstItem]);
@@ -209,6 +213,7 @@ describe('Toolbar', () => {
             selectedKeys: new Set(firstItem.id),
             setSelectedKeys: vi.fn(),
             toggleSelectedKeys: vi.fn(),
+            isSelected: vi.fn().mockReturnValue(false),
         });
 
         await renderToolbar([firstItem]);

--- a/application/ui/src/features/dataset/providers/selected-data-provider.component.test.tsx
+++ b/application/ui/src/features/dataset/providers/selected-data-provider.component.test.tsx
@@ -36,3 +36,68 @@ describe('SelectedDataProvider', () => {
         expect(screen.queryByText(testKey)).not.toBeInTheDocument();
     });
 });
+
+describe('isSelected', () => {
+    it('returns false for a key not in the selection', () => {
+        const App = () => {
+            const { isSelected } = useSelectedData();
+            return <p>{isSelected('absent-key') ? 'selected' : 'not selected'}</p>;
+        };
+
+        render(
+            <SelectedDataProvider>
+                <App />
+            </SelectedDataProvider>
+        );
+
+        expect(screen.getByText('not selected')).toBeInTheDocument();
+    });
+
+    it('returns true after a key is added via toggleSelectedKeys', async () => {
+        const testKey = 'key-abc';
+        const App = () => {
+            const { isSelected, toggleSelectedKeys } = useSelectedData();
+            return (
+                <div>
+                    <p>{isSelected(testKey) ? 'selected' : 'not selected'}</p>
+                    <button onClick={() => toggleSelectedKeys([testKey])}>toggle</button>
+                </div>
+            );
+        };
+
+        render(
+            <SelectedDataProvider>
+                <App />
+            </SelectedDataProvider>
+        );
+
+        expect(screen.getByText('not selected')).toBeInTheDocument();
+        screen.getByRole('button', { name: 'toggle' }).click();
+        expect(await screen.findByText('selected')).toBeInTheDocument();
+    });
+
+    it('returns false after a key is removed via toggleSelectedKeys', async () => {
+        const testKey = 'key-to-remove';
+        const App = () => {
+            const { isSelected, toggleSelectedKeys } = useSelectedData();
+            return (
+                <div>
+                    <p>{isSelected(testKey) ? 'selected' : 'not selected'}</p>
+                    <button onClick={() => toggleSelectedKeys([testKey])}>toggle</button>
+                </div>
+            );
+        };
+
+        render(
+            <SelectedDataProvider>
+                <App />
+            </SelectedDataProvider>
+        );
+
+        screen.getByRole('button', { name: 'toggle' }).click();
+        await screen.findByText('selected');
+
+        screen.getByRole('button', { name: 'toggle' }).click();
+        await screen.findByText('not selected');
+    });
+});

--- a/application/ui/src/features/dataset/providers/selected-data-provider.component.tsx
+++ b/application/ui/src/features/dataset/providers/selected-data-provider.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { createContext, ReactNode, useContext, useState, type Dispatch, type SetStateAction } from 'react';
+import { createContext, ReactNode, useContext, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
 
 import { Selection } from '@geti/ui';
 
@@ -9,12 +9,14 @@ type SelectedDataState = null | {
     selectedKeys: Selection;
     setSelectedKeys: Dispatch<SetStateAction<Selection>>;
     toggleSelectedKeys: (key: string[]) => void;
+    isSelected: (key: string) => boolean;
 };
 
 const SelectedDataContext = createContext<SelectedDataState>(null);
 
 export const SelectedDataProvider = ({ children }: { children: ReactNode }) => {
     const [selectedKeys, setSelectedKeys] = useState<Selection>(new Set());
+    const selectedKeysSet = useMemo(() => new Set(selectedKeys), [selectedKeys]);
 
     const toggleSelectedKeys = (keys: string[]) => {
         setSelectedKeys((prevSelectedKeys) => {
@@ -28,12 +30,17 @@ export const SelectedDataProvider = ({ children }: { children: ReactNode }) => {
         });
     };
 
+    const isSelected = (key: string) => {
+        return selectedKeysSet.has(key);
+    };
+
     return (
         <SelectedDataContext.Provider
             value={{
                 selectedKeys,
                 setSelectedKeys,
                 toggleSelectedKeys,
+                isSelected,
             }}
         >
             {children}


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

The issue was that on delete we always called toggle selection state, no matter if was selected or no.

Fix #6835 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
