### PR TITLE
Offload copy operation from async event loop when uploading dataset

### DIFF
--- a/application/backend/app/api/routers/dataset_ie.py
+++ b/application/backend/app/api/routers/dataset_ie.py
@@ -33,10 +33,7 @@ async def upload_archive(
                 status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail="Only zip files are allowed.",
             )
-        staged_dataset = await staged_datasets_service.upload(
-            filename="dataset.zip",
-            chunk_reader=lambda: file.read(1024 * 1024),
-        )
+        staged_dataset = await staged_datasets_service.upload(filename="dataset.zip", file_obj=file.file)
         return StagedDatasetView.model_validate(staged_dataset, from_attributes=True)
     finally:
         await file.close()

--- a/application/backend/app/services/staged_dataset_service.py
+++ b/application/backend/app/services/staged_dataset_service.py
@@ -159,10 +159,30 @@ class StagedDatasetService:
 
         # Run the blocking write operation in a worker thread.
         def _perform_copy() -> int:
-            file_obj.seek(0)
-            with target_path.open("wb") as out_f:
-                shutil.copyfileobj(file_obj, out_f, length=1024 * 1024)
-            return target_path.stat().st_size
+            # 1. Defensively reset stream pointer if allowed
+            try:
+                file_obj.seek(0)
+            except (AttributeError, OSError, ValueError):
+                pass
+
+            temp_path = target_path.with_suffix(f"{target_path.suffix}.part")
+
+            try:
+                # 2. Copy payload to partial file
+                with temp_path.open("wb") as out_f:
+                    shutil.copyfileobj(file_obj, out_f, length=1024 * 1024)
+
+                # 3. Grab size from the temp file *before* swapping (saves a tiny bit of OS overhead)
+                file_size = temp_path.stat().st_size
+
+                # 4. Atomic swap
+                temp_path.replace(target_path)
+                return file_size
+
+            except Exception:
+                # Explicit clean up if the copy itself errors out
+                temp_path.unlink(missing_ok=True)
+                raise
 
         size = await to_thread.run_sync(_perform_copy)
 

--- a/application/backend/app/services/staged_dataset_service.py
+++ b/application/backend/app/services/staged_dataset_service.py
@@ -2,11 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import shutil
-from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, BinaryIO
 from uuid import UUID, uuid4
+
+from anyio import to_thread
 
 from app.models import AnnotationType, DatasetFormat, StagedDataset
 from app.models.dataset import DatasetMetadata
@@ -134,17 +135,18 @@ class StagedDatasetService:
     def __init__(self, staged_datasets_dir: Path) -> None:
         self._staged_datasets_dir = staged_datasets_dir
 
-    async def upload(self, filename: str, chunk_reader: Callable[[], Awaitable[bytes]]) -> StagedDataset:
+    async def upload(self, filename: str, file_obj: BinaryIO) -> StagedDataset:
         """
-        Store an uploaded dataset archive into a new staged dataset directory.
+        Store an uploaded dataset archive using high-speed threaded block copies.
 
         A new UUID is generated, a subdirectory with that UUID is created under the configured staging root,
-        and the incoming byte stream is written to a file with the given filename.
+        and the incoming file stream is written to a file with the given filename. The file copy operation is
+        offloaded to a worker thread using AnyIO to prevent blocking the main asynchronous event loop.
 
         Args:
             filename: Target filename of the uploaded archive within the staged dataset directory.
-            chunk_reader: Async callable that returns the next chunk of bytes from the upload stream.
-                Must return an empty `bytes` object to signal end of stream.
+            file_obj: A readable binary stream (such as SpooledTemporaryFile)
+                containing the dataset payload.
 
         Returns:
             A `StagedDataset` object containing the dataset identifier, the total number of bytes written,
@@ -155,14 +157,14 @@ class StagedDatasetService:
         target_dir.mkdir(parents=True, exist_ok=True)
         target_path = target_dir / filename
 
-        size = 0
-        with target_path.open("wb") as out_f:
-            while True:
-                chunk = await chunk_reader()
-                if not chunk:
-                    break
-                size += len(chunk)
-                out_f.write(chunk)
+        # Run the blocking write operation in a worker thread.
+        def _perform_copy() -> int:
+            file_obj.seek(0)
+            with target_path.open("wb") as out_f:
+                shutil.copyfileobj(file_obj, out_f, length=1024 * 1024)
+            return target_path.stat().st_size
+
+        size = await to_thread.run_sync(_perform_copy)
 
         return StagedDataset(
             compressed=True,

--- a/application/backend/tests/integration/services/test_staged_dataset_service.py
+++ b/application/backend/tests/integration/services/test_staged_dataset_service.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import asyncio
+from io import BytesIO
 from pathlib import Path
 from uuid import UUID, uuid4
 
@@ -169,25 +169,21 @@ class TestStagedDatasetServiceIntegration:
         self, tmp_path: Path, fxt_staged_dataset_service: StagedDatasetService
     ):
         filename = "dataset.zip"
-        chunks = [b"hello ", b"world", b"!", b""]
-        chunks_iter = iter(chunks)
+        content = b"hello world!"
+        file_obj = BytesIO(content)
 
-        async def chunk_reader() -> bytes:
-            await asyncio.sleep(0)
-            return next(chunks_iter)
-
-        staged_dataset = await fxt_staged_dataset_service.upload(filename=filename, chunk_reader=chunk_reader)
+        staged_dataset = await fxt_staged_dataset_service.upload(filename=filename, file_obj=file_obj)
 
         assert staged_dataset.id is not None
         assert staged_dataset.compressed is True
         assert staged_dataset.format == DatasetFormat.UNKNOWN
-        assert staged_dataset.size == sum(len(c) for c in chunks[:-1])
+        assert staged_dataset.size == len(content)
 
         stored_path = Path(staged_dataset.filename)
         assert stored_path.name == "dataset.zip"
         assert stored_path.is_file()
         assert stored_path.parent.parent == tmp_path
-        assert stored_path.read_bytes() == b"hello world!"
+        assert stored_path.read_bytes() == content
 
     def test_list_all_single_zip_dataset(self, tmp_path: Path, fxt_staged_dataset_service: StagedDatasetService):
         dataset_id, archive_path = _stage_dataset_archive(tmp_path, "my_coco_dataset.zip", b"123456")


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

This PR improves upload dataset by making event loop responsive

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
