### PR TITLE
 Keep model architectures list expanded when navigating back

### DIFF
--- a/application/ui/src/features/models/train-model/model-architectures-list/model-architectures-list.component.tsx
+++ b/application/ui/src/features/models/train-model/model-architectures-list/model-architectures-list.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect } from 'react';
+import { useState } from 'react';
 
 import { Button, Flex } from '@geti/ui';
 
@@ -13,17 +13,21 @@ import { getRecommendedArchitectures } from './utils';
 const SHOW_MORE_THRESHOLD = 4;
 
 export const ModelArchitecturesList = () => {
-    const {
-        modelArchitectures,
-        selectedModelArchitectureId,
-        onSelectModelArchitectureId,
-        showMoreModelArchitectures: showMore,
-        setShowMoreModelArchitectures: setShowMore,
-    } = useTrainModelState();
+    const { modelArchitectures, selectedModelArchitectureId, onSelectModelArchitectureId } = useTrainModelState();
 
     const recommendedArchitectures = getRecommendedArchitectures(modelArchitectures);
     const collapsedArchitectures = recommendedArchitectures.slice(0, SHOW_MORE_THRESHOLD);
     const canToggleArchitecturesList = modelArchitectures.length > SHOW_MORE_THRESHOLD;
+
+    const [showMore, setShowMore] = useState<boolean>(() => {
+        if (selectedModelArchitectureId !== null) {
+            const isSelectedInCollapsed = collapsedArchitectures.some(
+                (arch) => arch.id === selectedModelArchitectureId
+            );
+            return !isSelectedInCollapsed;
+        }
+        return false;
+    });
 
     return (
         <Flex direction={'column'} minHeight={0} gap={'size-300'}>

--- a/application/ui/src/features/models/train-model/model-architectures-list/model-architectures-list.component.tsx
+++ b/application/ui/src/features/models/train-model/model-architectures-list/model-architectures-list.component.tsx
@@ -13,12 +13,19 @@ import { getRecommendedArchitectures } from './utils';
 const SHOW_MORE_THRESHOLD = 4;
 
 export const ModelArchitecturesList = () => {
-    const [showMore, setShowMore] = useState<boolean>(false);
     const { modelArchitectures, selectedModelArchitectureId, onSelectModelArchitectureId } = useTrainModelState();
 
     const recommendedArchitectures = getRecommendedArchitectures(modelArchitectures);
     const collapsedArchitectures = recommendedArchitectures.slice(0, SHOW_MORE_THRESHOLD);
     const canToggleArchitecturesList = modelArchitectures.length > SHOW_MORE_THRESHOLD;
+
+    const [showMore, setShowMore] = useState<boolean>(() => {
+        if (selectedModelArchitectureId !== null) {
+            const isSelectedInCollapsed = collapsedArchitectures.some((arch) => arch.id === selectedModelArchitectureId);
+            return !isSelectedInCollapsed;
+        }
+        return false;
+    });
 
     return (
         <Flex direction={'column'} minHeight={0} gap={'size-300'}>

--- a/application/ui/src/features/models/train-model/model-architectures-list/model-architectures-list.component.tsx
+++ b/application/ui/src/features/models/train-model/model-architectures-list/model-architectures-list.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useState } from 'react';
+import { useEffect } from 'react';
 
 import { Button, Flex } from '@geti/ui';
 
@@ -13,21 +13,28 @@ import { getRecommendedArchitectures } from './utils';
 const SHOW_MORE_THRESHOLD = 4;
 
 export const ModelArchitecturesList = () => {
-    const { modelArchitectures, selectedModelArchitectureId, onSelectModelArchitectureId } = useTrainModelState();
+    const {
+        modelArchitectures,
+        selectedModelArchitectureId,
+        onSelectModelArchitectureId,
+        showMoreModelArchitectures: showMore,
+        setShowMoreModelArchitectures: setShowMore,
+    } = useTrainModelState();
 
     const recommendedArchitectures = getRecommendedArchitectures(modelArchitectures);
     const collapsedArchitectures = recommendedArchitectures.slice(0, SHOW_MORE_THRESHOLD);
     const canToggleArchitecturesList = modelArchitectures.length > SHOW_MORE_THRESHOLD;
 
-    const [showMore, setShowMore] = useState<boolean>(() => {
-        if (selectedModelArchitectureId !== null) {
+    useEffect(() => {
+        if (selectedModelArchitectureId !== null && !showMore) {
             const isSelectedInCollapsed = collapsedArchitectures.some(
                 (arch) => arch.id === selectedModelArchitectureId
             );
-            return !isSelectedInCollapsed;
+            if (!isSelectedInCollapsed) {
+                setShowMore(true);
+            }
         }
-        return false;
-    });
+    }, [selectedModelArchitectureId, collapsedArchitectures, setShowMore, showMore]);
 
     return (
         <Flex direction={'column'} minHeight={0} gap={'size-300'}>

--- a/application/ui/src/features/models/train-model/model-architectures-list/model-architectures-list.component.tsx
+++ b/application/ui/src/features/models/train-model/model-architectures-list/model-architectures-list.component.tsx
@@ -25,17 +25,6 @@ export const ModelArchitecturesList = () => {
     const collapsedArchitectures = recommendedArchitectures.slice(0, SHOW_MORE_THRESHOLD);
     const canToggleArchitecturesList = modelArchitectures.length > SHOW_MORE_THRESHOLD;
 
-    useEffect(() => {
-        if (selectedModelArchitectureId !== null && !showMore) {
-            const isSelectedInCollapsed = collapsedArchitectures.some(
-                (arch) => arch.id === selectedModelArchitectureId
-            );
-            if (!isSelectedInCollapsed) {
-                setShowMore(true);
-            }
-        }
-    }, [selectedModelArchitectureId, collapsedArchitectures, setShowMore, showMore]);
-
     return (
         <Flex direction={'column'} minHeight={0} gap={'size-300'}>
             {showMore ? (

--- a/application/ui/src/features/models/train-model/model-architectures-list/model-architectures-list.component.tsx
+++ b/application/ui/src/features/models/train-model/model-architectures-list/model-architectures-list.component.tsx
@@ -21,7 +21,9 @@ export const ModelArchitecturesList = () => {
 
     const [showMore, setShowMore] = useState<boolean>(() => {
         if (selectedModelArchitectureId !== null) {
-            const isSelectedInCollapsed = collapsedArchitectures.some((arch) => arch.id === selectedModelArchitectureId);
+            const isSelectedInCollapsed = collapsedArchitectures.some(
+                (arch) => arch.id === selectedModelArchitectureId
+            );
             return !isSelectedInCollapsed;
         }
         return false;

--- a/application/ui/src/features/models/train-model/model-architectures-list/model-architectures-list.test.tsx
+++ b/application/ui/src/features/models/train-model/model-architectures-list/model-architectures-list.test.tsx
@@ -9,12 +9,6 @@ import { ModelArchitecturesList } from './model-architectures-list.component';
 
 const mockOnSelectModelArchitectureId = vi.hoisted(() => vi.fn());
 const mockSelectedModelArchitectureId = vi.hoisted(() => ({ value: null as string | null }));
-const mockShowMore = vi.hoisted(() => ({ value: false as boolean }));
-const mockSetShowMore = vi.hoisted(() =>
-    vi.fn((val: boolean) => {
-        mockShowMore.value = val;
-    })
-);
 
 const mockModelArchitectures = [
     getMockedModelArchitecture({ id: 'arch-1', name: 'Alpha Model' }),
@@ -29,8 +23,6 @@ vi.mock('../train-model-provider.component', () => ({
         modelArchitectures: mockModelArchitectures,
         selectedModelArchitectureId: mockSelectedModelArchitectureId.value,
         onSelectModelArchitectureId: mockOnSelectModelArchitectureId,
-        showMoreModelArchitectures: mockShowMore.value,
-        setShowMoreModelArchitectures: mockSetShowMore,
     }),
 }));
 
@@ -38,8 +30,6 @@ describe('ModelArchitecturesList', () => {
     beforeEach(() => {
         mockOnSelectModelArchitectureId.mockReset();
         mockSelectedModelArchitectureId.value = null;
-        mockShowMore.value = false;
-        mockSetShowMore.mockClear();
     });
 
     it('does not render the sort control in the default (recommended) view', () => {
@@ -48,27 +38,29 @@ describe('ModelArchitecturesList', () => {
         expect(screen.queryByText('Sort Models by:')).not.toBeInTheDocument();
     });
 
-    it('calls setShowMore with true when clicking "Show more"', async () => {
+    it('renders the sort control after clicking "Show more"', async () => {
         render(<ModelArchitecturesList />);
 
         fireEvent.click(screen.getByRole('button', { name: 'Show more' }));
 
-        expect(mockSetShowMore).toHaveBeenCalledWith(true);
+        expect(screen.getByRole('button', { name: /Sort Models by:/i })).toBeVisible();
     });
 
-    it('calls setShowMore with false when clicking "Show less"', async () => {
-        mockShowMore.value = true;
+    it('hides the sort control again after clicking "Show less"', async () => {
         render(<ModelArchitecturesList />);
 
-        fireEvent.click(screen.getByRole('button', { name: 'Show less' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Show more' }));
+        expect(screen.getByRole('button', { name: /Sort Models by:/i })).toBeVisible();
 
-        expect(mockSetShowMore).toHaveBeenCalledWith(false);
+        fireEvent.click(screen.getByRole('button', { name: 'Show less' }));
+        expect(screen.queryByRole('button', { name: /Sort Models by:/i })).not.toBeInTheDocument();
     });
 
-    it('calls setShowMore to true on mount if a non-default architecture is already selected', () => {
+    it('renders expanded list by default if a non-default architecture is already selected', () => {
         mockSelectedModelArchitectureId.value = mockModelArchitectures[mockModelArchitectures.length - 1].id;
         render(<ModelArchitecturesList />);
 
-        expect(mockSetShowMore).toHaveBeenCalledWith(true);
+        expect(screen.getByRole('button', { name: 'Show less' })).toBeVisible();
+        expect(screen.getByRole('button', { name: /Sort Models by:/i })).toBeVisible();
     });
 });

--- a/application/ui/src/features/models/train-model/model-architectures-list/model-architectures-list.test.tsx
+++ b/application/ui/src/features/models/train-model/model-architectures-list/model-architectures-list.test.tsx
@@ -55,9 +55,9 @@ describe('ModelArchitecturesList', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Show less' }));
         expect(screen.queryByRole('button', { name: /Sort Models by:/i })).not.toBeInTheDocument();
     });
-    
+
     it('renders expanded list by default if a non-default architecture is already selected', () => {
-        mockSelectedModelArchitectureId.value = 'arch-5';
+        mockSelectedModelArchitectureId.value = mockModelArchitectures[mockModelArchitectures.length - 1].id;
         render(<ModelArchitecturesList />);
 
         expect(screen.getByRole('button', { name: 'Show less' })).toBeVisible();

--- a/application/ui/src/features/models/train-model/model-architectures-list/model-architectures-list.test.tsx
+++ b/application/ui/src/features/models/train-model/model-architectures-list/model-architectures-list.test.tsx
@@ -9,6 +9,12 @@ import { ModelArchitecturesList } from './model-architectures-list.component';
 
 const mockOnSelectModelArchitectureId = vi.hoisted(() => vi.fn());
 const mockSelectedModelArchitectureId = vi.hoisted(() => ({ value: null as string | null }));
+const mockShowMore = vi.hoisted(() => ({ value: false as boolean }));
+const mockSetShowMore = vi.hoisted(() =>
+    vi.fn((val: boolean) => {
+        mockShowMore.value = val;
+    })
+);
 
 const mockModelArchitectures = [
     getMockedModelArchitecture({ id: 'arch-1', name: 'Alpha Model' }),
@@ -23,6 +29,8 @@ vi.mock('../train-model-provider.component', () => ({
         modelArchitectures: mockModelArchitectures,
         selectedModelArchitectureId: mockSelectedModelArchitectureId.value,
         onSelectModelArchitectureId: mockOnSelectModelArchitectureId,
+        showMoreModelArchitectures: mockShowMore.value,
+        setShowMoreModelArchitectures: mockSetShowMore,
     }),
 }));
 
@@ -30,6 +38,8 @@ describe('ModelArchitecturesList', () => {
     beforeEach(() => {
         mockOnSelectModelArchitectureId.mockReset();
         mockSelectedModelArchitectureId.value = null;
+        mockShowMore.value = false;
+        mockSetShowMore.mockClear();
     });
 
     it('does not render the sort control in the default (recommended) view', () => {
@@ -38,29 +48,27 @@ describe('ModelArchitecturesList', () => {
         expect(screen.queryByText('Sort Models by:')).not.toBeInTheDocument();
     });
 
-    it('renders the sort control after clicking "Show more"', async () => {
+    it('calls setShowMore with true when clicking "Show more"', async () => {
         render(<ModelArchitecturesList />);
 
         fireEvent.click(screen.getByRole('button', { name: 'Show more' }));
 
-        expect(screen.getByRole('button', { name: /Sort Models by:/i })).toBeVisible();
+        expect(mockSetShowMore).toHaveBeenCalledWith(true);
     });
 
-    it('hides the sort control again after clicking "Show less"', async () => {
+    it('calls setShowMore with false when clicking "Show less"', async () => {
+        mockShowMore.value = true;
         render(<ModelArchitecturesList />);
-
-        fireEvent.click(screen.getByRole('button', { name: 'Show more' }));
-        expect(screen.getByRole('button', { name: /Sort Models by:/i })).toBeVisible();
 
         fireEvent.click(screen.getByRole('button', { name: 'Show less' }));
-        expect(screen.queryByRole('button', { name: /Sort Models by:/i })).not.toBeInTheDocument();
+
+        expect(mockSetShowMore).toHaveBeenCalledWith(false);
     });
 
-    it('renders expanded list by default if a non-default architecture is already selected', () => {
+    it('calls setShowMore to true on mount if a non-default architecture is already selected', () => {
         mockSelectedModelArchitectureId.value = mockModelArchitectures[mockModelArchitectures.length - 1].id;
         render(<ModelArchitecturesList />);
 
-        expect(screen.getByRole('button', { name: 'Show less' })).toBeVisible();
-        expect(screen.getByRole('button', { name: /Sort Models by:/i })).toBeVisible();
+        expect(mockSetShowMore).toHaveBeenCalledWith(true);
     });
 });

--- a/application/ui/src/features/models/train-model/model-architectures-list/model-architectures-list.test.tsx
+++ b/application/ui/src/features/models/train-model/model-architectures-list/model-architectures-list.test.tsx
@@ -8,6 +8,7 @@ import { render } from 'test-utils/render';
 import { ModelArchitecturesList } from './model-architectures-list.component';
 
 const mockOnSelectModelArchitectureId = vi.hoisted(() => vi.fn());
+const mockSelectedModelArchitectureId = vi.hoisted(() => ({ value: null as string | null }));
 
 const mockModelArchitectures = [
     getMockedModelArchitecture({ id: 'arch-1', name: 'Alpha Model' }),
@@ -20,7 +21,7 @@ const mockModelArchitectures = [
 vi.mock('../train-model-provider.component', () => ({
     useTrainModelState: () => ({
         modelArchitectures: mockModelArchitectures,
-        selectedModelArchitectureId: null,
+        selectedModelArchitectureId: mockSelectedModelArchitectureId.value,
         onSelectModelArchitectureId: mockOnSelectModelArchitectureId,
     }),
 }));
@@ -28,6 +29,7 @@ vi.mock('../train-model-provider.component', () => ({
 describe('ModelArchitecturesList', () => {
     beforeEach(() => {
         mockOnSelectModelArchitectureId.mockReset();
+        mockSelectedModelArchitectureId.value = null;
     });
 
     it('does not render the sort control in the default (recommended) view', () => {
@@ -52,5 +54,13 @@ describe('ModelArchitecturesList', () => {
 
         fireEvent.click(screen.getByRole('button', { name: 'Show less' }));
         expect(screen.queryByRole('button', { name: /Sort Models by:/i })).not.toBeInTheDocument();
+    });
+    
+    it('renders expanded list by default if a non-default architecture is already selected', () => {
+        mockSelectedModelArchitectureId.value = 'arch-5';
+        render(<ModelArchitecturesList />);
+
+        expect(screen.getByRole('button', { name: 'Show less' })).toBeVisible();
+        expect(screen.getByRole('button', { name: /Sort Models by:/i })).toBeVisible();
     });
 });

--- a/application/ui/src/features/models/train-model/train-model-provider.component.tsx
+++ b/application/ui/src/features/models/train-model/train-model-provider.component.tsx
@@ -42,6 +42,9 @@ export type TrainModelContextProps = {
     isAdvancedSettingsMode: boolean;
     onToggleAdvancedSettingsMode: (isAdvancedSettingsMode: boolean) => void;
 
+    showMoreModelArchitectures: boolean;
+    setShowMoreModelArchitectures: (showMore: boolean) => void;
+
     trainingConfiguration: TrainingConfiguration | undefined;
     defaultTrainingConfiguration: TrainingConfiguration | undefined;
     onTrainingConfigurationChange: Dispatch<SetStateAction<TrainingConfiguration | undefined>>;
@@ -127,6 +130,7 @@ export const TrainModelProvider = ({ children }: TrainModelProviderProps) => {
     );
 
     const [isAdvancedSettingsMode, setIsAdvancedSettingsMode] = useState<boolean>(false);
+    const [showMoreModelArchitectures, setShowMoreModelArchitectures] = useState<boolean>(false);
 
     const modelRevisions = useMemo(() => {
         return getModelRevisionsForArchitecture(allModelRevisions, selectedModelArchitectureId);
@@ -166,6 +170,9 @@ export const TrainModelProvider = ({ children }: TrainModelProviderProps) => {
 
                 isAdvancedSettingsMode,
                 onToggleAdvancedSettingsMode: setIsAdvancedSettingsMode,
+
+                showMoreModelArchitectures,
+                setShowMoreModelArchitectures,
 
                 trainingConfiguration,
                 defaultTrainingConfiguration,

--- a/application/ui/tests/models/model-training.spec.ts
+++ b/application/ui/tests/models/model-training.spec.ts
@@ -23,10 +23,23 @@ import { expect, http, test } from '../fixtures';
 import { MOCKED_MODEL_TRAINING_CONFIGURATION, MOCKED_TRAINING_CONFIGURATION } from './mocks';
 
 const mockedModelArchitectures = [
-    getMockedModelArchitecture({ id: 'Object_Detection_SSD', name: 'Object_Detection_SSD' }),
+    getMockedModelArchitecture({
+        id: 'Object_Detection_SSD',
+        name: 'Object_Detection_SSD',
+        performanceCategory: 'balance',
+    }),
     getMockedModelArchitecture({
         id: 'Custom_Object_Detection_Gen3_ATSS',
         name: 'Custom_Object_Detection_Gen3_ATSS',
+        performanceCategory: 'speed',
+    }),
+    getMockedModelArchitecture({ id: 'arch-3', name: 'Gamma Model', performanceCategory: 'accuracy' }),
+    getMockedModelArchitecture({ id: 'arch-4', name: 'Delta Model', performanceCategory: undefined }),
+    getMockedModelArchitecture({ id: 'arch-5', name: 'Epsilon Model', performanceCategory: undefined }),
+    getMockedModelArchitecture({
+        id: 'Object_Detection_YOLOX_X',
+        name: 'Object_Detection_YOLOX_X',
+        performanceCategory: undefined,
     }),
 ];
 
@@ -263,6 +276,39 @@ test.describe('Model training flow', () => {
         expect(state.submittedTrainingConfiguration).toMatchObject(
             getTrainingConfigurationUpdatePayload({ parameters: updatedTrainingConfigurationParameters })
         );
+    });
+
+    test('Keeps model architectures list expanded when navigating back from advanced settings if non-default model is selected', async ({
+        network,
+        modelsPage,
+        page,
+    }) => {
+        setupNetworkMocks(network);
+
+        await modelsPage.goto();
+        await modelsPage.openTrainModelDialog();
+
+        await test.step('Expand architectures list', async () => {
+            await page.getByRole('button', { name: 'Show more' }).click();
+        });
+
+        await test.step('Select a non-default model architecture', async () => {
+            await modelsPage.selectModelArchitecture('Object_Detection_YOLOX_X');
+        });
+
+        await test.step('Open advanced settings', async () => {
+            await modelsPage.openAdvancedSettings();
+            await expect(page.getByLabel('Advanced settings tabs').getByText('Data management')).toBeVisible();
+        });
+
+        await test.step('Navigate back', async () => {
+            await page.getByRole('button', { name: 'Back' }).click();
+        });
+
+        await test.step('Verify that the list is still expanded', async () => {
+            await expect(page.getByRole('button', { name: 'Show less' })).toBeVisible();
+            await expect(page.getByRole('button', { name: /Sort Models by:/i })).toBeVisible();
+        });
     });
 
     test('Advanced model training flow with training from scratch', async ({ network, modelsPage }) => {


### PR DESCRIPTION

<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
Initializes the `showMore` state in `ModelArchitecturesList` to `true` if the currently selected model architecture is not in the collapsed list. This ensures that when a user selects a non-default model and navigates back from the "Advanced settings" screen, their selection is still visible.

Closes:#6823
<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

1. Open the Train model dialog.
2. Click Show more in the model architectures list.
3. Select an architecture that is not in the initially recommended/collapsed list (e.g., the 5th option).
4. Click Advanced settings.
5. Click Back.
6. Verify that the model architectures list remains expanded, making the selected architecture visible.

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
