### PR TITLE
refactor(annotator canvas): Decouple read only annotator from fully functional annotator

### DIFF
--- a/application/ui/src/features/annotator/annotations/read-only-annotations.component.test.tsx
+++ b/application/ui/src/features/annotator/annotations/read-only-annotations.component.test.tsx
@@ -1,0 +1,163 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { screen } from '@testing-library/react';
+import { getMockedAnnotation } from 'mocks/mock-annotation';
+import { render } from 'test-utils/render';
+
+import { useAnnotationActions } from '../../../shared/annotator/annotation-actions-provider.component';
+import { useAnnotationVisibility } from '../../../shared/annotator/annotation-visibility-provider.component';
+import type { Annotation } from '../../../shared/types';
+import { useCanvasSettings } from '../../dataset/media-preview/primary-toolbar/settings/canvas-settings-provider.component';
+import { ReadOnlyAnnotations } from './read-only-annotations.component';
+
+vi.mock('../../../shared/annotator/annotation-actions-provider.component', () => ({
+    useAnnotationActions: vi.fn(),
+}));
+
+vi.mock('../../../shared/annotator/annotation-visibility-provider.component', () => ({
+    useAnnotationVisibility: vi.fn(),
+}));
+
+vi.mock('../../dataset/media-preview/primary-toolbar/settings/canvas-settings-provider.component', () => ({
+    useCanvasSettings: vi.fn(),
+}));
+
+vi.mock('../annotator-labels-provider.component', () => ({
+    useAnnotatorLabels: () => ({
+        labels: [],
+        selectedLabel: null,
+        selectedLabelId: null,
+        setSelectedLabelId: vi.fn(),
+    }),
+}));
+
+vi.mock('../selected-media-item-provider.component', () => ({
+    useSelectedMediaItem: () => ({
+        mediaItem: { width: 800, height: 600 },
+        roi: { x: 0, y: 0, width: 800, height: 600 },
+        image: { width: 800, height: 600 },
+    }),
+}));
+
+vi.mock('../../../components/zoom/zoom.provider', () => ({
+    useZoom: () => ({ scale: 1 }),
+}));
+
+const defaultAnnotation = getMockedAnnotation();
+
+type SetupOptions = {
+    annotations?: Annotation[];
+    isFocussed?: boolean;
+    isVisible?: boolean;
+    isReadOnlyMode?: boolean;
+    hideLabels?: boolean;
+};
+
+const setupMocks = ({
+    annotations = [defaultAnnotation],
+    isFocussed = false,
+    isVisible = true,
+    isReadOnlyMode = true,
+    hideLabels = false,
+}: SetupOptions = {}) => {
+    vi.mocked(useAnnotationActions).mockReturnValue({
+        annotations,
+        isReadOnlyMode,
+        updateAnnotations: vi.fn(),
+        deleteAnnotations: vi.fn(),
+    } as unknown as ReturnType<typeof useAnnotationActions>);
+
+    vi.mocked(useAnnotationVisibility).mockReturnValue({
+        isFocussed,
+        isVisible,
+        toggleVisibility: vi.fn(),
+        toggleFocus: vi.fn(),
+    });
+
+    vi.mocked(useCanvasSettings).mockReturnValue({
+        canvasSettings: {
+            hideLabels: { value: hideLabels, defaultValue: false },
+            annotationFillOpacity: { value: 1, defaultValue: 1 },
+            annotationBorderOpacity: { value: 1, defaultValue: 1 },
+            imageBrightness: { value: 0, defaultValue: 0 },
+            imageContrast: { value: 0, defaultValue: 0 },
+            imageSaturation: { value: 0, defaultValue: 0 },
+            pixelView: { value: false, defaultValue: false },
+        },
+        setCanvasSettings: vi.fn(),
+    });
+};
+
+describe('ReadOnlyAnnotations', () => {
+    beforeEach(() => {
+        setupMocks();
+    });
+
+    it('renders the annotations SVG element', () => {
+        render(<ReadOnlyAnnotations width={800} height={600} />);
+
+        expect(screen.getByLabelText('annotations')).toBeInTheDocument();
+    });
+
+    it('renders a shape for each annotation', () => {
+        setupMocks({
+            annotations: [
+                getMockedAnnotation({
+                    id: 'ann-1',
+                    shape: { type: 'rectangle', x: 10, y: 20, width: 100, height: 50 },
+                }),
+            ],
+        });
+
+        render(<ReadOnlyAnnotations width={800} height={600} />);
+
+        expect(screen.getAllByLabelText('annotation rect')).toHaveLength(2); // 1 in mask, 1 visible
+    });
+
+    it('renders no shapes when there are no annotations', () => {
+        setupMocks({ annotations: [] });
+
+        render(<ReadOnlyAnnotations width={800} height={600} />);
+
+        expect(screen.queryByLabelText('annotation rect')).not.toBeInTheDocument();
+    });
+
+    it('activates the focus mask when isFocussed is true', () => {
+        setupMocks({ isFocussed: true });
+
+        const { container } = render(<ReadOnlyAnnotations width={800} height={600} />);
+
+        const maskOverlay = container.querySelector('rect[mask]') as SVGRectElement | null;
+
+        expect(maskOverlay).toBeInTheDocument();
+        expect(maskOverlay?.style.fillOpacity).toBe('0.3');
+    });
+
+    it('deactivates the focus mask when isFocussed is false', () => {
+        setupMocks({ isFocussed: false });
+
+        const { container } = render(<ReadOnlyAnnotations width={800} height={600} />);
+
+        const maskOverlay = container.querySelector('rect[mask]') as SVGRectElement | null;
+
+        expect(maskOverlay).toBeInTheDocument();
+        expect(maskOverlay?.style.fillOpacity).toBe('0');
+    });
+
+    it('renders annotation labels when hideLabels is false', () => {
+        setupMocks({ hideLabels: false });
+
+        render(<ReadOnlyAnnotations width={800} height={600} />);
+
+        expect(screen.getByText('label-1')).toBeInTheDocument();
+    });
+
+    it('omits annotation labels when hideLabels is true', () => {
+        setupMocks({ hideLabels: true });
+
+        render(<ReadOnlyAnnotations width={800} height={600} />);
+
+        expect(screen.queryByText('label-1')).not.toBeInTheDocument();
+    });
+});

--- a/application/ui/src/features/annotator/annotations/read-only-annotations.component.tsx
+++ b/application/ui/src/features/annotator/annotations/read-only-annotations.component.tsx
@@ -1,0 +1,45 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { isEmpty } from 'lodash-es';
+
+import { useAnnotationActions } from '../../../shared/annotator/annotation-actions-provider.component';
+import { useAnnotationVisibility } from '../../../shared/annotator/annotation-visibility-provider.component';
+import { DEFAULT_ANNOTATION_STYLES } from '../utils';
+import { AnnotationShapeRenderer } from './annotation-shape-renderer.component';
+import { MaskAnnotations } from './mask-annotations.component';
+
+type ReadOnlyAnnotationsProps = {
+    width: number;
+    height: number;
+};
+
+export const ReadOnlyAnnotations = ({ width, height }: ReadOnlyAnnotationsProps) => {
+    const { annotations } = useAnnotationActions();
+    const { isFocussed } = useAnnotationVisibility();
+
+    return (
+        <svg
+            aria-label={'annotations'}
+            data-testid={'annotation-layer'}
+            width={width}
+            height={height}
+            tabIndex={-1}
+            style={{
+                position: 'absolute',
+                inset: 0,
+                outline: 'none',
+                overflow: 'visible',
+                ...DEFAULT_ANNOTATION_STYLES,
+            }}
+        >
+            {!isEmpty(annotations) && (
+                <MaskAnnotations annotations={annotations} width={width} height={height} isEnabled={isFocussed}>
+                    {annotations.map((annotation) => (
+                        <AnnotationShapeRenderer key={annotation.id} annotation={annotation} />
+                    ))}
+                </MaskAnnotations>
+            )}
+        </svg>
+    );
+};

--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -17,8 +17,7 @@ import { useAnnotator } from '../../../shared/annotator/annotator-provider.compo
 import { useSelectedAnnotations } from '../../../shared/annotator/select-annotation-provider.component';
 import { useTool } from '../../../shared/annotator/tool-provider.component';
 import { useEditableAnnotationState } from '../../../shared/annotator/use-editable-annotation-state.hook';
-import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
-import { getMediaBinaryUrl } from '../../../shared/media-url.utils';
+import { isVideoFrame } from '../../../shared/media-item-utils';
 import { Annotations } from '../annotations/annotations.component';
 import { VideoAnnotations, VideoPredictions } from '../annotations/video-annotations.component';
 import { useIsAnnotatorSceneBusy } from '../hooks/use-is-annotator-scene-busy';
@@ -32,84 +31,10 @@ import {
     usePrefetchVideoFramesPredictions,
 } from '../video-player/api/use-video-frames-predictions';
 import { getVideoFrameRangeIndexes } from '../video-player/api/utils';
-import { VideoFrame } from '../video-player/video-frame.component';
 import { useVideoPlayer, useVideoPlayerContext } from '../video-player/video-player-provider.component';
-import { drawImageDataOnCanvas } from './draw-image-data-on-canvas';
+import { MediaImage } from './media-image.component';
 
 import classes from './annotator-canvas.module.scss';
-
-type MediaImageProps = {
-    image: ImageData;
-    mediaItem: Media;
-};
-
-const useDrawImageOnCanvas = (image: ImageData) => {
-    const canvasRef = useRef<HTMLCanvasElement>(null);
-
-    useEffect(() => {
-        const ctx = canvasRef?.current?.getContext('2d');
-
-        if (ctx == null) {
-            return;
-        }
-
-        drawImageDataOnCanvas(ctx, image);
-    }, [image]);
-
-    return canvasRef;
-};
-
-// Oversized static images: use <img> to bypass canvas rasterization limit.
-const StaticImage = ({ mediaItem }: { mediaItem: Media }) => {
-    const projectId = useProjectIdentifier();
-
-    return (
-        <img
-            src={getMediaBinaryUrl(projectId, mediaItem.id)}
-            width={mediaItem.width}
-            height={mediaItem.height}
-            crossOrigin='anonymous'
-            className={classes.image}
-            alt=''
-        />
-    );
-};
-
-type CanvasMediaImageProps = {
-    image: ImageData;
-    showVideoFrame?: boolean;
-};
-
-const CanvasMediaImage = ({ image, showVideoFrame = false }: CanvasMediaImageProps) => {
-    const canvasRef = useDrawImageOnCanvas(image);
-
-    return (
-        <>
-            <canvas ref={canvasRef} width={image.width} height={image.height} className={classes.image} />
-            {showVideoFrame && <VideoFrame canvasRef={canvasRef} />}
-        </>
-    );
-};
-
-const MediaImage = ({ image, mediaItem }: MediaImageProps) => {
-    if (isVideo(mediaItem) || isVideoFrame(mediaItem)) {
-        return <CanvasMediaImage image={image} showVideoFrame />;
-    }
-
-    // Render via canvas only when decoded at native resolution.
-    // `ImageData.data.length` is expected to be width * height * 4
-    // (RGBA: 4 channels, 1 byte per channel = 4 bytes per pixel).
-    const isFullResolution =
-        image.width === mediaItem.width &&
-        image.height === mediaItem.height &&
-        image.data.length === mediaItem.width * mediaItem.height * 4;
-
-    if (isFullResolution) {
-        return <CanvasMediaImage image={image} />;
-    }
-
-    return <StaticImage mediaItem={mediaItem} />;
-};
 
 type ImageAnnotationsProps = {
     mediaItem: Media;

--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -1,14 +1,8 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { MouseEvent, PointerEvent, useEffect, useRef, useState } from 'react';
+import { PointerEvent, useEffect, useRef, useState } from 'react';
 
-import { Loading } from '@geti/ui';
-import { useIsFetching } from '@tanstack/react-query';
-import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
-import { useSpinDelay } from 'spin-delay';
-
-import { ZoomTransform } from '../../../components/zoom/zoom-transform';
 import type { Media } from '../../../constants/shared-types';
 import { useAnnotationActions } from '../../../shared/annotator/annotation-actions-provider.component';
 import { useAnnotationVisibility } from '../../../shared/annotator/annotation-visibility-provider.component';
@@ -21,7 +15,6 @@ import { isVideoFrame } from '../../../shared/media-item-utils';
 import { Annotations } from '../annotations/annotations.component';
 import { VideoAnnotations, VideoPredictions } from '../annotations/video-annotations.component';
 import { useIsAnnotatorSceneBusy } from '../hooks/use-is-annotator-scene-busy';
-import { loadImageQueryOptions } from '../hooks/use-load-image-query.hook';
 import { ToolManager } from '../tools/tool-manager.component';
 import { usePrefetchVideoFramesAnnotations } from '../video-player/api/use-video-frames-annotations';
 import {
@@ -32,7 +25,7 @@ import {
 } from '../video-player/api/use-video-frames-predictions';
 import { getVideoFrameRangeIndexes } from '../video-player/api/utils';
 import { useVideoPlayer, useVideoPlayerContext } from '../video-player/video-player-provider.component';
-import { MediaImage } from './media-image.component';
+import { MediaCanvas } from './media-canvas';
 
 import classes from './annotator-canvas.module.scss';
 
@@ -258,53 +251,39 @@ export const AnnotatorCanvas = ({
     isReadOnly = false,
     isLoadingPredictions = false,
 }: AnnotatorCanvasProps) => {
-    const projectId = useProjectIdentifier();
     const isSceneBusy = useIsAnnotatorSceneBusy();
     const { canvasRef } = useAnnotator();
     const { isSingleEditableSelection } = useEditableAnnotationState();
 
-    const isFetchingMedia = useIsFetching({ queryKey: loadImageQueryOptions(projectId, mediaItem).queryKey }) > 0;
-
-    const isLoadingMedia = useSpinDelay(isFetchingMedia, { delay: 400, minDuration: 200 });
     const areToolsDisabled = isSceneBusy || isReadOnly;
-    const size = { width: mediaItem.width, height: mediaItem.height };
     const canEditSelectedAnnotation = !areToolsDisabled && isSingleEditableSelection;
     const { toolLayerRef, toolLayerPointerEvents, handlePointerMove } = useToolLayerPointerPassthrough({
         canEditSelectedAnnotation,
         areToolsDisabled,
     });
 
-    const isPlaceholderImage = image.width === 1 && image.height === 1;
-
-    if (isLoadingMedia && isPlaceholderImage) {
-        return <Loading size='M' />;
-    }
-
     return (
-        <ZoomTransform target={size}>
-            <div
-                style={{ position: 'relative', height: '100%', width: '100%' }}
-                onContextMenu={(event: MouseEvent): void => event.preventDefault()}
-                onPointerMove={handlePointerMove}
-                className={isReadOnly ? classes.readOnlyCanvas : undefined}
-                ref={canvasRef}
-            >
-                {(isLoadingMedia || isLoadingPredictions) && <Loading mode={'overlay'} />}
-                <MediaImage image={image} mediaItem={mediaItem} />
-                <MediaAnnotations mediaItem={mediaItem} mode={mode} />
+        <MediaCanvas
+            mediaItem={mediaItem}
+            image={image}
+            containerRef={canvasRef}
+            onPointerMove={handlePointerMove}
+            className={isReadOnly ? classes.readOnlyCanvas : undefined}
+            isLoadingOverlay={isLoadingPredictions}
+        >
+            <MediaAnnotations mediaItem={mediaItem} mode={mode} />
 
-                <div
-                    ref={toolLayerRef}
-                    aria-hidden={areToolsDisabled || undefined}
-                    style={{
-                        position: 'absolute',
-                        inset: 0,
-                        pointerEvents: toolLayerPointerEvents,
-                    }}
-                >
-                    <ToolManager />
-                </div>
+            <div
+                ref={toolLayerRef}
+                aria-hidden={areToolsDisabled || undefined}
+                style={{
+                    position: 'absolute',
+                    inset: 0,
+                    pointerEvents: toolLayerPointerEvents,
+                }}
+            >
+                <ToolManager />
             </div>
-        </ZoomTransform>
+        </MediaCanvas>
     );
 };

--- a/application/ui/src/features/annotator/annotator-canvas/media-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/media-canvas.tsx
@@ -1,0 +1,64 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { MouseEvent, PointerEvent, ReactNode, RefObject, useRef } from 'react';
+
+import { Loading } from '@geti/ui';
+import { useIsFetching } from '@tanstack/react-query';
+import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
+import { useSpinDelay } from 'spin-delay';
+
+import { ZoomTransform } from '../../../components/zoom/zoom-transform';
+import type { Media } from '../../../constants/shared-types';
+import { loadImageQueryOptions } from '../hooks/use-load-image-query.hook';
+import { MediaImage } from './media-image.component';
+
+type MediaCanvasProps = {
+    mediaItem: Media;
+    image: ImageData;
+    containerRef?: RefObject<HTMLDivElement | null>;
+    onPointerMove?: (event: PointerEvent<HTMLDivElement>) => void;
+    className?: string;
+    isLoadingOverlay?: boolean;
+    children?: ReactNode;
+};
+
+export const MediaCanvas = ({
+    mediaItem,
+    image,
+    containerRef,
+    onPointerMove,
+    className,
+    isLoadingOverlay = false,
+    children,
+}: MediaCanvasProps) => {
+    const projectId = useProjectIdentifier();
+    const localRef = useRef<HTMLDivElement | null>(null);
+    const resolvedRef = containerRef ?? localRef;
+
+    const isFetchingMedia = useIsFetching({ queryKey: loadImageQueryOptions(projectId, mediaItem).queryKey }) > 0;
+    const isLoadingMedia = useSpinDelay(isFetchingMedia, { delay: 400, minDuration: 200 });
+
+    const isPlaceholderImage = image.width === 1 && image.height === 1;
+    const size = { width: mediaItem.width, height: mediaItem.height };
+
+    if (isLoadingMedia && isPlaceholderImage) {
+        return <Loading size='M' />;
+    }
+
+    return (
+        <ZoomTransform target={size}>
+            <div
+                ref={resolvedRef}
+                style={{ position: 'relative', height: '100%', width: '100%' }}
+                onContextMenu={(event: MouseEvent): void => event.preventDefault()}
+                onPointerMove={onPointerMove}
+                className={className}
+            >
+                {(isLoadingMedia || isLoadingOverlay) && <Loading mode={'overlay'} />}
+                <MediaImage image={image} mediaItem={mediaItem} />
+                {children}
+            </div>
+        </ZoomTransform>
+    );
+};

--- a/application/ui/src/features/annotator/annotator-canvas/media-image.component.test.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/media-image.component.test.tsx
@@ -1,0 +1,60 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { screen } from '@testing-library/react';
+import { getMockedMediaImage, getMockedVideo, getMockedVideoFrame } from 'mocks/mock-media';
+import { render } from 'test-utils/render';
+
+import { MediaImage } from './media-image.component';
+
+vi.mock('../video-player/video-frame.component', () => ({
+    VideoFrame: () => <div data-testid='video-frame' />,
+}));
+
+const makeImageData = (width: number, height: number): ImageData =>
+    ({ width, height, data: new Uint8ClampedArray(width * height * 4) }) as ImageData;
+
+describe('MediaImage', () => {
+    it('renders a canvas for a full-resolution image', () => {
+        const mediaItem = getMockedMediaImage({ width: 100, height: 100 });
+        const image = makeImageData(100, 100);
+
+        const { container } = render(<MediaImage image={image} mediaItem={mediaItem} />);
+
+        expect(container.querySelector('canvas')).toBeInTheDocument();
+        expect(container.querySelector('img')).not.toBeInTheDocument();
+    });
+
+    it('renders an img for a downscaled (non-full-resolution) image', () => {
+        const mediaItem = getMockedMediaImage({ width: 200, height: 200 });
+        // Image decoded at half resolution — not full-res.
+        const image = makeImageData(100, 100);
+
+        const { container } = render(<MediaImage image={image} mediaItem={mediaItem} />);
+
+        expect(container.querySelector('img')).toBeInTheDocument();
+        expect(container.querySelector('canvas')).not.toBeInTheDocument();
+    });
+
+    it('renders a canvas with a video-frame overlay for a video-frame media item', () => {
+        const mediaItem = getMockedVideoFrame({ width: 400, height: 400 });
+        const image = makeImageData(400, 400);
+
+        const { container } = render(<MediaImage image={image} mediaItem={mediaItem} />);
+
+        expect(container.querySelector('canvas')).toBeInTheDocument();
+        expect(screen.getByTestId('video-frame')).toBeInTheDocument();
+        expect(container.querySelector('img')).not.toBeInTheDocument();
+    });
+
+    it('renders a canvas with a video-frame overlay for a video media item', () => {
+        const mediaItem = getMockedVideo({ width: 400, height: 400 });
+        const image = makeImageData(400, 400);
+
+        const { container } = render(<MediaImage image={image} mediaItem={mediaItem} />);
+
+        expect(container.querySelector('canvas')).toBeInTheDocument();
+        expect(screen.getByTestId('video-frame')).toBeInTheDocument();
+        expect(container.querySelector('img')).not.toBeInTheDocument();
+    });
+});

--- a/application/ui/src/features/annotator/annotator-canvas/media-image.component.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/media-image.component.tsx
@@ -13,7 +13,7 @@ import { drawImageDataOnCanvas } from './draw-image-data-on-canvas';
 
 import classes from './annotator-canvas.module.scss';
 
-export const useDrawImageOnCanvas = (image: ImageData) => {
+const useDrawImageOnCanvas = (image: ImageData) => {
     const canvasRef = useRef<HTMLCanvasElement>(null);
 
     useEffect(() => {

--- a/application/ui/src/features/annotator/annotator-canvas/media-image.component.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/media-image.component.tsx
@@ -1,0 +1,87 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useRef } from 'react';
+
+import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
+
+import type { Media } from '../../../constants/shared-types';
+import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
+import { getMediaBinaryUrl } from '../../../shared/media-url.utils';
+import { VideoFrame } from '../video-player/video-frame.component';
+import { drawImageDataOnCanvas } from './draw-image-data-on-canvas';
+
+import classes from './annotator-canvas.module.scss';
+
+export const useDrawImageOnCanvas = (image: ImageData) => {
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+
+    useEffect(() => {
+        const ctx = canvasRef?.current?.getContext('2d');
+
+        if (ctx == null) {
+            return;
+        }
+
+        drawImageDataOnCanvas(ctx, image);
+    }, [image]);
+
+    return canvasRef;
+};
+
+// Oversized static images: use <img> to bypass canvas rasterization limit.
+const StaticImage = ({ mediaItem }: { mediaItem: Media }) => {
+    const projectId = useProjectIdentifier();
+
+    return (
+        <img
+            src={getMediaBinaryUrl(projectId, mediaItem.id)}
+            width={mediaItem.width}
+            height={mediaItem.height}
+            crossOrigin='anonymous'
+            className={classes.image}
+            alt=''
+        />
+    );
+};
+
+type CanvasMediaImageProps = {
+    image: ImageData;
+    showVideoFrame?: boolean;
+};
+
+const CanvasMediaImage = ({ image, showVideoFrame = false }: CanvasMediaImageProps) => {
+    const canvasRef = useDrawImageOnCanvas(image);
+
+    return (
+        <>
+            <canvas ref={canvasRef} width={image.width} height={image.height} className={classes.image} />
+            {showVideoFrame && <VideoFrame canvasRef={canvasRef} />}
+        </>
+    );
+};
+
+type MediaImageProps = {
+    image: ImageData;
+    mediaItem: Media;
+};
+
+export const MediaImage = ({ image, mediaItem }: MediaImageProps) => {
+    if (isVideo(mediaItem) || isVideoFrame(mediaItem)) {
+        return <CanvasMediaImage image={image} showVideoFrame />;
+    }
+
+    // Render via canvas only when decoded at native resolution.
+    // `ImageData.data.length` is expected to be width * height * 4
+    // (RGBA: 4 channels, 1 byte per channel = 4 bytes per pixel).
+    const isFullResolution =
+        image.width === mediaItem.width &&
+        image.height === mediaItem.height &&
+        image.data.length === mediaItem.width * mediaItem.height * 4;
+
+    if (isFullResolution) {
+        return <CanvasMediaImage image={image} />;
+    }
+
+    return <StaticImage mediaItem={mediaItem} />;
+};

--- a/application/ui/src/features/annotator/annotator-canvas/read-only-annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/read-only-annotator-canvas.tsx
@@ -1,49 +1,17 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { MouseEvent, useRef } from 'react';
-
-import { Loading } from '@geti/ui';
-import { useIsFetching } from '@tanstack/react-query';
-import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
-import { useSpinDelay } from 'spin-delay';
-
-import { ZoomTransform } from '../../../components/zoom/zoom-transform';
 import type { Media } from '../../../constants/shared-types';
 import { ReadOnlyAnnotations } from '../annotations/read-only-annotations.component';
-import { loadImageQueryOptions } from '../hooks/use-load-image-query.hook';
-import { MediaImage } from './media-image.component';
+import { MediaCanvas } from './media-canvas';
 
 type ReadOnlyAnnotatorCanvasProps = {
     mediaItem: Media;
     image: ImageData;
 };
 
-export const ReadOnlyAnnotatorCanvas = ({ mediaItem, image }: ReadOnlyAnnotatorCanvasProps) => {
-    const projectId = useProjectIdentifier();
-    const containerRef = useRef<HTMLDivElement>(null);
-
-    const isFetchingMedia = useIsFetching({ queryKey: loadImageQueryOptions(projectId, mediaItem).queryKey }) > 0;
-    const isLoadingMedia = useSpinDelay(isFetchingMedia, { delay: 400, minDuration: 200 });
-
-    const isPlaceholderImage = image.width === 1 && image.height === 1;
-    const size = { width: mediaItem.width, height: mediaItem.height };
-
-    if (isLoadingMedia && isPlaceholderImage) {
-        return <Loading size='M' />;
-    }
-
-    return (
-        <ZoomTransform target={size}>
-            <div
-                ref={containerRef}
-                style={{ position: 'relative', height: '100%', width: '100%' }}
-                onContextMenu={(event: MouseEvent): void => event.preventDefault()}
-            >
-                {isLoadingMedia && <Loading mode={'overlay'} />}
-                <MediaImage image={image} mediaItem={mediaItem} />
-                <ReadOnlyAnnotations width={size.width} height={size.height} />
-            </div>
-        </ZoomTransform>
-    );
-};
+export const ReadOnlyAnnotatorCanvas = ({ mediaItem, image }: ReadOnlyAnnotatorCanvasProps) => (
+    <MediaCanvas mediaItem={mediaItem} image={image}>
+        <ReadOnlyAnnotations width={mediaItem.width} height={mediaItem.height} />
+    </MediaCanvas>
+);

--- a/application/ui/src/features/annotator/annotator-canvas/read-only-annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/read-only-annotator-canvas.tsx
@@ -1,0 +1,49 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { MouseEvent, useRef } from 'react';
+
+import { Loading } from '@geti/ui';
+import { useIsFetching } from '@tanstack/react-query';
+import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
+import { useSpinDelay } from 'spin-delay';
+
+import { ZoomTransform } from '../../../components/zoom/zoom-transform';
+import type { Media } from '../../../constants/shared-types';
+import { ReadOnlyAnnotations } from '../annotations/read-only-annotations.component';
+import { loadImageQueryOptions } from '../hooks/use-load-image-query.hook';
+import { MediaImage } from './media-image.component';
+
+type ReadOnlyAnnotatorCanvasProps = {
+    mediaItem: Media;
+    image: ImageData;
+};
+
+export const ReadOnlyAnnotatorCanvas = ({ mediaItem, image }: ReadOnlyAnnotatorCanvasProps) => {
+    const projectId = useProjectIdentifier();
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    const isFetchingMedia = useIsFetching({ queryKey: loadImageQueryOptions(projectId, mediaItem).queryKey }) > 0;
+    const isLoadingMedia = useSpinDelay(isFetchingMedia, { delay: 400, minDuration: 200 });
+
+    const isPlaceholderImage = image.width === 1 && image.height === 1;
+    const size = { width: mediaItem.width, height: mediaItem.height };
+
+    if (isLoadingMedia && isPlaceholderImage) {
+        return <Loading size='M' />;
+    }
+
+    return (
+        <ZoomTransform target={size}>
+            <div
+                ref={containerRef}
+                style={{ position: 'relative', height: '100%', width: '100%' }}
+                onContextMenu={(event: MouseEvent): void => event.preventDefault()}
+            >
+                {isLoadingMedia && <Loading mode={'overlay'} />}
+                <MediaImage image={image} mediaItem={mediaItem} />
+                <ReadOnlyAnnotations width={size.width} height={size.height} />
+            </div>
+        </ZoomTransform>
+    );
+};

--- a/application/ui/src/features/dataset/media-preview/read-only-annotator-providers.component.test.tsx
+++ b/application/ui/src/features/dataset/media-preview/read-only-annotator-providers.component.test.tsx
@@ -1,0 +1,90 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { type ReactNode } from 'react';
+
+import { screen, waitFor } from '@testing-library/react';
+import { getMockedLabel } from 'mocks/mock-labels';
+import { getMockedMediaImage } from 'mocks/mock-media';
+import { getMockedProject } from 'mocks/mock-project';
+import { HttpResponse } from 'msw';
+import { render, renderHook } from 'test-utils/render';
+
+import { http } from '../../../api/utils';
+import { server } from '../../../msw-node-setup';
+import { useAnnotationActions } from '../../../shared/annotator/annotation-actions-provider.component';
+import { ReadOnlyAnnotatorProviders } from './read-only-annotator-providers.component';
+
+const mediaItem = getMockedMediaImage();
+
+describe('ReadOnlyAnnotatorProviders', () => {
+    beforeEach(() => {
+        server.use(http.get('/api/projects/{project_id}', () => HttpResponse.json(getMockedProject())));
+    });
+
+    it('renders children within the provider tree', async () => {
+        render(
+            <ReadOnlyAnnotatorProviders mediaItem={mediaItem} initialAnnotationsDTO={[]} isUserReviewed={false}>
+                <span>child content</span>
+            </ReadOnlyAnnotatorProviders>
+        );
+
+        expect(await screen.findByText('child content')).toBeInTheDocument();
+    });
+
+    it('provides AnnotationActions with isReadOnlyMode true', async () => {
+        const wrapper = ({ children }: { children: ReactNode }) => (
+            <ReadOnlyAnnotatorProviders mediaItem={mediaItem} initialAnnotationsDTO={[]} isUserReviewed={false}>
+                {children}
+            </ReadOnlyAnnotatorProviders>
+        );
+
+        const { result } = renderHook(() => useAnnotationActions(), { wrapper });
+
+        await waitFor(() => expect(result.current.isReadOnlyMode).toBe(true));
+    });
+
+    it('exposes annotations from initialAnnotationsDTO', async () => {
+        const label = getMockedLabel({ id: 'label-1' });
+
+        server.use(
+            http.get('/api/projects/{project_id}', () =>
+                HttpResponse.json(
+                    getMockedProject({
+                        task: { task_type: 'detection', exclusive_labels: true, labels: [label] },
+                    })
+                )
+            )
+        );
+
+        const initialAnnotationsDTO = [
+            {
+                shape: { type: 'rectangle' as const, x: 10, y: 20, width: 100, height: 50 },
+                labels: [{ id: label.id }],
+            },
+        ];
+
+        const wrapper = ({ children }: { children: ReactNode }) => (
+            <ReadOnlyAnnotatorProviders
+                mediaItem={mediaItem}
+                initialAnnotationsDTO={initialAnnotationsDTO}
+                isUserReviewed={false}
+            >
+                {children}
+            </ReadOnlyAnnotatorProviders>
+        );
+
+        const { result } = renderHook(() => useAnnotationActions(), { wrapper });
+
+        await waitFor(() => {
+            expect(result.current.annotations).toHaveLength(1);
+            expect(result.current.annotations[0].shape).toEqual({
+                type: 'rectangle',
+                x: 10,
+                y: 20,
+                width: 100,
+                height: 50,
+            });
+        });
+    });
+});

--- a/application/ui/src/features/dataset/media-preview/read-only-annotator-providers.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/read-only-annotator-providers.component.tsx
@@ -1,0 +1,46 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { ReactNode } from 'react';
+
+import { ZoomProvider } from '../../../components/zoom/zoom.provider';
+import type { AnnotationDTO, Media } from '../../../constants/shared-types';
+import { AnnotationActionsProvider } from '../../../shared/annotator/annotation-actions-provider.component';
+import { AnnotationVisibilityProvider } from '../../../shared/annotator/annotation-visibility-provider.component';
+import { AnnotatorLabelsProvider } from '../../annotator/annotator-labels-provider.component';
+import { CanvasSettingsProvider } from './primary-toolbar/settings/canvas-settings-provider.component';
+
+type ReadOnlyAnnotatorProvidersProps = {
+    mediaItem: Media;
+    initialAnnotationsDTO: AnnotationDTO[];
+    isUserReviewed: boolean;
+    children: ReactNode;
+};
+
+export const ReadOnlyAnnotatorProviders = ({
+    mediaItem,
+    initialAnnotationsDTO,
+    isUserReviewed,
+    children,
+}: ReadOnlyAnnotatorProvidersProps) => {
+    return (
+        <ZoomProvider>
+            <AnnotationVisibilityProvider>
+                <CanvasSettingsProvider>
+                    <AnnotatorLabelsProvider>
+                        <AnnotationActionsProvider
+                            mediaItem={mediaItem}
+                            initialAnnotationsDTO={initialAnnotationsDTO}
+                            initialPredictionsDTO={[]}
+                            isUserReviewed={isUserReviewed}
+                            mode='annotation'
+                            isReadOnly
+                        >
+                            {children}
+                        </AnnotationActionsProvider>
+                    </AnnotatorLabelsProvider>
+                </CanvasSettingsProvider>
+            </AnnotationVisibilityProvider>
+        </ZoomProvider>
+    );
+};

--- a/application/ui/src/features/dataset/media-preview/read-only-annotator-providers.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/read-only-annotator-providers.component.tsx
@@ -17,6 +17,8 @@ type ReadOnlyAnnotatorProvidersProps = {
     children: ReactNode;
 };
 
+const EMPTY_PREDICTIONS_DTO: AnnotationDTO[] = [];
+
 export const ReadOnlyAnnotatorProviders = ({
     mediaItem,
     initialAnnotationsDTO,
@@ -31,7 +33,7 @@ export const ReadOnlyAnnotatorProviders = ({
                         <AnnotationActionsProvider
                             mediaItem={mediaItem}
                             initialAnnotationsDTO={initialAnnotationsDTO}
-                            initialPredictionsDTO={[]}
+                            initialPredictionsDTO={EMPTY_PREDICTIONS_DTO}
                             isUserReviewed={isUserReviewed}
                             mode='annotation'
                             isReadOnly

--- a/application/ui/src/features/dataset/media-preview/read-only-annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/read-only-annotator.component.tsx
@@ -5,10 +5,7 @@ import { ActionButton, Flex, Icon, Text, View } from '@geti/ui';
 import { CloseSemiBold } from '@geti/ui/icons';
 
 import type { DatasetSubset, Media } from '../../../constants/shared-types';
-import type { AnnotatorMode } from '../../../shared/annotator/annotator-mode';
-import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
-import { AnnotatorCanvas } from '../../annotator/annotator-canvas/annotator-canvas';
-import { VideoToolbar } from '../../annotator/video-player/video-toolbar/video-toolbar.component';
+import { ReadOnlyAnnotatorCanvas } from '../../annotator/annotator-canvas/read-only-annotator-canvas';
 import { BottomToolbar } from './bottom-toolbar/bottom-toolbar.component';
 import { AnnotatorCanvasSettings } from './primary-toolbar/settings/annotator-canvas-settings.component';
 import { Toolbar } from './toolbar-container/toolbar-container.component';
@@ -16,7 +13,6 @@ import { Toolbar } from './toolbar-container/toolbar-container.component';
 import classes from './read-only-annotator.module.scss';
 
 type ReadOnlyAnnotatorProps = {
-    mode: AnnotatorMode;
     mediaItem: Media;
     image: ImageData;
     onClose: () => void;
@@ -36,7 +32,6 @@ type ReadOnlyAnnotatorProps = {
  * It uses the same gridArea structure as the normal annotator but with fewer elements.
  */
 export const ReadOnlyAnnotator = ({
-    mode,
     image,
     mediaItem,
     subset,
@@ -62,15 +57,9 @@ export const ReadOnlyAnnotator = ({
 
             <View gridArea={'canvas'} overflow={'hidden'}>
                 <AnnotatorCanvasSettings>
-                    <AnnotatorCanvas isReadOnly mediaItem={mediaItem} image={image} mode={mode} />
+                    <ReadOnlyAnnotatorCanvas mediaItem={mediaItem} image={image} />
                 </AnnotatorCanvasSettings>
             </View>
-
-            {(isVideo(mediaItem) || isVideoFrame(mediaItem)) && (
-                <View gridArea={'video-toolbar'}>
-                    <VideoToolbar mode={mode} />
-                </View>
-            )}
 
             <View gridArea={'bottom'}>
                 <BottomToolbar

--- a/application/ui/src/features/models/model-listing/model-training-datasets/subset-gallery.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-training-datasets/subset-gallery.component.tsx
@@ -15,11 +15,10 @@ import {
     SelectedMediaItemProvider,
     useSelectedMediaItem,
 } from '../../../../features/annotator/selected-media-item-provider.component';
-import { AnnotatorProviders } from '../../../../features/dataset/media-preview/annotator-providers.component';
 import { useAnnotationsQuery } from '../../../../features/dataset/media-preview/api/use-annotations-query';
+import { ReadOnlyAnnotatorProviders } from '../../../../features/dataset/media-preview/read-only-annotator-providers.component';
 import { ReadOnlyAnnotator } from '../../../../features/dataset/media-preview/read-only-annotator.component';
 import { getInitialAnnotations } from '../../../../features/dataset/media-preview/utils';
-import { ToolProvider } from '../../../../shared/annotator/tool-provider.component';
 import { type GalleryViewMode } from '../../../../shared/gallery-view-modes';
 import { getDatasetRevisionThumbnailUrl } from '../../../../shared/media-url.utils';
 import { datasetRevisionItemToMedia } from './utils';
@@ -56,17 +55,13 @@ const SubsetMediaDialogContent = ({ item, onClose }: SubsetMediaDialogContentPro
 
     const annotationsDTO = annotationsData?.annotations ?? [];
     const isUserReviewed = annotationsData?.user_reviewed ?? false;
-    const mode = 'annotation';
 
     return (
-        <AnnotatorProviders
+        <ReadOnlyAnnotatorProviders
             key={mediaItem.id}
             mediaItem={mediaItem}
             initialAnnotationsDTO={getInitialAnnotations(isUserReviewed, annotationsDTO)}
-            initialPredictionsDTO={[]}
             isUserReviewed={isUserReviewed}
-            mode={mode}
-            isReadOnly
         >
             <ReadOnlyAnnotator
                 image={image}
@@ -75,7 +70,7 @@ const SubsetMediaDialogContent = ({ item, onClose }: SubsetMediaDialogContentPro
                 subset={item.subset}
                 hasAnnotationStatus={false}
             />
-        </AnnotatorProviders>
+        </ReadOnlyAnnotatorProviders>
     );
 };
 
@@ -93,11 +88,9 @@ const SubsetMediaDialog = ({ item, onClose }: SubsetMediaDialogProps) => {
                     columns={['1fr']}
                     areas={['header', 'canvas', 'bottom']}
                 >
-                    <ToolProvider>
-                        <SelectedMediaItemProvider mediaItem={mediaItem}>
-                            <SubsetMediaDialogContent item={item} onClose={onClose} />
-                        </SelectedMediaItemProvider>
-                    </ToolProvider>
+                    <SelectedMediaItemProvider mediaItem={mediaItem}>
+                        <SubsetMediaDialogContent item={item} onClose={onClose} />
+                    </SelectedMediaItemProvider>
                 </Grid>
             </Content>
         </Dialog>

--- a/application/ui/src/features/models/model-listing/model-training-datasets/subset-gallery.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-training-datasets/subset-gallery.component.tsx
@@ -72,7 +72,6 @@ const SubsetMediaDialogContent = ({ item, onClose }: SubsetMediaDialogContentPro
                 image={image}
                 mediaItem={mediaItem}
                 onClose={onClose}
-                mode={mode}
                 subset={item.subset}
                 hasAnnotationStatus={false}
             />

--- a/application/ui/tests/models/subset-gallery.spec.ts
+++ b/application/ui/tests/models/subset-gallery.spec.ts
@@ -125,7 +125,7 @@ test.describe('Subset Gallery — read-only dialog', () => {
         const dialog = page.getByRole('dialog');
         await expect(dialog).toBeVisible();
 
-        await expect(dialog.getByLabel('annotation polygon').first()).toBeVisible();
+        await expect(dialog.getByLabel('annotation polygon').last()).toBeVisible();
 
         const toggleFocusButton = page.getByRole('button', { name: 'Toggle focus' });
         await toggleFocusButton.click();

--- a/application/ui/tests/models/subset-gallery.spec.ts
+++ b/application/ui/tests/models/subset-gallery.spec.ts
@@ -125,6 +125,8 @@ test.describe('Subset Gallery — read-only dialog', () => {
         const dialog = page.getByRole('dialog');
         await expect(dialog).toBeVisible();
 
+        await expect(dialog.getByLabel('annotation polygon').first()).toBeVisible();
+
         const toggleFocusButton = page.getByRole('button', { name: 'Toggle focus' });
         await toggleFocusButton.click();
         await expect(toggleFocusButton).toBeVisible();
@@ -132,7 +134,10 @@ test.describe('Subset Gallery — read-only dialog', () => {
         await page.getByRole('button', { name: 'Settings' }).click();
         await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
 
-        await page.getByRole('button', { name: 'Close' }).click();
+        await page.getByRole('button', { name: 'Close settings' }).click();
+        await expect(page.getByRole('heading', { name: 'Settings' })).toBeHidden();
+
+        await page.getByRole('button', { name: 'Close', exact: true }).click();
         await expect(dialog).toBeHidden();
     });
 });

--- a/application/ui/tests/models/subset-gallery.spec.ts
+++ b/application/ui/tests/models/subset-gallery.spec.ts
@@ -1,0 +1,138 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { getMockedDatasetRevision } from 'mocks/mock-dataset-revision';
+import { getMockedModel } from 'mocks/mock-model';
+import { getMockedProject } from 'mocks/mock-project';
+import { HttpResponse } from 'msw';
+
+import { expect, http, test } from '../fixtures';
+
+const filename = fileURLToPath(import.meta.url);
+const dirname = path.dirname(filename);
+const candyPngBuffer = fs.readFileSync(path.resolve(dirname, '../assets/candy.png'));
+
+const ITEM_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+const DATASET_REVISION_ID = 'dataset-1';
+const MODEL_ID = 'model-1';
+
+const mockedModel = getMockedModel({
+    id: MODEL_ID,
+    name: 'YOLOX Model v1',
+    architecture: 'Object_Detection_YOLOX_X',
+    training_info: {
+        status: 'successful',
+        label_schema_revision: { labels: [] },
+        start_time: '2025-01-10T10:00:00.000000+00:00',
+        end_time: '2025-01-10T12:30:00.000000+00:00',
+        dataset_revision_id: DATASET_REVISION_ID,
+    },
+});
+
+const mockedDatasetRevision = getMockedDatasetRevision({
+    id: DATASET_REVISION_ID,
+    name: 'Dataset Revision 1',
+    item_counts: { training: 1, validation: 0, testing: 0, total: 1 },
+});
+
+const mockedTrainingItem = {
+    id: ITEM_ID,
+    format: 'jpg' as const,
+    width: 1000,
+    height: 750,
+    subset: 'training' as const,
+};
+
+const mockedSegmentationProject = getMockedProject({
+    task: {
+        exclusive_labels: true,
+        task_type: 'instance_segmentation',
+        labels: [{ id: 'label-seg', name: 'car', color: '#2424a0', hotkey: 'B' }],
+    },
+});
+
+test.describe('Subset Gallery — read-only dialog', () => {
+    test('opens, toolbar controls work, and segmentation polygon annotations render without crash', async ({
+        page,
+        network,
+        modelsPage,
+    }) => {
+        network.use(
+            http.get('/api/projects/{project_id}', () => HttpResponse.json(mockedSegmentationProject)),
+            http.get('/api/projects/{project_id}/models', () => HttpResponse.json([mockedModel])),
+            http.get('/api/projects/{project_id}/models/{model_id}', ({ params }) => {
+                if (params.model_id === MODEL_ID) {
+                    return HttpResponse.json(mockedModel);
+                }
+
+                return new HttpResponse(null, { status: 404 });
+            }),
+            http.get('/api/projects/{project_id}/dataset_revisions', () => HttpResponse.json([mockedDatasetRevision])),
+            http.get('/api/projects/{project_id}/dataset_revisions/{dataset_revision_id}/items', ({ request }) => {
+                const url = new URL(request.url);
+                const subset = url.searchParams.get('subset');
+                const items = subset === 'training' ? [mockedTrainingItem] : [];
+
+                return HttpResponse.json({
+                    items,
+                    pagination: { offset: 0, limit: 20, count: items.length, total: items.length },
+                });
+            }),
+            http.get(
+                '/api/projects/{project_id}/dataset_revisions/{dataset_revision_id}/items/{dataset_item_id}/thumbnail',
+                () =>
+                    HttpResponse.arrayBuffer(candyPngBuffer.buffer, {
+                        headers: { 'content-type': 'image/png' },
+                    })
+            ),
+            http.get('/api/projects/{project_id}/dataset/media/{media_id}/binary', () =>
+                HttpResponse.arrayBuffer(candyPngBuffer.buffer, {
+                    headers: { 'content-type': 'image/png' },
+                })
+            ),
+            http.get('/api/projects/{project_id}/dataset/media/{media_id}/annotations', () =>
+                HttpResponse.json({
+                    annotations: [
+                        {
+                            shape: {
+                                type: 'polygon',
+                                points: [
+                                    { x: 10, y: 20 },
+                                    { x: 110, y: 20 },
+                                    { x: 110, y: 70 },
+                                ],
+                            },
+                            labels: [{ id: 'label-seg' }],
+                        },
+                    ],
+                    user_reviewed: true,
+                    subset: 'training',
+                })
+            )
+        );
+
+        await modelsPage.goto();
+        await modelsPage.expandModel('YOLOX Model v1');
+        await modelsPage.clickTrainingDatasetsTab();
+
+        await expect(page.getByAltText('training item')).toBeVisible();
+        await page.getByAltText('training item').dblclick();
+
+        const dialog = page.getByRole('dialog');
+        await expect(dialog).toBeVisible();
+
+        const toggleFocusButton = page.getByRole('button', { name: 'Toggle focus' });
+        await toggleFocusButton.click();
+        await expect(toggleFocusButton).toBeVisible();
+
+        await page.getByRole('button', { name: 'Settings' }).click();
+        await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+
+        await page.getByRole('button', { name: 'Close' }).click();
+        await expect(dialog).toBeHidden();
+    });
+});


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

The goal of this PR is to remove from read only annotator providers, which are meant to be used only for fully functional annotator (tools etc).

Close #6884 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
