### PR TITLE
Images are not identical after upload/download roundtrip

### DIFF
--- a/application/backend/app/services/media_service.py
+++ b/application/backend/app/services/media_service.py
@@ -120,31 +120,44 @@ class MediaService(BaseSessionManagedService):
         except Exception:
             logger.exception("Failed to generate thumbnail image")
 
+    @staticmethod
+    def _copy_binary(data: BinaryIO | BytesIO, path: Path, chunk_size: int = 1024 * 1024) -> None:
+        data.seek(0)
+        with path.open("wb") as output:
+            while chunk := data.read(chunk_size):
+                output.write(chunk)
+
     def create_image(
         self,
         metadata: ImageMetadata,
     ) -> Media:
         """Creates a new media (image)"""
         media_id = uuid4()
+        original_binary: BinaryIO | BytesIO | None = None
         match metadata.data:
             case Image.Image():
                 image = metadata.data
             case np.ndarray():
                 image = self._read_image_from_ndarray(metadata.data)
             case _:
+                original_binary = metadata.data
                 image = self._read_image_from_binary(metadata.data)
 
         dataset_dir = self.projects_dir / f"{metadata.project_id}/dataset"
         dataset_dir.mkdir(parents=True, exist_ok=True)
         binary_path = dataset_dir / f"{media_id}.{metadata.image_format}"
-        try:
-            image.save(binary_path, exif=image.getexif())
-        except RuntimeError:
-            logger.warning(
-                "Failed to save image with EXIF data ({}), saving without EXIF.",
-                metadata.name,
-            )
-            image.save(binary_path)
+
+        if original_binary is not None:
+            self._copy_binary(original_binary, binary_path)
+        else:
+            try:
+                image.save(binary_path, exif=image.getexif())
+            except RuntimeError:
+                logger.warning(
+                    "Failed to save image with EXIF data ({}), saving without EXIF.",
+                    metadata.name,
+                )
+                image.save(binary_path)
 
         try:
             MediaService._generate_and_save_thumbnail(image, dataset_dir / f"{media_id}-thumb.jpg")
@@ -185,11 +198,7 @@ class MediaService(BaseSessionManagedService):
         dataset_dir.mkdir(parents=True, exist_ok=True)
         binary_path = dataset_dir / f"{media_id}.{video_format}"
 
-        data.seek(0)
-        with open(binary_path, "wb") as f:
-            # Read in chunks to avoid memory issues for large files
-            while chunk := data.read(VIDEO_WRITE_CHUNK_SIZE):
-                f.write(chunk)
+        self._copy_binary(data, binary_path, VIDEO_WRITE_CHUNK_SIZE)
 
         try:
             video_metadata = self._get_video_service().get_video_metadata(video_path=binary_path)

--- a/application/backend/tests/integration/services/test_media_service.py
+++ b/application/backend/tests/integration/services/test_media_service.py
@@ -554,8 +554,14 @@ class TestMediaServiceIntegration:
         use_pipeline_source: bool,
     ) -> None:
         """Test creating a media."""
-        image = PILImage.new("RGB", (1024, 768))
+        rng = np.random.default_rng(seed=42)
+        image_data = rng.integers(0, 255, (64, 96, 3), dtype=np.uint8)
+        image = PILImage.fromarray(image_data, mode="RGB")
         image.getexif()[ExifTags.Base.Software] = "Intel Geti"
+
+        original_file_path = tmp_path / f"original.{format}"
+        image.save(original_file_path, exif=image.getexif())
+        original_bytes = original_file_path.read_bytes()
 
         project, pipeline = fxt_project_with_pipeline
 
@@ -564,10 +570,14 @@ class TestMediaServiceIntegration:
                 project_id=project.id,
                 name="test",
                 image_format=format,
-                data=image,
+                data=BytesIO(original_bytes),
                 source_id=pipeline.source_id if use_pipeline_source else None,
             )
         )
+
+        binary_file_path = tmp_path / f"projects/{project.id}/dataset/{created_media.id}.{format}"
+        assert binary_file_path.exists()
+        assert binary_file_path.read_bytes() == original_bytes
 
         media = db_session.get(MediaDB, str(created_media.id))
         assert media is not None
@@ -577,8 +587,8 @@ class TestMediaServiceIntegration:
             and media.type == "image"
             and media.name == "test"
             and media.format == format
-            and media.width == 1024
-            and media.height == 768
+            and media.width == 96
+            and media.height == 64
         )
         if use_pipeline_source:
             assert media.source_id == str(pipeline.source_id)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

- [x] Do not save converted `PIL.Image`, but the original binary on image creation

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
