### PR TITLE
Add Ultralytics YOLO licensing notice to README and NOTICE

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,3 +1,5 @@
 This repository is under Apache License Version 2.0 licence. However the following files are borrowed from the external sources under different licenses.
 
 - MIT License: `lib/src/otx/core/engine/**/*.py`
+
+The optional `ultralytics` extra installs the Ultralytics YOLO package at runtime; it is not redistributed as part of this repository. The Ultralytics YOLO package and YOLO26 model weights are distributed under the AGPL-3.0 license. For commercial use and alternative licensing terms, see https://www.ultralytics.com/license.

--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ uv pip install getitune # CPU-only by default
 > ```
 >
 > See the [library README](library/README.md#installation) for more details.
+>
+> ℹ️ Ultralytics YOLO models are distributed under the [AGPL-3.0 license](https://www.ultralytics.com/license).
 
 **Discover available models and train a model in just a few lines of code:**
 
@@ -424,4 +426,5 @@ Geti™ utilizes FFmpeg.
 
 FFmpeg is an open source project licensed under LGPL and GPL. See [https://www.ffmpeg.org/legal.html](https://www.ffmpeg.org/legal.html). You are solely responsible for determining if your use of FFmpeg requires any additional licenses. Intel is not responsible for obtaining any such licenses, nor liable for any licensing fees due, in connection with your use of FFmpeg.
 
-Ultralytics YOLO models are distributed under the AGPL-3.0 license, an OSI approved license ideal for open-source research, academic, and personal projects. For commercial use, enhanced support, and tailored licensing terms, please explore flexible Ultralytics licensing options at https://www.ultralytics.com/license.
+> [!NOTE]
+> Ultralytics YOLO models are distributed under the AGPL-3.0 license, an OSI approved license ideal for open-source research, academic, and personal projects. For commercial use, enhanced support, and tailored licensing terms, please explore flexible Ultralytics licensing options at https://www.ultralytics.com/license.


### PR DESCRIPTION
### Summary

Adds an Ultralytics YOLO licensing notice across the repo's licensing surfaces, all pointing to https://www.ultralytics.com/license:

- **`README.md`** — a short inline note at the `getitune` source-install step (where the `ultralytics` extra is pulled in), and reformats the existing Ultralytics disclaimer at the bottom into a `> [!NOTE]` admonition matching the style used elsewhere in the README.
- **`NOTICE`** — adds an entry noting that the optional `ultralytics` extra installs the Ultralytics YOLO package at runtime (not redistributed here) and that the package and YOLO26 weights are AGPL-3.0 licensed.

Ultralytics YOLO models are distributed under the AGPL-3.0 license; the notices link to the Ultralytics license page for commercial/enterprise licensing options. Documentation only — no code changes.

### How to test

Render `README.md` and confirm the inline note appears under the YOLO source-install block and the bottom disclaimer renders as a NOTE admonition. Review `NOTICE` for the added Ultralytics entry.

### Checklist

- [x] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [x] Documentation has been updated (if applicable)
