### PR TITLE
feat: Show warning message about empty label when exporting dataset with other format than Geti

### DIFF
--- a/application/ui/src/components/export-dataset-config-dialog/export-dataset-config.component.tsx
+++ b/application/ui/src/components/export-dataset-config-dialog/export-dataset-config.component.tsx
@@ -25,21 +25,34 @@ import { useProject } from 'hooks/api/project.hook';
 
 import { useExportDatasetJobAction } from '../../hooks/use-export-dataset-job-action.hook';
 import { Link } from '../../platform/components/link.component';
+import { getEmptyLabel } from '../../shared/annotator/labels';
 import { MultiSelectList } from '../multi-select-list/multi-select-list.component';
 import { getFormatOptions } from '../util';
 
 import classes from './export-dataset-config.module.scss';
 
-const WarningMessage = () => {
+type WarningMessagesProps = {
+    emptyLabelName: string | null;
+};
+
+const WarningMessages = ({ emptyLabelName }: WarningMessagesProps) => {
     return (
         <Flex alignItems={'start'} marginTop={'size-100'} gap={'size-100'}>
             <Flex>
                 <Alert className={classes.warningMessageIcon} />
             </Flex>
-            <Text>
-                Exporting videos is not supported by this dataset format. All annotated frames from videos will be
-                exported as images.
-            </Text>
+            <Flex direction={'column'} gap={'size-75'}>
+                <Text>
+                    Exporting videos is not supported by this dataset format. All annotated frames from videos will be
+                    exported as images.
+                </Text>
+                {emptyLabelName !== null && (
+                    <Text>
+                        {`Empty labels ('${emptyLabelName}') are exclusively supported by the Geti format. Other
+                        export formats do not support empty labels.`}
+                    </Text>
+                )}
+            </Flex>
         </Flex>
     );
 };
@@ -71,9 +84,10 @@ export const ExportDatasetConfig = ({
     const formatOptions = getFormatOptions(selectedProject.task.task_type);
     const [selectedExportFormat, setSelectedExportFormat] = useState<string | null>(formatOptions.at(0)?.value ?? null);
 
-    const labels = selectedProject.task?.labels?.map((label) => ({ id: label.name, name: label.name })) ?? [];
+    const labels = selectedProject.task.labels?.map((label) => ({ id: label.name, name: label.name })) ?? [];
 
     const isNonGetiFormatSelected = selectedExportFormat !== 'geti';
+    const emptyLabel = getEmptyLabel(selectedProject.task.task_type, selectedProject.task.exclusive_labels);
 
     return (
         <DialogContainer onDismiss={dialogState.close}>
@@ -117,7 +131,7 @@ export const ExportDatasetConfig = ({
                                 </RadioGroup>
                             </Form>
 
-                            {isNonGetiFormatSelected && <WarningMessage />}
+                            {isNonGetiFormatSelected && <WarningMessages emptyLabelName={emptyLabel?.name ?? null} />}
 
                             <Link
                                 href={EXPORT_FORMATS_LINK}

--- a/application/ui/src/components/export-dataset-config-dialog/export-dataset-config.component.tsx
+++ b/application/ui/src/components/export-dataset-config-dialog/export-dataset-config.component.tsx
@@ -49,10 +49,11 @@ const WarningMessages = ({ emptyLabelName }: WarningMessagesProps) => {
                 {emptyLabelName !== null && (
                     <Text>
                         {`The selected format does not support empty labels (e.g. "${emptyLabelName}"). Images
-                        and frames containing them will be exported as unannotated. To preserve videos or empty
-                        labels, please use the Geti export format.`}
+                        and frames containing them will be exported as unannotated.`}
                     </Text>
                 )}
+                <Text>{`To preserve videos ${emptyLabelName !== null ? 'or empty labels' : ''}, please
+                use the Geti export format.`}</Text>
             </Flex>
         </Flex>
     );

--- a/application/ui/src/components/export-dataset-config-dialog/export-dataset-config.component.tsx
+++ b/application/ui/src/components/export-dataset-config-dialog/export-dataset-config.component.tsx
@@ -68,12 +68,14 @@ const FORM_ID = 'export-dataset-form';
 const EXPORT_FORMATS_LINK =
     'https://docs.geti.intel.com/docs/user-guide/geti-fundamentals/datasets/dataset-export-import#supported-formats';
 
-export const ExportDatasetConfig = ({
-    name = 'dataset',
-    datasetId,
-    statistics,
-    dialogState,
-}: ExportDatasetConfigProps) => {
+type ExportDatasetDialogContentProps = {
+    name: string;
+    datasetId: string | null;
+    statistics: ReactNode;
+    dialogState: OverlayTriggerState;
+};
+
+const ExportDatasetDialogContent = ({ name, datasetId, statistics, dialogState }: ExportDatasetDialogContentProps) => {
     const { data: selectedProject } = useProject();
 
     const [formState, submitAction, isPending] = useExportDatasetJobAction({
@@ -90,76 +92,86 @@ export const ExportDatasetConfig = ({
     const emptyLabel = getEmptyLabel(selectedProject.task.task_type, selectedProject.task.exclusive_labels);
 
     return (
+        <Dialog size='L' width={{ base: '70vw' }}>
+            <Heading>Export {name}</Heading>
+            <Divider />
+            <Content UNSAFE_className={classes.container}>
+                <Heading>Exported dataset statistics</Heading>
+                {statistics}
+
+                <Heading>Export settings</Heading>
+
+                <View backgroundColor='gray-75' padding='size-200' borderRadius='regular'>
+                    <Form id={FORM_ID} validationBehavior='native' action={submitAction}>
+                        <MultiSelectList
+                            name='labels'
+                            items={labels}
+                            maxHeight='size-2000'
+                            label='Filter annotations by label'
+                            defaultSelectedKeys={new Set(labels.map(({ id }) => id))}
+                        />
+
+                        <Checkbox name='include_unannotated' defaultSelected={formState.include_unannotated}>
+                            Include media without annotations
+                        </Checkbox>
+
+                        <Divider size='S' />
+
+                        <RadioGroup
+                            name='export_format'
+                            label='Select dataset export format'
+                            defaultValue={formState.export_format}
+                            onChange={(value) => setSelectedExportFormat(value)}
+                        >
+                            {formatOptions.map((item) => (
+                                <Radio key={item.value} value={item.value}>
+                                    {item.label}
+                                </Radio>
+                            ))}
+                        </RadioGroup>
+                    </Form>
+
+                    {isNonGetiFormatSelected && <WarningMessages emptyLabelName={emptyLabel?.name ?? null} />}
+
+                    <Link
+                        href={EXPORT_FORMATS_LINK}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                        UNSAFE_className={classes.link}
+                    >
+                        Learn more about export formats
+                        <LinkOut size='XS' />
+                    </Link>
+                </View>
+            </Content>
+
+            <ButtonGroup>
+                <Button onPress={dialogState.close} variant='secondary'>
+                    Cancel
+                </Button>
+                <Button type='submit' form={FORM_ID} variant='accent' isPending={isPending} isDisabled={isPending}>
+                    Export
+                </Button>
+            </ButtonGroup>
+        </Dialog>
+    );
+};
+
+export const ExportDatasetConfig = ({
+    name = 'dataset',
+    datasetId,
+    statistics,
+    dialogState,
+}: ExportDatasetConfigProps) => {
+    return (
         <DialogContainer onDismiss={dialogState.close}>
             {dialogState.isOpen && (
-                <Dialog size='L' width={{ base: '70vw' }}>
-                    <Heading>Export {name}</Heading>
-                    <Divider />
-                    <Content UNSAFE_className={classes.container}>
-                        <Heading>Exported dataset statistics</Heading>
-                        {statistics}
-
-                        <Heading>Export settings</Heading>
-
-                        <View backgroundColor='gray-75' padding='size-200' borderRadius='regular'>
-                            <Form id={FORM_ID} validationBehavior='native' action={submitAction}>
-                                <MultiSelectList
-                                    name='labels'
-                                    items={labels}
-                                    maxHeight='size-2000'
-                                    label='Filter annotations by label'
-                                    defaultSelectedKeys={new Set(labels.map(({ id }) => id))}
-                                />
-
-                                <Checkbox name='include_unannotated' defaultSelected={formState.include_unannotated}>
-                                    Include media without annotations
-                                </Checkbox>
-
-                                <Divider size='S' />
-
-                                <RadioGroup
-                                    name='export_format'
-                                    label='Select dataset export format'
-                                    defaultValue={formState.export_format}
-                                    onChange={(value) => setSelectedExportFormat(value)}
-                                >
-                                    {formatOptions.map((item) => (
-                                        <Radio key={item.value} value={item.value}>
-                                            {item.label}
-                                        </Radio>
-                                    ))}
-                                </RadioGroup>
-                            </Form>
-
-                            {isNonGetiFormatSelected && <WarningMessages emptyLabelName={emptyLabel?.name ?? null} />}
-
-                            <Link
-                                href={EXPORT_FORMATS_LINK}
-                                target='_blank'
-                                rel='noopener noreferrer'
-                                UNSAFE_className={classes.link}
-                            >
-                                Learn more about export formats
-                                <LinkOut size='XS' />
-                            </Link>
-                        </View>
-                    </Content>
-
-                    <ButtonGroup>
-                        <Button onPress={dialogState.close} variant='secondary'>
-                            Cancel
-                        </Button>
-                        <Button
-                            type='submit'
-                            form={FORM_ID}
-                            variant='accent'
-                            isPending={isPending}
-                            isDisabled={isPending}
-                        >
-                            Export
-                        </Button>
-                    </ButtonGroup>
-                </Dialog>
+                <ExportDatasetDialogContent
+                    name={name}
+                    datasetId={datasetId}
+                    statistics={statistics}
+                    dialogState={dialogState}
+                />
             )}
         </DialogContainer>
     );

--- a/application/ui/src/components/export-dataset-config-dialog/export-dataset-config.component.tsx
+++ b/application/ui/src/components/export-dataset-config-dialog/export-dataset-config.component.tsx
@@ -48,8 +48,9 @@ const WarningMessages = ({ emptyLabelName }: WarningMessagesProps) => {
                 </Text>
                 {emptyLabelName !== null && (
                     <Text>
-                        {`Empty labels ('${emptyLabelName}') are exclusively supported by the Geti format. Other
-                        export formats do not support empty labels.`}
+                        {`The selected format does not support empty labels (e.g. "${emptyLabelName}"). Images
+                        and frames containing them will be exported as unannotated. To preserve videos or empty
+                        labels, please use the Geti export format.`}
                     </Text>
                 )}
             </Flex>

--- a/application/ui/src/components/export-dataset-config-dialog/export-dataset-config.component.tsx
+++ b/application/ui/src/components/export-dataset-config-dialog/export-dataset-config.component.tsx
@@ -52,7 +52,7 @@ const WarningMessages = ({ emptyLabelName }: WarningMessagesProps) => {
                         and frames containing them will be exported as unannotated.`}
                     </Text>
                 )}
-                <Text>{`To preserve videos ${emptyLabelName !== null ? 'or empty labels' : ''}, please
+                <Text>{`To preserve videos${emptyLabelName !== null ? ' or empty labels' : ''}, please
                 use the Geti export format.`}</Text>
             </Flex>
         </Flex>

--- a/application/ui/src/components/export-dataset-config-dialog/export-dataset-config.test.tsx
+++ b/application/ui/src/components/export-dataset-config-dialog/export-dataset-config.test.tsx
@@ -21,6 +21,8 @@ describe('ExportDatasetConfig', () => {
     };
 
     const VIDEO_WARNING = /Exporting videos is not supported by this dataset format/i;
+    const EMPTY_LABEL_WARNING_NO_OBJECT = /Empty labels \('No object'\) are exclusively supported by the Geti format/i;
+    const EMPTY_LABEL_WARNING_NO_LABEL = /Empty labels \('No label'\) are exclusively supported by the Geti format/i;
 
     const renderApp = (project: SchemaProjectView) => {
         server.use(
@@ -81,5 +83,26 @@ describe('ExportDatasetConfig', () => {
         fireEvent.click(screen.getByRole('radio', { name: 'Geti' }));
         expect(screen.getByRole('radio', { name: 'Geti' })).toBeChecked();
         expect(screen.queryByText(VIDEO_WARNING)).not.toBeInTheDocument();
+    });
+
+    it('shows the empty label warning for a task with empty labels when a non-Geti format is selected', async () => {
+        renderApp(getMockedProject({ task: { exclusive_labels: true, task_type: 'detection' } }));
+
+        fireEvent.click(await screen.findByRole('radio', { name: 'COCO' }));
+        expect(screen.getByRole('radio', { name: 'COCO' })).toBeChecked();
+        expect(screen.getByText(EMPTY_LABEL_WARNING_NO_OBJECT)).toBeVisible();
+
+        fireEvent.click(screen.getByRole('radio', { name: 'Geti' }));
+        expect(screen.getByRole('radio', { name: 'Geti' })).toBeChecked();
+        expect(screen.queryByText(EMPTY_LABEL_WARNING_NO_OBJECT)).not.toBeInTheDocument();
+    });
+
+    it('does not show the empty label warning for a single-label classification task', async () => {
+        renderApp(getMockedProject({ task: { exclusive_labels: true, task_type: 'classification' } }));
+
+        fireEvent.click(await screen.findByRole('radio', { name: 'VOC' }));
+        expect(screen.getByRole('radio', { name: 'VOC' })).toBeChecked();
+        expect(screen.queryByText(EMPTY_LABEL_WARNING_NO_OBJECT)).not.toBeInTheDocument();
+        expect(screen.queryByText(EMPTY_LABEL_WARNING_NO_LABEL)).not.toBeInTheDocument();
     });
 });

--- a/application/ui/src/components/export-dataset-config-dialog/export-dataset-config.test.tsx
+++ b/application/ui/src/components/export-dataset-config-dialog/export-dataset-config.test.tsx
@@ -21,8 +21,8 @@ describe('ExportDatasetConfig', () => {
     };
 
     const VIDEO_WARNING = /Exporting videos is not supported by this dataset format/i;
-    const EMPTY_LABEL_WARNING_NO_OBJECT = /Empty labels \('No object'\) are exclusively supported by the Geti format/i;
-    const EMPTY_LABEL_WARNING_NO_LABEL = /Empty labels \('No label'\) are exclusively supported by the Geti format/i;
+    const EMPTY_LABEL_WARNING_NO_OBJECT = /does not support empty labels.*"No object"/i;
+    const EMPTY_LABEL_WARNING_NO_LABEL = /does not support empty labels.*"No label"/i;
 
     const renderApp = (project: SchemaProjectView) => {
         server.use(

--- a/application/ui/src/features/models/model-listing/components/dataset-actions/dataset-actions.component.test.tsx
+++ b/application/ui/src/features/models/model-listing/components/dataset-actions/dataset-actions.component.test.tsx
@@ -98,6 +98,6 @@ describe('DatasetActions', () => {
 
         await userEvent.click(screen.getByRole('menuitem', { name: 'Export' }));
 
-        expect(screen.getByRole('heading', { name: 'Exported dataset statistics' })).toBeVisible();
+        expect(await screen.findByRole('heading', { name: 'Exported dataset statistics' })).toBeVisible();
     });
 });

--- a/application/ui/src/shared/annotator/labels.ts
+++ b/application/ui/src/shared/annotator/labels.ts
@@ -17,7 +17,7 @@ const NO_OBJECT_LABEL: Label = { id: EMPTY_LABEL_ID, name: 'No object', color: '
 export const isEmptyLabel = <T extends { id: string }>({ id }: T): boolean => id === EMPTY_LABEL_ID;
 export const isNonEmptyLabel = negate(isEmptyLabel);
 
-const getEmptyLabel = (taskType: TaskType, exclusiveLabels: boolean): Label | null => {
+export const getEmptyLabel = (taskType: TaskType, exclusiveLabels: boolean): Label | null => {
     if (isClassificationTask(taskType)) {
         const isMultiLabel = exclusiveLabels === false;
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

1. Add warning message.
2. Fresh state for export dataset dialog when user opens that dialog again.

<img width="917" height="862" alt="image" src="https://github.com/user-attachments/assets/2d16aee4-74bf-4a4f-b135-960de4a71119" />
Fixes #6921 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
