### PR TITLE
 Add media navigation hotkeys and confirmation alternative

### DIFF
--- a/application/ui/src/features/dataset/media-preview/primary-toolbar/hotkeys/hotkeys-list.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/primary-toolbar/hotkeys/hotkeys-list.component.tsx
@@ -25,7 +25,13 @@ export const HotkeysList = () => {
 
     return (
         <Grid columns={['2fr', '1fr']} rowGap={'size-100'}>
-            <HotkeyItem hotkeyName={'Submit annotations/predictions'} hotkey={formatHotkeyForDisplay(HOTKEYS.submit)} />
+            <HotkeyItem
+                hotkeyName={'Submit annotations/predictions'}
+                hotkey={`${formatHotkeyForDisplay(HOTKEYS.submitAlternative)} or ${formatHotkeyForDisplay(HOTKEYS.submit)}`}
+            />
+            <Divider size='S' gridColumn={'1/-1'} />
+            <HotkeyItem hotkeyName={'Previous media'} hotkey={'ArrowUp or ArrowLeft'} />
+            <HotkeyItem hotkeyName={'Next media'} hotkey={'ArrowDown or ArrowRight'} />
             <Divider size='S' gridColumn={'1/-1'} />
             {availableTools.map((tool) => (
                 <HotkeyItem key={tool.label} hotkeyName={tool.label} hotkey={formatHotkeyForDisplay(tool.hotkey)} />

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/secondary-toolbar.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/secondary-toolbar.component.tsx
@@ -125,7 +125,7 @@ export const SecondaryToolbar = ({
     const isSubmitDisabled = (!canSubmit && !hasSubsetChanged) || isSaving || isLoadingPredictions;
 
     useHotkeys(
-        HOTKEYS.submit,
+        `${HOTKEYS.submit}, ${HOTKEYS.submitAlternative}`,
         (event) => {
             event.preventDefault();
 

--- a/application/ui/src/features/dataset/media-preview/sidebar-items/use-keyboard-navigation.hook.test.tsx
+++ b/application/ui/src/features/dataset/media-preview/sidebar-items/use-keyboard-navigation.hook.test.tsx
@@ -21,9 +21,17 @@ describe('useKeyboardNavigation', () => {
 
     it('calls onSelectedMediaItem with previous item on ArrowUp', async () => {
         const mockedOnSelectedMediaItem = vi.fn();
-        render(<App items={items} onSelectedMediaItem={mockedOnSelectedMediaItem} selectedIndex={0} />);
+        render(<App items={items} onSelectedMediaItem={mockedOnSelectedMediaItem} selectedIndex={1} />);
 
         fireEvent.keyDown(screen.getByTestId('target'), { key: 'ArrowUp' });
+        expect(mockedOnSelectedMediaItem).toHaveBeenCalledWith(items[0]);
+    });
+
+    it('calls onSelectedMediaItem with previous item on ArrowLeft', async () => {
+        const mockedOnSelectedMediaItem = vi.fn();
+        render(<App items={items} onSelectedMediaItem={mockedOnSelectedMediaItem} selectedIndex={1} />);
+
+        fireEvent.keyDown(screen.getByTestId('target'), { key: 'ArrowLeft' });
         expect(mockedOnSelectedMediaItem).toHaveBeenCalledWith(items[0]);
     });
 
@@ -35,19 +43,33 @@ describe('useKeyboardNavigation', () => {
         expect(mockedOnSelectedMediaItem).toHaveBeenCalledWith(items[2]);
     });
 
-    it('does not go below index 0 on ArrowUp', async () => {
+    it('calls onSelectedMediaItem with next item on ArrowRight', async () => {
+        const mockedOnSelectedMediaItem = vi.fn();
+        render(<App items={items} onSelectedMediaItem={mockedOnSelectedMediaItem} selectedIndex={1} />);
+
+        fireEvent.keyDown(screen.getByTestId('target'), { key: 'ArrowRight' });
+        expect(mockedOnSelectedMediaItem).toHaveBeenCalledWith(items[2]);
+    });
+
+    it('does not go below index 0 on ArrowUp or ArrowLeft', async () => {
         const mockedOnSelectedMediaItem = vi.fn();
         render(<App items={items} onSelectedMediaItem={mockedOnSelectedMediaItem} selectedIndex={0} />);
 
         fireEvent.keyDown(screen.getByTestId('target'), { key: 'ArrowUp' });
         expect(mockedOnSelectedMediaItem).toHaveBeenCalledWith(items[0]);
+
+        fireEvent.keyDown(screen.getByTestId('target'), { key: 'ArrowLeft' });
+        expect(mockedOnSelectedMediaItem).toHaveBeenCalledWith(items[0]);
     });
 
-    it('does not go above last index on ArrowDown', async () => {
+    it('does not go above last index on ArrowDown or ArrowRight', async () => {
         const mockedOnSelectedMediaItem = vi.fn();
         render(<App items={items} onSelectedMediaItem={mockedOnSelectedMediaItem} selectedIndex={2} />);
 
         fireEvent.keyDown(screen.getByTestId('target'), { key: 'ArrowDown' });
+        expect(mockedOnSelectedMediaItem).toHaveBeenCalledWith(items[2]);
+
+        fireEvent.keyDown(screen.getByTestId('target'), { key: 'ArrowRight' });
         expect(mockedOnSelectedMediaItem).toHaveBeenCalledWith(items[2]);
     });
 

--- a/application/ui/src/features/dataset/media-preview/sidebar-items/use-keyboard-navigation.hook.tsx
+++ b/application/ui/src/features/dataset/media-preview/sidebar-items/use-keyboard-navigation.hook.tsx
@@ -20,12 +20,12 @@ export const useKeyboardNavigation = ({
     selectedIndex,
     onSelectedMediaItem,
 }: UseKeyboardNavigationProps) => {
-    const getNewIndex = (key: 'ArrowUp' | 'ArrowDown') => {
-        if (key === 'ArrowUp') {
+    const getNewIndex = (key: 'ArrowUp' | 'ArrowDown' | 'ArrowLeft' | 'ArrowRight') => {
+        if (key === 'ArrowUp' || key === 'ArrowLeft') {
             return Math.max(0, selectedIndex - 1);
         }
 
-        if (key === 'ArrowDown') {
+        if (key === 'ArrowDown' || key === 'ArrowRight') {
             return Math.min(items.length - 1, selectedIndex + 1);
         }
 
@@ -35,7 +35,12 @@ export const useKeyboardNavigation = ({
     useEventListener(
         'keydown',
         (event) => {
-            if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+            if (
+                event.key === 'ArrowUp' ||
+                event.key === 'ArrowDown' ||
+                event.key === 'ArrowLeft' ||
+                event.key === 'ArrowRight'
+            ) {
                 const newIndex = getNewIndex(event.key);
 
                 items[newIndex] && onSelectedMediaItem(items[newIndex]);

--- a/application/ui/src/shared/hotkeys-definition.ts
+++ b/application/ui/src/shared/hotkeys-definition.ts
@@ -25,6 +25,7 @@ export const HOTKEYS = {
     selectAllAnnotations: `${CTRL_OR_COMMAND_KEY}+a`,
     deselectAllAnnotations: `${CTRL_OR_COMMAND_KEY}+d`,
     submit: `${CTRL_OR_COMMAND_KEY}+s`,
+    submitAlternative: 'enter',
 } as const;
 
 const COMMON_HOTKEYS = {


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
- Added standard hotkeys for navigating between media items: Left Arrow for Previous Media, Right Arrow for Next Media.
- Added Enter as an alternative hotkey for saving/finalizing annotations and predictions, as requested.
- Updated the `useKeyboardNavigation` hook to handle ArrowLeft and ArrowRight.
- Updated the `SecondaryToolbar` to listen for the new alternative confirmation hotkey.
- Updated the `HotkeysList` component so these new shortcuts display properly in the UI

Closes : #6273
<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

1. Open the application UI and navigate to your project.
2. Click on the Dataset tab to view your media gallery.
3. Select an image or video frame to open the Annotator view.
4. Test Navigation: Make sure you aren't focused on a text box, then press the Left Arrow key. You should navigate to the previous media item. Press the Right Arrow key. You should navigate to the next media item.
5. Test Boundaries: Press the Left Arrow on the very first item, and the Right Arrow on the last item. Verify that the UI stays on the current item and no errors occur.
6. Test Save Action: Create or modify an annotation (or select a classification label) so the confirmation button becomes enabled. Press the Enter key.
7. Verify that the annotation is successfully saved and the UI automatically advances to the next media item.
8. Verify Hotkey Menu: Click the "Hotkeys" (keyboard) icon in the toolbar.
9. Check that "Previous media" (ArrowUp or ArrowLeft) and "Next media" (ArrowDown or ArrowRight) are now listed.
10. Check that the "Save annotations/predictions" entry now reads ENTER or CMD+S (or CTRL+S).

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
