### PR TITLE
Restrict remove-rc-app-images workflow to exact geti- packages

### DIFF
--- a/.github/workflows/remove-rc-app-images.yml
+++ b/.github/workflows/remove-rc-app-images.yml
@@ -3,6 +3,10 @@ name: Remove Application RC Container Images
 on:
   workflow_dispatch:
     inputs:
+      version:
+        description: "Released version whose RC images should be removed, e.g. 3.0.0"
+        required: true
+        type: string
       dry_run:
         description: "Preview deletions without removing image versions"
         required: false
@@ -26,6 +30,7 @@ jobs:
       # GH_TOKEN: ${{ secrets.WRITE_PACKAGES_TOKEN }}
       GH_TOKEN: ${{ github.token }}
       OWNER: ${{ github.repository_owner }}
+      TARGET_VERSION: ${{ inputs.version }}
       DRY_RUN: ${{ inputs.dry_run }}
     steps:
       - name: Harden the runner (audit all outbound calls)
@@ -40,6 +45,12 @@ jobs:
 
           # Application container packages to clean up.
           packages=(geti-cpu geti-xpu geti-cuda)
+
+          # Validate the requested version is a semver release (X.Y.Z).
+          if ! [[ "${TARGET_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version '${TARGET_VERSION}'. Must be a released semver, e.g. 3.0.0."
+            exit 1
+          fi
 
           deleted=0
           candidates=0
@@ -61,6 +72,7 @@ jobs:
 
           echo "Owner: ${OWNER} (type=${owner_type})"
           echo "Using ${scope_kind} package API scope: ${api_scope}"
+          echo "Target version: ${TARGET_VERSION}"
 
           for package in "${packages[@]}"; do
             scanned_packages=$((scanned_packages + 1))
@@ -73,15 +85,33 @@ jobs:
               continue
             fi
 
-            # Select versions where at least one tag matches semver RC format, e.g. 3.0.0rc1.
+            # Fetch all versions and normalize to a JSON array of {id, tags}.
+            raw_versions="$(gh api --paginate "${api_scope}/packages/container/${package_url}/versions?per_page=100")"
+            versions_json="$(
+              printf '%s\n' "${raw_versions}" | \
+              jq -sc '
+                map(if type=="array" then .[] else . end)
+                | map({id, tags: (.metadata.container.tags // [])})
+              '
+            )"
+
+            # Select RC-tagged versions for the requested version (e.g. 3.0.0rc1)
+            # only when the released version (e.g. 3.0.0) also exists as a tag in
+            # this package.
             # Each line is "<id>\t<comma-separated tags>".
             mapfile -t versions < <(
-              gh api --paginate "${api_scope}/packages/container/${package_url}/versions?per_page=100" \
-                --jq '.[] | select((.metadata.container.tags // []) | any(test("^[0-9]+\\.[0-9]+\\.[0-9]+rc[0-9]+$"; "i"))) | "\(.id)\t\((.metadata.container.tags // []) | join(","))"'
+              echo "${versions_json}" | jq -r --arg version "${TARGET_VERSION}" '
+                ([.[] | .tags[]?] | any(. == $version)) as $has_release
+                | .[]
+                | select($has_release
+                    and any(.tags[]?;
+                        startswith($version + "rc")
+                        and ((ltrimstr($version + "rc")) | test("^[0-9]+$"))))
+                | "\(.id)\t\(.tags | join(","))"'
             )
 
             if [[ "${#versions[@]}" -eq 0 ]]; then
-              echo "No RC-tagged versions found for ${package}"
+              echo "No ${TARGET_VERSION} RC-tagged versions with a matching released version found for ${package}"
               continue
             fi
 
@@ -106,6 +136,7 @@ jobs:
             echo "- Owner: ${OWNER}"
             echo "- Owner type: ${owner_type}"
             echo "- API scope: ${api_scope}"
+            echo "- Target version: ${TARGET_VERSION}"
             echo "- Dry run: ${DRY_RUN}"
             echo "- Packages scanned: ${scanned_packages}"
             echo "- Package versions matched: ${candidates}"

--- a/.github/workflows/remove-rc-app-images.yml
+++ b/.github/workflows/remove-rc-app-images.yml
@@ -11,6 +11,10 @@ on:
 
 permissions: {} # No permissions by default
 
+concurrency:
+  group: ${{ github.repository_owner }}-rc-image-cleanup
+  cancel-in-progress: false
+
 jobs:
   remove-rc-images:
     name: Delete GHCR Application RC-tagged images
@@ -22,7 +26,6 @@ jobs:
       # GH_TOKEN: ${{ secrets.WRITE_PACKAGES_TOKEN }}
       GH_TOKEN: ${{ github.token }}
       OWNER: ${{ github.repository_owner }}
-      PACKAGE_PREFIX: geti-
       DRY_RUN: ${{ inputs.dry_run }}
     steps:
       - name: Harden the runner (audit all outbound calls)
@@ -34,6 +37,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
+          # Application container packages to clean up.
+          packages=(geti-cpu geti-xpu geti-cuda)
 
           deleted=0
           candidates=0
@@ -55,47 +61,39 @@ jobs:
 
           echo "Owner: ${OWNER} (type=${owner_type})"
           echo "Using ${scope_kind} package API scope: ${api_scope}"
-          echo "Listing container packages for owner '${OWNER}'"
-
-          mapfile -t packages < <(
-            gh api --paginate "${api_scope}/packages?package_type=container&per_page=100" \
-              --jq '.[].name' \
-              | grep -E "^${PACKAGE_PREFIX}" || true
-          )
-
-          if [[ "${#packages[@]}" -eq 0 ]]; then
-            echo "No container packages found matching prefix '${PACKAGE_PREFIX}'."
-            {
-              echo "## Application RC Image Cleanup"
-              echo ""
-              echo "No packages matched prefix '${PACKAGE_PREFIX}'."
-              echo "No image versions were deleted."
-            } >> "${GITHUB_STEP_SUMMARY}"
-            exit 0
-          fi
 
           for package in "${packages[@]}"; do
             scanned_packages=$((scanned_packages + 1))
             package_url="$(printf '%s' "${package}" | jq -sRr @uri)"
             echo "Processing package: ${package}"
 
+            # Skip packages that do not exist for this owner.
+            if ! gh api "${api_scope}/packages/container/${package_url}" >/dev/null 2>&1; then
+              echo "Package '${package}' not found for owner '${OWNER}', skipping."
+              continue
+            fi
+
             # Select versions where at least one tag matches semver RC format, e.g. 3.0.0rc1.
-            mapfile -t version_ids < <(
+            # Each line is "<id>\t<comma-separated tags>".
+            mapfile -t versions < <(
               gh api --paginate "${api_scope}/packages/container/${package_url}/versions?per_page=100" \
-                --jq '.[] | select((.metadata.container.tags // []) | any(test("^[0-9]+\\.[0-9]+\\.[0-9]+rc[0-9]+$"; "i"))) | .id'
+                --jq '.[] | select((.metadata.container.tags // []) | any(test("^[0-9]+\\.[0-9]+\\.[0-9]+rc[0-9]+$"; "i"))) | "\(.id)\t\((.metadata.container.tags // []) | join(","))"'
             )
 
-            if [[ "${#version_ids[@]}" -eq 0 ]]; then
+            if [[ "${#versions[@]}" -eq 0 ]]; then
               echo "No RC-tagged versions found for ${package}"
               continue
             fi
 
-            for version_id in "${version_ids[@]}"; do
+            for version_entry in "${versions[@]}"; do
+              version_id="${version_entry%%$'\t'*}"
+              version_tags="${version_entry#*$'\t'}"
+              [[ -n "${version_tags}" ]] || version_tags="<untagged>"
               candidates=$((candidates + 1))
               if [[ "${DRY_RUN}" == "true" ]]; then
-                echo "[dry-run] Would delete ${package} version id ${version_id}"
+                echo "[dry-run] Would delete ${package} version id ${version_id} (tags: ${version_tags})"
               else
-                echo "Deleting ${package} version id ${version_id}"
+                echo "Deleting ${package} version id ${version_id} (tags: ${version_tags})"
                 gh api -X DELETE "${api_scope}/packages/container/${package_url}/versions/${version_id}"
                 deleted=$((deleted + 1))
               fi
@@ -108,7 +106,6 @@ jobs:
             echo "- Owner: ${OWNER}"
             echo "- Owner type: ${owner_type}"
             echo "- API scope: ${api_scope}"
-            echo "- Package prefix: ${PACKAGE_PREFIX}"
             echo "- Dry run: ${DRY_RUN}"
             echo "- Packages scanned: ${scanned_packages}"
             echo "- Package versions matched: ${candidates}"

--- a/.github/workflows/remove-rc-app-images.yml
+++ b/.github/workflows/remove-rc-app-images.yml
@@ -68,8 +68,8 @@ jobs:
             echo "Processing package: ${package}"
 
             # Skip packages that do not exist for this owner.
-            if ! gh api "${api_scope}/packages/container/${package_url}" >/dev/null 2>&1; then
-              echo "Package '${package}' not found for owner '${OWNER}', skipping."
+            if ! gh api --silent "${api_scope}/packages/container/${package_url}" >/dev/null; then
+              echo "Unable to access package '${package}' for owner '${OWNER}' (missing or insufficient permissions), skipping."
               continue
             fi
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Restrict workflow which removes old application release candidate images to exact packages: geti-cpu, geti-xpu, geti-cuda

Resolves #6939
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

Dispatch workflow

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
