### PR TITLE
chore: Diplay 'items'  instead of 'images' in dataset statistics

### DIFF
--- a/application/ui/src/features/models/model-listing/components/dataset-actions/dataset-revision-statistics/dataset-revision-statistics.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/dataset-actions/dataset-revision-statistics/dataset-revision-statistics.component.tsx
@@ -36,6 +36,6 @@ export const DatasetRevisionStatistics = ({ datasetRevisionId }: DatasetRevision
     const totalAnnotatedItems = annotatedItems?.pagination.total ?? 0;
 
     return (
-        <DatasetStatistics label='images' totalMediaItems={totalMediaItems} totalAnnotatedItems={totalAnnotatedItems} />
+        <DatasetStatistics label='items' totalMediaItems={totalMediaItems} totalAnnotatedItems={totalAnnotatedItems} />
     );
 };


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

Most probably we forgotten to update this place. The text is wrong because dataset might have only videos but we would display `images` label.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
