### PR TITLE
Fix failure reports in automated benchmark and disable segnext models 

### DIFF
--- a/library/benchmark_manifest.yaml
+++ b/library/benchmark_manifest.yaml
@@ -158,15 +158,16 @@ experiments:
       - name: dino_v2
         priority: extended
         recipe: semantic_segmentation/dino_v2.yaml
-      - name: segnext_t
-        priority: extended
-        recipe: semantic_segmentation/segnext_t.yaml
-      - name: segnext_s
-        priority: extended
-        recipe: semantic_segmentation/segnext_s.yaml
-      - name: segnext_b
-        priority: extended
-        recipe: semantic_segmentation/segnext_b.yaml
+      # SegNeXt models are currently disabled due to https://github.com/open-edge-platform/geti/issues/6694.
+      #      - name: segnext_t
+      #        priority: extended
+      #        recipe: semantic_segmentation/segnext_t.yaml
+      #      - name: segnext_s
+      #        priority: extended
+      #        recipe: semantic_segmentation/segnext_s.yaml
+      #      - name: segnext_b
+      #        priority: extended
+      #        recipe: semantic_segmentation/segnext_b.yaml
       - name: litehrnet_s
         priority: extended
         recipe: semantic_segmentation/litehrnet_s.yaml

--- a/library/benchmark_manifest.yaml
+++ b/library/benchmark_manifest.yaml
@@ -40,7 +40,7 @@ experiments:
         "training:val/{metric}": { compare: ">=", margin: 0.10 }
         "torch:test/{metric}": { compare: ">=", margin: 0.10 }
         "export:test/{metric}": { compare: ">=", margin: 0.10 }
-        "training:e2e_time": { compare: "<=", margin: 0.10 }
+        "training:e2e_time": { compare: "<=", margin: 0.20 }
         "training:gpu_mem": { compare: "<=", margin: 0.10 }
         "torch:test/latency": { compare: "<=", margin: 0.15 }
   classification/multi_label_cls:
@@ -71,7 +71,7 @@ experiments:
         "training:val/{metric}": { compare: ">=", margin: 0.10 }
         "torch:test/{metric}": { compare: ">=", margin: 0.10 }
         "export:test/{metric}": { compare: ">=", margin: 0.10 }
-        "training:e2e_time": { compare: "<=", margin: 0.10 }
+        "training:e2e_time": { compare: "<=", margin: 0.20 }
         "training:gpu_mem": { compare: "<=", margin: 0.10 }
         "torch:test/latency": { compare: "<=", margin: 0.15 }
   detection:
@@ -147,7 +147,7 @@ experiments:
         "training:val/{metric}": { compare: ">=", margin: 0.10 }
         "torch:test/{metric}": { compare: ">=", margin: 0.10 }
         "export:test/{metric}": { compare: ">=", margin: 0.10 }
-        "training:e2e_time": { compare: "<=", margin: 0.10 }
+        "training:e2e_time": { compare: "<=", margin: 0.20 }
         "training:gpu_mem": { compare: "<=", margin: 0.10 }
         "torch:test/latency": { compare: "<=", margin: 0.15 }
   semantic_segmentation:
@@ -181,7 +181,7 @@ experiments:
         "training:val/{metric}": { compare: ">=", margin: 0.10 }
         "torch:test/{metric}": { compare: ">=", margin: 0.10 }
         "export:test/{metric}": { compare: ">=", margin: 0.10 }
-        "training:e2e_time": { compare: "<=", margin: 0.10 }
+        "training:e2e_time": { compare: "<=", margin: 0.20 }
         "training:gpu_mem": { compare: "<=", margin: 0.10 }
         "torch:test/latency": { compare: "<=", margin: 0.15 }
   instance_segmentation:
@@ -227,6 +227,6 @@ experiments:
         "training:val/{metric}": { compare: ">=", margin: 0.10 }
         "torch:test/{metric}": { compare: ">=", margin: 0.10 }
         "export:test/{metric}": { compare: ">=", margin: 0.10 }
-        "training:e2e_time": { compare: "<=", margin: 0.10 }
+        "training:e2e_time": { compare: "<=", margin: 0.20 }
         "training:gpu_mem": { compare: "<=", margin: 0.10 }
         "torch:test/latency": { compare: "<=", margin: 0.15 }

--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -414,6 +414,7 @@ notice-rgx = """
     "ANN201",   # Skip return type hint in test codes
     "D",     # Test skips missing docstring argument with magic (fixture) methods.
     "ARG001",   # Some arguments are passed for executing fixture
+    "PT019",    # False positive on `@patch`-injected mock parameters, which aren't pytest fixtures.
 ]
 "src/getitune/**/*.py" = [
     "ERA001",

--- a/library/src/getitune/benchmark/cli.py
+++ b/library/src/getitune/benchmark/cli.py
@@ -323,7 +323,9 @@ def _cmd_report(args: argparse.Namespace) -> int:
     branch = args.branch or get_git_branch()
     git_sha = get_git_sha()
 
-    # Query MLflow for the most recent successful runs in this experiment
+    # Query MLflow for the most recent successful AND failed runs in this
+    # experiment. Skip "rollup" parent runs — only leaf "seed" runs carry
+    # per-run status/metrics.
     client = mlflow.tracking.MlflowClient(args.mlflow_uri)
 
     experiment_name = tracking_config.experiment_name
@@ -332,15 +334,21 @@ def _cmd_report(args: argparse.Namespace) -> int:
         logger.error("MLflow experiment '%s' not found.", experiment_name)
         return 1
 
-    runs = client.search_runs(
+    success_runs = client.search_runs(
         experiment_ids=[exp.experiment_id],
-        filter_string="tags.status = 'success'",
+        filter_string="tags.status = 'success' AND tags.run_type = 'seed'",
+        order_by=["attributes.start_time DESC"],
+        max_results=1000,
+    )
+    failed_runs = client.search_runs(
+        experiment_ids=[exp.experiment_id],
+        filter_string="tags.status = 'failed' AND tags.run_type = 'seed'",
         order_by=["attributes.start_time DESC"],
         max_results=1000,
     )
 
-    if not runs:
-        logger.warning("No successful runs found in experiment '%s'.", experiment_name)
+    if not success_runs and not failed_runs:
+        logger.warning("No runs found in experiment '%s'.", experiment_name)
         return 0
 
     # Convert MLflow runs into ExperimentResult objects for reuse by report.py
@@ -358,7 +366,7 @@ def _cmd_report(args: argparse.Namespace) -> int:
     }
 
     results: list[ExperimentResult] = []
-    for run in runs:
+    for run in success_runs:
         tags = run.data.tags
         metrics = dict(run.data.metrics)
         # MLflow stores total wall time under ``duration_seconds`` (see
@@ -395,6 +403,36 @@ def _cmd_report(args: argparse.Namespace) -> int:
             )
         )
 
+    failures: list[ExperimentResult] = []
+    for run in failed_runs:
+        tags = run.data.tags
+
+        # The full traceback is stored as an artifact (see
+        # ``BenchmarkTracker.log_run``) rather than a tag, to keep tag values
+        # short. Best-effort download; missing artifacts must not break the
+        # report.
+        traceback_text: str | None = None
+        try:
+            local_path = client.download_artifacts(run.info.run_id, "traceback.txt")
+            traceback_text = Path(local_path).read_text()
+        except Exception:
+            logger.debug("Could not download traceback artifact for run %s.", run.info.run_id, exc_info=True)
+
+        failures.append(
+            ExperimentResult(
+                task=tags.get("task", "unknown"),
+                model=tags.get("model", "unknown"),
+                dataset=tags.get("dataset", "unknown"),
+                scenario=tags.get("scenario", "default"),
+                seed=int(tags.get("seed", "0")),
+                success=False,
+                phases=[],
+                error=tags.get("error", "Unknown error"),
+                traceback=traceback_text,
+                failed_phase=tags.get("error_phase"),
+            )
+        )
+
     # Resolve baselines using the tracker
     baselines = tracker.resolve_baselines_for_results(results)
 
@@ -404,7 +442,7 @@ def _cmd_report(args: argparse.Namespace) -> int:
     output_dir = args.output_root
     report = generate_report(
         results=results,
-        failures=[],
+        failures=failures,
         baselines=baselines,
         criteria_by_task=criteria_by_task,
         output_dir=output_dir,

--- a/library/src/getitune/benchmark/report.py
+++ b/library/src/getitune/benchmark/report.py
@@ -437,18 +437,28 @@ def generate_markdown(report: BenchmarkReport) -> str:
         # Use a standard set: primary accuracy metric, train time, GPU mem, test latency
         metric_cols = _detect_metric_columns(comps)
 
-        header = "| Model | Dataset | Scenario "
+        header = "| Model | Dataset | Status "
         separator = "| --- | --- | --- "
         for col_label, _, _ in metric_cols:
             header += f"| {col_label} "
             separator += "| --- "
-        header += "| Status |"
-        separator += "| --- |"
+        header += "|"
+        separator += "|"
         lines.append(header)
         lines.append(separator)
 
         for comp in sorted(comps, key=lambda c: (c.model, c.dataset, c.scenario)):
-            row = f"| {comp.model} | {comp.dataset} | {comp.scenario} "
+            # Status column with regression details
+            status_detail = comp.status_emoji
+            regression_details = [r for r in comp.regressions if r.status == "regression"]
+            if regression_details:
+                detail_parts = []
+                for r in regression_details:
+                    short_metric = r.metric.rsplit("/", 1)[-1] if "/" in r.metric else r.metric
+                    detail_parts.append(f"{short_metric} {r.delta_pct}")
+                status_detail += " " + ", ".join(detail_parts)
+
+            row = f"| {comp.model} | {comp.dataset} | {status_detail} "
 
             for _col_label, metric_key, fmt_fn in metric_cols:
                 value = comp.current_metrics.get(metric_key)
@@ -465,17 +475,7 @@ def generate_markdown(report: BenchmarkReport) -> str:
 
                 row += f"| {formatted}{delta_str} "
 
-            # Status column with regression details
-            status_detail = comp.status_emoji
-            regression_details = [r for r in comp.regressions if r.status == "regression"]
-            if regression_details:
-                detail_parts = []
-                for r in regression_details:
-                    short_metric = r.metric.rsplit("/", 1)[-1] if "/" in r.metric else r.metric
-                    detail_parts.append(f"{short_metric} {r.delta_pct}")
-                status_detail += " " + ", ".join(detail_parts)
-
-            row += f"| {status_detail} |"
+            row += "|"
             lines.append(row)
 
         lines.append("")

--- a/library/src/getitune/benchmark/report.py
+++ b/library/src/getitune/benchmark/report.py
@@ -403,6 +403,22 @@ def _fmt_memory(mb: float | None) -> str:
     return f"{mb:.0f} MB"
 
 
+def _fmt_latency(seconds: float | None) -> str:
+    """Format a per-sample latency into a human-readable string.
+
+    Unlike :func:`_fmt_time` (built for run-length durations such as train
+    time), per-sample test latency is typically well under a second. Reusing
+    ``_fmt_time``'s single-decimal-second precision collapses nearly every
+    real value into ``0.0s`` or ``0.1s``, so sub-second values are rendered
+    in milliseconds instead to preserve meaningful precision.
+    """
+    if seconds is None:
+        return "—"
+    if seconds < 1:
+        return f"{seconds * 1000:.1f} ms"
+    return f"{seconds:.2f}s"
+
+
 def generate_markdown(report: BenchmarkReport) -> str:
     """Render a :class:`BenchmarkReport` as a Markdown string."""
     lines: list[str] = []
@@ -598,7 +614,7 @@ def _detect_metric_columns(
         columns.append(("GPU Mem ↓", "training:gpu_mem", _fmt_memory))
 
     if rewrite_metric_key("torch:test/latency") in all_keys:
-        columns.append(("Test Latency ↓", rewrite_metric_key("torch:test/latency"), _fmt_time))
+        columns.append(("Test Latency ↓", rewrite_metric_key("torch:test/latency"), _fmt_latency))
 
     return columns
 

--- a/library/tests/unit/benchmark/test_cli.py
+++ b/library/tests/unit/benchmark/test_cli.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from getitune.benchmark.cli import _build_parser, _cmd_provision, _cmd_run, _parse_key_value_pairs, main
+from getitune.benchmark.cli import _build_parser, _cmd_provision, _cmd_report, _cmd_run, _parse_key_value_pairs, main
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -272,6 +272,222 @@ class TestCmdRun:
             ]
         )
         rc = _cmd_run(args)
+        assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# Report sub-command
+# ---------------------------------------------------------------------------
+
+
+class TestCmdReport:
+    """Regression tests for the ``report`` sub-command including failures.
+
+    Ensures failed MLflow runs (``tags.status = 'failed'``) are surfaced in
+    the generated report instead of being silently dropped (see bug where
+    ``_cmd_report`` only ever queried successful runs and hardcoded
+    ``failures=[]``).
+    """
+
+    @patch("getitune.benchmark.report.generate_report")
+    @patch("getitune.benchmark.tracking.get_git_sha", return_value="abc123")
+    @patch("getitune.benchmark.tracking.get_git_branch", return_value="develop")
+    @patch("mlflow.tracking.MlflowClient")
+    @patch("mlflow.set_experiment")
+    @patch("mlflow.create_experiment")
+    @patch("mlflow.get_experiment_by_name")
+    @patch("mlflow.set_tracking_uri")
+    def test_report_includes_failed_runs(
+        self,
+        _mock_set_uri: MagicMock,
+        mock_get_exp: MagicMock,
+        _mock_create_exp: MagicMock,
+        _mock_set_exp: MagicMock,
+        mock_client_cls: MagicMock,
+        _mock_git_branch: MagicMock,
+        _mock_git_sha: MagicMock,
+        mock_generate_report: MagicMock,
+        manifest_file: Path,
+        tmp_path: Path,
+    ) -> None:
+        mock_experiment = MagicMock()
+        mock_experiment.experiment_id = "1"
+        mock_get_exp.return_value = mock_experiment  # tracker.setup()'s module-level lookup
+
+        mock_client = mock_client_cls.return_value
+        mock_client.get_experiment_by_name.return_value = mock_experiment  # cli.py's client-level lookup
+        mock_client.search_experiments.return_value = []  # no baselines available
+
+        success_run = MagicMock()
+        success_run.data.tags = {
+            "task": "detection",
+            "model": "model_a",
+            "dataset": "ds_a",
+            "scenario": "default",
+            "seed": "0",
+        }
+        success_run.data.metrics = {"training:val/mAP": 0.5, "duration_seconds": 120.0}
+
+        failed_run = MagicMock()
+        failed_run.info.run_id = "run-failed-1"
+        failed_run.data.tags = {
+            "task": "detection",
+            "model": "model_a",
+            "dataset": "ds_a",
+            "scenario": "default",
+            "seed": "1",
+            "error": "RuntimeError: could not create a primitive",
+            "error_phase": "train",
+        }
+        failed_run.data.metrics = {}
+
+        def _search_runs(
+            *,
+            experiment_ids: list[str],
+            filter_string: str,
+            order_by: list[str],
+            max_results: int,
+        ) -> list[MagicMock]:
+            if "status = 'success'" in filter_string:
+                return [success_run]
+            if "status = 'failed'" in filter_string:
+                return [failed_run]
+            return []
+
+        mock_client.search_runs.side_effect = _search_runs
+
+        traceback_path = tmp_path / "traceback.txt"
+        traceback_path.write_text("Traceback (most recent call last):\nRuntimeError: could not create a primitive\n")
+        mock_client.download_artifacts.return_value = str(traceback_path)
+
+        parser = _build_parser()
+        args = parser.parse_args(
+            [
+                "report",
+                "--manifest",
+                str(manifest_file),
+                "--output-root",
+                str(tmp_path / "results"),
+                "--mlflow-uri",
+                "http://localhost:5000",
+                "--branch",
+                "develop",
+            ]
+        )
+
+        rc = _cmd_report(args)
+
+        assert rc == 0
+        mock_generate_report.assert_called_once()
+        call_kwargs = mock_generate_report.call_args.kwargs
+
+        results = call_kwargs["results"]
+        assert len(results) == 1
+        assert results[0].success is True
+        assert results[0].model == "model_a"
+
+        failures = call_kwargs["failures"]
+        assert len(failures) == 1
+        failure = failures[0]
+        assert failure.success is False
+        assert failure.model == "model_a"
+        assert failure.seed == 1
+        assert "could not create a primitive" in failure.error
+        assert failure.failed_phase == "train"
+        assert failure.traceback is not None
+        assert "could not create a primitive" in failure.traceback
+
+    @patch("getitune.benchmark.report.generate_report")
+    @patch("getitune.benchmark.tracking.get_git_sha", return_value="abc123")
+    @patch("getitune.benchmark.tracking.get_git_branch", return_value="develop")
+    @patch("mlflow.tracking.MlflowClient")
+    @patch("mlflow.set_experiment")
+    @patch("mlflow.create_experiment")
+    @patch("mlflow.get_experiment_by_name")
+    @patch("mlflow.set_tracking_uri")
+    def test_report_no_runs_returns_zero(
+        self,
+        _mock_set_uri: MagicMock,
+        mock_get_exp: MagicMock,
+        _mock_create_exp: MagicMock,
+        _mock_set_exp: MagicMock,
+        mock_client_cls: MagicMock,
+        _mock_git_branch: MagicMock,
+        _mock_git_sha: MagicMock,
+        mock_generate_report: MagicMock,
+        manifest_file: Path,
+        tmp_path: Path,
+    ) -> None:
+        mock_experiment = MagicMock()
+        mock_experiment.experiment_id = "1"
+        mock_get_exp.return_value = mock_experiment
+
+        mock_client = mock_client_cls.return_value
+        mock_client.get_experiment_by_name.return_value = mock_experiment
+        mock_client.search_runs.return_value = []
+
+        parser = _build_parser()
+        args = parser.parse_args(
+            [
+                "report",
+                "--manifest",
+                str(manifest_file),
+                "--output-root",
+                str(tmp_path / "results"),
+                "--mlflow-uri",
+                "http://localhost:5000",
+                "--branch",
+                "develop",
+            ]
+        )
+
+        rc = _cmd_report(args)
+
+        assert rc == 0
+        mock_generate_report.assert_not_called()
+
+    @patch("getitune.benchmark.tracking.get_git_sha", return_value="abc123")
+    @patch("getitune.benchmark.tracking.get_git_branch", return_value="develop")
+    @patch("mlflow.tracking.MlflowClient")
+    @patch("mlflow.set_experiment")
+    @patch("mlflow.create_experiment")
+    @patch("mlflow.get_experiment_by_name")
+    @patch("mlflow.set_tracking_uri")
+    def test_report_experiment_not_found_returns_one(
+        self,
+        _mock_set_uri: MagicMock,
+        mock_get_exp: MagicMock,
+        _mock_create_exp: MagicMock,
+        _mock_set_exp: MagicMock,
+        mock_client_cls: MagicMock,
+        _mock_git_branch: MagicMock,
+        _mock_git_sha: MagicMock,
+        manifest_file: Path,
+        tmp_path: Path,
+    ) -> None:
+        mock_experiment = MagicMock()
+        mock_experiment.experiment_id = "1"
+        mock_get_exp.return_value = mock_experiment  # tracker.setup() succeeds
+
+        mock_client = mock_client_cls.return_value
+        mock_client.get_experiment_by_name.return_value = None  # but the report query fails to find it
+
+        parser = _build_parser()
+        args = parser.parse_args(
+            [
+                "report",
+                "--manifest",
+                str(manifest_file),
+                "--output-root",
+                str(tmp_path / "results"),
+                "--mlflow-uri",
+                "http://localhost:5000",
+                "--branch",
+                "develop",
+            ]
+        )
+
+        rc = _cmd_report(args)
         assert rc == 1
 
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
Failures were not included in generated reports ([example](https://github.com/intel-innersource/applications.ai.geti.geti-release/actions/runs/28507722067)). This PR ensures failures are now included in the generated report.

Additionally, segnext models are disabled due to a failure on XPU and the threshold for variation in training time was increased.

Also removes scenario columns from the report and puts the status in its place so it is easily visible. 
 
### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
