### PR TITLE
feat: Open unannotated media item

### DIFF
--- a/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.ts
+++ b/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.ts
@@ -1,11 +1,11 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { useDatasetMediaWithReviewStatus } from 'hooks/use-dataset-media-with-review-status.hook';
 import { useLocation, useNavigate, useParams } from 'react-router';
 
 import { paths } from '../../../../constants/paths';
 import { Media } from '../../../../constants/shared-types';
-import { useGetDatasetMediaItems } from '../../../../hooks/use-get-dataset-media-items.hook';
 import { useProjectIdentifier } from '../../../../hooks/use-project-identifier.hook';
 import { isVideo, isVideoFrame } from '../../../../shared/media-item-utils';
 
@@ -13,7 +13,7 @@ export const useSelectDatasetItem = () => {
     const navigate = useNavigate();
     const { search } = useLocation();
     const projectId = useProjectIdentifier();
-    const { items } = useGetDatasetMediaItems();
+    const { items } = useDatasetMediaWithReviewStatus();
     const { datasetItemId: selectedDatasetItemId } = useParams<{ datasetItemId: string }>();
 
     const onSelectedMediaItemChange = (item: Media | null) => {

--- a/application/ui/src/features/dataset/media-preview/utils.test.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.test.ts
@@ -137,17 +137,20 @@ describe('useNextMediaItem', () => {
 
     beforeEach(() => {
         mockUseVideoPlayerContext.mockReturnValue(null);
-        mockUseDatasetMediaWithReviewStatus.mockReturnValue({ fetchNextPage: mockFetchNextPage } as never);
-        mockUseFetchNextUnannotatedMediaItem.mockReturnValue({ data: { items: [] }, isPending: false } as never);
+        // @ts-expect-error We only care about mocking part of the context for this test.
+        mockUseDatasetMediaWithReviewStatus.mockReturnValue({ fetchNextPage: mockFetchNextPage });
+        // @ts-expect-error We only care about mocking data and isPending for this test.
+        mockUseFetchNextUnannotatedMediaItem.mockReturnValue({ data: { items: [] }, isPending: false });
         vi.clearAllMocks();
     });
 
     it('prefers the next unannotated media item over the positional next item', () => {
         const items = getMultipleMockedMediaImage(3);
         mockUseFetchNextUnannotatedMediaItem.mockReturnValue({
+            // @ts-expect-error We only care about mocking data and isPending for this test.
             data: { items: [getMockedDatasetItem({ id: items[2].id })] },
             isPending: false,
-        } as never);
+        });
 
         const { result } = renderHook(() => useNextMediaItem(items[0], items));
 
@@ -166,18 +169,20 @@ describe('useNextMediaItem', () => {
         const frame = getMockedVideoFrame({ id: 'video-1', frame_number: 0, frame_count: 10 });
         const nextImage = getMockedMediaImage({ id: 'image-1' });
         mockUseFetchNextUnannotatedMediaItem.mockReturnValue({
+            // @ts-expect-error We only care about mocking data and isPending for this test.
             data: { items: [getMockedDatasetItem({ id: nextImage.id })] },
             isPending: false,
-        } as never);
+        });
 
         const { result } = renderHook(() => useNextMediaItem(frame, [frame, nextImage]));
 
         expect(result.current).toEqual({ ...frame, frame_number: 1 });
     });
 
-    it('advances video frames using the step size from the video player context', () => {
-        mockUseVideoPlayerContext.mockReturnValue({ step: 60 } as never);
-        const frame = getMockedVideoFrame({ id: 'video-1', frame_number: 0, frame_count: 10 });
+    it('advances video frames using the step size from the video player context', async () => {
+        // @ts-expect-error We only care about mocking only step for this test.
+        mockUseVideoPlayerContext.mockReturnValue({ step: 60 });
+        const frame = getMockedVideoFrame({ id: 'video-1', frame_number: 0, frame_count: 70 });
 
         const { result } = renderHook(() => useNextMediaItem(frame, [frame]));
 
@@ -187,9 +192,10 @@ describe('useNextMediaItem', () => {
     it('excludes the current item from the unannotated candidates', () => {
         const items = getMultipleMockedMediaImage(2);
         mockUseFetchNextUnannotatedMediaItem.mockReturnValue({
+            // @ts-expect-error We only care about mocking data and isPending for this test.
             data: { items: [getMockedDatasetItem({ id: items[0].id })] },
             isPending: false,
-        } as never);
+        });
 
         const { result } = renderHook(() => useNextMediaItem(items[0], items));
 
@@ -201,9 +207,10 @@ describe('useNextMediaItem', () => {
         const nextUnannotatedItem = getMockedDatasetItem({ id: 'not-loaded-item' });
         const nextUnannotatedMediaImage = getMockedMediaImage({ id: nextUnannotatedItem.id });
         mockUseFetchNextUnannotatedMediaItem.mockReturnValue({
+            // @ts-expect-error We only care about mocking data and isPending for this test.
             data: { items: [nextUnannotatedItem] },
             isPending: false,
-        } as never);
+        });
 
         const { result, rerender } = renderHook(() => useNextMediaItem(alreadyFetchedItems[0], alreadyFetchedItems));
 
@@ -219,9 +226,10 @@ describe('useNextMediaItem', () => {
     it('does not fetch the next page when the next unannotated item is already among the fetched items', () => {
         const alreadyFetchedItems = getMultipleMockedMediaImage(2);
         mockUseFetchNextUnannotatedMediaItem.mockReturnValue({
+            // @ts-expect-error We only care about mocking data and isPending for this test.
             data: { items: [getMockedDatasetItem({ id: alreadyFetchedItems[1].id })] },
             isPending: false,
-        } as never);
+        });
 
         renderHook(() => useNextMediaItem(alreadyFetchedItems[0], alreadyFetchedItems));
 
@@ -236,7 +244,8 @@ describe('usePlayPauseVideoBySystem', () => {
 
     it('does not call play or pause when not loading and video is not playing', () => {
         const context = createVideoPlayerContext(false);
-        mockUseVideoPlayerContext.mockReturnValue(context as never);
+        // @ts-expect-error We only care about mocking part of the context for this test.
+        mockUseVideoPlayerContext.mockReturnValue(context);
 
         renderHook(() => usePlayPauseVideoBySystem(false));
 
@@ -246,7 +255,8 @@ describe('usePlayPauseVideoBySystem', () => {
 
     it('calls pause when range predictions are loading and video is playing', () => {
         const context = createVideoPlayerContext(true);
-        mockUseVideoPlayerContext.mockReturnValue(context as never);
+        // @ts-expect-error We only care about mocking part of the context for this test.
+        mockUseVideoPlayerContext.mockReturnValue(context);
 
         renderHook(() => usePlayPauseVideoBySystem(true));
 
@@ -256,7 +266,8 @@ describe('usePlayPauseVideoBySystem', () => {
 
     it('calls play when range predictions stop loading after system paused the video', () => {
         const context = createVideoPlayerContext(true);
-        mockUseVideoPlayerContext.mockReturnValue(context as never);
+        // @ts-expect-error We only care about mocking part of the context for this test.
+        mockUseVideoPlayerContext.mockReturnValue(context);
 
         let isLoading = true;
         const { rerender } = renderHook(() => usePlayPauseVideoBySystem(isLoading));
@@ -273,7 +284,8 @@ describe('usePlayPauseVideoBySystem', () => {
 
     it('does not call play when range predictions stop loading but video was paused by user', () => {
         const context = createVideoPlayerContext(false);
-        mockUseVideoPlayerContext.mockReturnValue(context as never);
+        // @ts-expect-error We only care about mocking part of the context for this test.
+        mockUseVideoPlayerContext.mockReturnValue(context);
 
         let isLoading = true;
         const { rerender } = renderHook(() => usePlayPauseVideoBySystem(isLoading));
@@ -290,7 +302,8 @@ describe('usePlayPauseVideoBySystem', () => {
 
     it('does not call pause when video is not playing and range predictions are loading', () => {
         const context = createVideoPlayerContext(false);
-        mockUseVideoPlayerContext.mockReturnValue(context as never);
+        // @ts-expect-error We only care about mocking part of the context for this test.
+        mockUseVideoPlayerContext.mockReturnValue(context);
 
         renderHook(() => usePlayPauseVideoBySystem(true));
 

--- a/application/ui/src/features/dataset/media-preview/utils.test.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.test.ts
@@ -2,18 +2,31 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { act } from '@testing-library/react';
+import { useDatasetMediaWithReviewStatus } from 'hooks/use-dataset-media-with-review-status.hook';
+import { useFetchNextUnannotatedMediaItem } from 'hooks/use-get-dataset-items.hook';
+import { getMockedDatasetItem } from 'mocks/mock-dataset-item';
 import { getMockedMediaImage, getMockedVideoFrame, getMultipleMockedMediaImage } from 'mocks/mock-media';
 import { renderHook } from 'test-utils/render';
 
 import type { AnnotationDTO } from '../../../constants/shared-types';
 import { useVideoPlayerContext } from '../../annotator/video-player/video-player-provider.component';
-import { getInitialAnnotations, getNextMediaItem, usePlayPauseVideoBySystem } from './utils';
+import { getInitialAnnotations, getNextMediaItem, useNextMediaItem, usePlayPauseVideoBySystem } from './utils';
 
 vi.mock('../../annotator/video-player/video-player-provider.component', () => ({
     useVideoPlayerContext: vi.fn(),
 }));
 
+vi.mock('hooks/use-dataset-media-with-review-status.hook', () => ({
+    useDatasetMediaWithReviewStatus: vi.fn(),
+}));
+
+vi.mock('hooks/use-get-dataset-items.hook', () => ({
+    useFetchNextUnannotatedMediaItem: vi.fn(),
+}));
+
 const mockUseVideoPlayerContext = vi.mocked(useVideoPlayerContext);
+const mockUseDatasetMediaWithReviewStatus = vi.mocked(useDatasetMediaWithReviewStatus);
+const mockUseFetchNextUnannotatedMediaItem = vi.mocked(useFetchNextUnannotatedMediaItem);
 
 const createVideoPlayerContext = (isPlaying: boolean) => {
     const play = vi.fn().mockResolvedValue(undefined);
@@ -116,6 +129,103 @@ describe('getNextMediaItem', () => {
             const result = getNextMediaItem(frame, [frame], 3);
             expect(result).toEqual({ ...frame, frame_number: 6 });
         });
+    });
+});
+
+describe('useNextMediaItem', () => {
+    const mockFetchNextPage = vi.fn();
+
+    beforeEach(() => {
+        mockUseVideoPlayerContext.mockReturnValue(null);
+        mockUseDatasetMediaWithReviewStatus.mockReturnValue({ fetchNextPage: mockFetchNextPage } as never);
+        mockUseFetchNextUnannotatedMediaItem.mockReturnValue({ data: { items: [] }, isPending: false } as never);
+        vi.clearAllMocks();
+    });
+
+    it('prefers the next unannotated media item over the positional next item', () => {
+        const items = getMultipleMockedMediaImage(3);
+        mockUseFetchNextUnannotatedMediaItem.mockReturnValue({
+            data: { items: [getMockedDatasetItem({ id: items[2].id })] },
+            isPending: false,
+        } as never);
+
+        const { result } = renderHook(() => useNextMediaItem(items[0], items));
+
+        expect(result.current).toEqual(items[2]);
+    });
+
+    it('falls back to the positional next item when every media item is annotated', () => {
+        const items = getMultipleMockedMediaImage(3);
+
+        const { result } = renderHook(() => useNextMediaItem(items[0], items));
+
+        expect(result.current).toEqual(items[1]);
+    });
+
+    it('ignores annotation status and advances by frame when the current item is a video frame', () => {
+        const frame = getMockedVideoFrame({ id: 'video-1', frame_number: 0, frame_count: 10 });
+        const nextImage = getMockedMediaImage({ id: 'image-1' });
+        mockUseFetchNextUnannotatedMediaItem.mockReturnValue({
+            data: { items: [getMockedDatasetItem({ id: nextImage.id })] },
+            isPending: false,
+        } as never);
+
+        const { result } = renderHook(() => useNextMediaItem(frame, [frame, nextImage]));
+
+        expect(result.current).toEqual({ ...frame, frame_number: 1 });
+    });
+
+    it('advances video frames using the step size from the video player context', () => {
+        mockUseVideoPlayerContext.mockReturnValue({ step: 60 } as never);
+        const frame = getMockedVideoFrame({ id: 'video-1', frame_number: 0, frame_count: 10 });
+
+        const { result } = renderHook(() => useNextMediaItem(frame, [frame]));
+
+        expect(result.current).toEqual({ ...frame, frame_number: 60 });
+    });
+
+    it('excludes the current item from the unannotated candidates', () => {
+        const items = getMultipleMockedMediaImage(2);
+        mockUseFetchNextUnannotatedMediaItem.mockReturnValue({
+            data: { items: [getMockedDatasetItem({ id: items[0].id })] },
+            isPending: false,
+        } as never);
+
+        const { result } = renderHook(() => useNextMediaItem(items[0], items));
+
+        expect(result.current).toEqual(items[1]);
+    });
+
+    it('fetches the next page when the next unannotated item is not among the already-fetched items', () => {
+        const alreadyFetchedItems = getMultipleMockedMediaImage(2);
+        const nextUnannotatedItem = getMockedDatasetItem({ id: 'not-loaded-item' });
+        const nextUnannotatedMediaImage = getMockedMediaImage({ id: nextUnannotatedItem.id });
+        mockUseFetchNextUnannotatedMediaItem.mockReturnValue({
+            data: { items: [nextUnannotatedItem] },
+            isPending: false,
+        } as never);
+
+        const { result, rerender } = renderHook(() => useNextMediaItem(alreadyFetchedItems[0], alreadyFetchedItems));
+
+        expect(mockFetchNextPage).toHaveBeenCalledTimes(1);
+
+        alreadyFetchedItems.push(nextUnannotatedMediaImage);
+
+        rerender();
+
+        expect(result.current).toEqual(nextUnannotatedMediaImage);
+    });
+
+    it('does not fetch the next page when the next unannotated item is already among the fetched items', () => {
+        const alreadyFetchedItems = getMultipleMockedMediaImage(2);
+        mockUseFetchNextUnannotatedMediaItem.mockReturnValue({
+            data: { items: [getMockedDatasetItem({ id: alreadyFetchedItems[1].id })] },
+            isPending: false,
+        } as never);
+
+        renderHook(() => useNextMediaItem(alreadyFetchedItems[0], alreadyFetchedItems));
+
+        expect(mockFetchNextPage).not.toHaveBeenCalled();
     });
 });
 

--- a/application/ui/src/features/dataset/media-preview/utils.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.ts
@@ -4,6 +4,8 @@
 import { useEffect, useMemo, useRef } from 'react';
 
 import { useQuery } from '@tanstack/react-query';
+import { useDatasetMediaWithReviewStatus } from 'hooks/use-dataset-media-with-review-status.hook';
+import { useFetchNextUnannotatedMediaItem } from 'hooks/use-get-dataset-items.hook';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { range } from 'lodash-es';
 import { useLocalStorage } from 'usehooks-ts';
@@ -54,13 +56,39 @@ export const getNextMediaItem = (currentMediaItem: Media, allMediaItems: Media[]
     return allMediaItems[currentIndex + 1];
 };
 
+const useNextUnannotatedMediaItem = (currentMediaItem: Media, allMediaItems: Media[]) => {
+    const { fetchNextPage } = useDatasetMediaWithReviewStatus();
+    const { data, isPending } = useFetchNextUnannotatedMediaItem();
+
+    const nextUnannotatedDatasetMediaItem = data?.items?.find((item) => item.id !== currentMediaItem.id);
+    const nextUnannotatedMediaItem = allMediaItems.find((item) => item.id === nextUnannotatedDatasetMediaItem?.id);
+    const isInsideFetchedMediaItems = nextUnannotatedMediaItem !== undefined;
+
+    useEffect(() => {
+        if (!isInsideFetchedMediaItems) {
+            fetchNextPage();
+        }
+    }, [isInsideFetchedMediaItems, fetchNextPage]);
+
+    if (isPending) {
+        return undefined;
+    }
+
+    return nextUnannotatedMediaItem;
+};
+
 export const useNextMediaItem = (currentMediaItem: Media, allMediaItems: Media[]) => {
     const context = useVideoPlayerContext();
     const step = context?.step ?? 1;
+    const nextUnannotatedMediaItem = useNextUnannotatedMediaItem(currentMediaItem, allMediaItems);
 
     return useMemo(() => {
-        return getNextMediaItem(currentMediaItem, allMediaItems, step);
-    }, [allMediaItems, currentMediaItem, step]);
+        if (isVideoFrame(currentMediaItem) || nextUnannotatedMediaItem === undefined) {
+            return getNextMediaItem(currentMediaItem, allMediaItems, step);
+        }
+
+        return nextUnannotatedMediaItem;
+    }, [allMediaItems, currentMediaItem, step, nextUnannotatedMediaItem]);
 };
 
 // When the user navigates to next media, image data and annotations will be already in React Query cache,

--- a/application/ui/src/features/dataset/media-preview/utils.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.ts
@@ -65,10 +65,12 @@ const useNextUnannotatedMediaItem = (currentMediaItem: Media, allMediaItems: Med
     const isInsideFetchedMediaItems = nextUnannotatedMediaItem !== undefined;
 
     useEffect(() => {
-        if (!isInsideFetchedMediaItems) {
-            fetchNextPage();
+        if (isPending || isInsideFetchedMediaItems) {
+            return;
         }
-    }, [isInsideFetchedMediaItems, fetchNextPage]);
+
+        fetchNextPage();
+    }, [isInsideFetchedMediaItems, fetchNextPage, isPending]);
 
     if (isPending) {
         return undefined;

--- a/application/ui/src/hooks/use-dataset-media-with-review-status.hook.ts
+++ b/application/ui/src/hooks/use-dataset-media-with-review-status.hook.ts
@@ -24,6 +24,9 @@ export const useDatasetMediaWithReviewStatus = () => {
 
     const datasetItemsResponse = useGetDatasetItemsById({
         annotationStatus: annotationStatus ?? undefined,
+        labelIds: isEmpty(selectedLabelIds) ? undefined : selectedLabelIds,
+        startDate: startDate ?? undefined,
+        endDate: endDate ?? undefined,
         sortDirection: sortDirection ?? undefined,
         subsets,
     });

--- a/application/ui/src/hooks/use-dataset-media-with-review-status.hook.ts
+++ b/application/ui/src/hooks/use-dataset-media-with-review-status.hook.ts
@@ -47,6 +47,7 @@ export const useDatasetMediaWithReviewStatus = () => {
 
     return {
         items: mediaItemsResponse.items,
+        datasetItems: datasetItemsResponse.items,
         // Wait for both the media-items and review-status queries to settle
         // before declaring "ready". Otherwise the gallery flashes thumbnails
         // first and pops in the annotation-status badges a moment later, which

--- a/application/ui/src/hooks/use-get-dataset-items-by-id.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-items-by-id.hook.ts
@@ -16,18 +16,32 @@ type UseGetDatasetItemsByIdOptions = {
     endDate?: string;
 };
 
-export const useGetDatasetItemsById = ({ annotationStatus, sortDirection, subsets }: UseGetDatasetItemsByIdOptions) => {
-    const { items, ...response } = useGetDatasetItems({ annotationStatus, sortDirection, subsets });
+export const useGetDatasetItemsById = ({
+    annotationStatus,
+    sortDirection,
+    subsets,
+    labelIds,
+    startDate,
+    endDate,
+}: UseGetDatasetItemsByIdOptions) => {
+    const datasetItemsQuery = useGetDatasetItems({
+        annotationStatus,
+        sortDirection,
+        subsets,
+        labelIds,
+        startDate,
+        endDate,
+    });
 
     const accumulatedReviewStatusRef = useRef(new Map<string, boolean>());
 
     const reviewStatus = useMemo(() => {
-        items.forEach(({ id, user_reviewed }) => {
+        datasetItemsQuery.items.forEach(({ id, user_reviewed }) => {
             accumulatedReviewStatusRef.current.set(id, user_reviewed);
         });
 
         return new Map(accumulatedReviewStatusRef.current);
-    }, [items]);
+    }, [datasetItemsQuery.items]);
 
-    return { reviewStatus, ...response };
+    return { reviewStatus, ...datasetItemsQuery };
 };

--- a/application/ui/src/hooks/use-get-dataset-items-by-id.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-items-by-id.hook.ts
@@ -11,6 +11,9 @@ type UseGetDatasetItemsByIdOptions = {
     annotationStatus?: DatasetItemAnnotationStatus;
     sortDirection?: SortDirection;
     subsets?: DatasetSubset[];
+    labelIds?: string[];
+    startDate?: string;
+    endDate?: string;
 };
 
 export const useGetDatasetItemsById = ({ annotationStatus, sortDirection, subsets }: UseGetDatasetItemsByIdOptions) => {

--- a/application/ui/src/hooks/use-get-dataset-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-items.hook.ts
@@ -30,6 +30,9 @@ export const useGetDatasetItems = ({ subsets, annotationStatus, sortDirection }:
         annotation_status?: DatasetItemAnnotationStatus;
         sort_direction?: SortDirection;
         sort_by?: SortBy;
+        labels?: string[];
+        start_date?: string;
+        end_date?: string;
     } = {
         offset: 0,
         limit: DATASET_ITEMS_LIMIT,
@@ -46,6 +49,18 @@ export const useGetDatasetItems = ({ subsets, annotationStatus, sortDirection }:
     if (sortDirection !== undefined) {
         query.sort_direction = sortDirection;
         query.sort_by = 'creation_date';
+    }
+
+    if (!isEmpty(labelIds)) {
+        query.labels = labelIds;
+    }
+
+    if (startDate !== undefined) {
+        query.start_date = startDate;
+    }
+
+    if (endDate !== undefined) {
+        query.end_date = endDate;
     }
 
     const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } = $api.useInfiniteQuery(

--- a/application/ui/src/hooks/use-get-dataset-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-items.hook.ts
@@ -30,6 +30,9 @@ const getDatasetItemsQueryOptions = ({
     annotationStatus,
     sortDirection,
     projectId,
+    labelIds,
+    startDate,
+    endDate,
 }: UseGetDatasetItemsOptions & { projectId: string }) => {
     const query: {
         offset: number;
@@ -38,6 +41,9 @@ const getDatasetItemsQueryOptions = ({
         annotation_status?: DatasetItemAnnotationStatus;
         sort_direction?: SortDirection;
         sort_by?: SortBy;
+        labels?: string[];
+        start_date?: string;
+        end_date?: string;
     } = {
         offset: 0,
         limit: DATASET_ITEMS_LIMIT,
@@ -54,6 +60,18 @@ const getDatasetItemsQueryOptions = ({
     if (sortDirection !== undefined) {
         query.sort_direction = sortDirection;
         query.sort_by = 'creation_date';
+    }
+
+    if (!isEmpty(labelIds)) {
+        query.labels = labelIds;
+    }
+
+    if (startDate !== undefined) {
+        query.start_date = startDate;
+    }
+
+    if (endDate !== undefined) {
+        query.end_date = endDate;
     }
 
     return $api.queryOptions('get', '/api/projects/{project_id}/dataset/items', {

--- a/application/ui/src/hooks/use-get-dataset-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-items.hook.ts
@@ -3,11 +3,13 @@
 
 import { useMemo } from 'react';
 
+import { useQuery } from '@tanstack/react-query';
 import { isEmpty } from 'lodash-es';
 
 import { $api } from '../api/client';
 import type { DatasetItemAnnotationStatus, DatasetSubset, Pagination } from '../constants/shared-types';
 import { type SortDirection } from './sort-direction.interface';
+import { useDatasetFiltersSearchParams } from './use-dataset-filters-search-params.hook';
 import { useProjectIdentifier } from './use-project-identifier.hook';
 
 const DATASET_ITEMS_LIMIT = 40;
@@ -18,9 +20,75 @@ type UseGetDatasetItemsOptions = {
     subsets?: DatasetSubset[];
     annotationStatus?: DatasetItemAnnotationStatus;
     sortDirection?: SortDirection;
+    labelIds?: string[];
+    startDate?: string;
+    endDate?: string;
 };
 
-export const useGetDatasetItems = ({ subsets, annotationStatus, sortDirection }: UseGetDatasetItemsOptions = {}) => {
+const getDatasetItemsQueryOptions = ({
+    subsets,
+    annotationStatus,
+    sortDirection,
+    projectId,
+}: UseGetDatasetItemsOptions & { projectId: string }) => {
+    const query: {
+        offset: number;
+        limit: number;
+        subsets?: DatasetSubset[];
+        annotation_status?: DatasetItemAnnotationStatus;
+        sort_direction?: SortDirection;
+        sort_by?: SortBy;
+    } = {
+        offset: 0,
+        limit: DATASET_ITEMS_LIMIT,
+    };
+
+    if (!isEmpty(subsets)) {
+        query.subsets = subsets;
+    }
+
+    if (annotationStatus !== undefined) {
+        query.annotation_status = annotationStatus;
+    }
+
+    if (sortDirection !== undefined) {
+        query.sort_direction = sortDirection;
+        query.sort_by = 'creation_date';
+    }
+
+    return $api.queryOptions('get', '/api/projects/{project_id}/dataset/items', {
+        params: {
+            query,
+            path: { project_id: projectId },
+        },
+    });
+};
+
+export const useFetchNextUnannotatedMediaItem = () => {
+    const projectId = useProjectIdentifier();
+
+    const { selectedSubsets, sortDirection, selectedLabelIds, startDate, endDate } = useDatasetFiltersSearchParams();
+    const queryOptions = getDatasetItemsQueryOptions({
+        subsets: selectedSubsets,
+        annotationStatus: 'missing_annotations',
+        sortDirection,
+        labelIds: selectedLabelIds,
+        startDate: startDate ?? undefined,
+        endDate: endDate ?? undefined,
+        projectId,
+    });
+
+    return useQuery(queryOptions);
+};
+
+export const useGetDatasetItems = ({
+    subsets,
+    annotationStatus,
+    sortDirection,
+    labelIds,
+    startDate,
+    endDate,
+}: UseGetDatasetItemsOptions = {}) => {
     const project_id = useProjectIdentifier();
 
     const query: {


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

1. It will open next unannotated media if such exists.
2. It won't open next unannotated frame (dataset items are created only for annotated frames, they are not created beforehand). We could fetch annotated frames and get unannotated based on that information but I didn't want to overcomplicate - to discuss.

In the next PR I'll add a notification when the last media is annotated that there are no more media to annotate.

Close #6711 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
