### PR TITLE
feat: Display pipeline health status

### DIFF
--- a/application/backend/app/api/routers/pipelines.py
+++ b/application/backend/app/api/routers/pipelines.py
@@ -145,11 +145,11 @@ def get_pipeline_health(
     source_status = source_status_service.get_status(source_id=pipeline.source_id) if pipeline.source_id else None
     sink_status = sink_status_service.get_status(sink_id=pipeline.sink_id) if pipeline.sink_id else None
     inference_status = inference_status_service.get_status(model_id=pipeline.model_id) if pipeline.model_id else None
-    if not source_status or not sink_status or not inference_status:
+    if not source_status or not inference_status:
         return PipelineHealth.idle()
     status = (
         PipelineStatus.ERROR
-        if source_status.is_error() or sink_status.is_error() or inference_status.is_error()
+        if source_status.is_error() or (sink_status.is_error() if sink_status else False) or inference_status.is_error()
         else PipelineStatus.RUNNING
     )
     return PipelineHealth.create(

--- a/application/backend/app/api/routers/pipelines.py
+++ b/application/backend/app/api/routers/pipelines.py
@@ -145,7 +145,7 @@ def get_pipeline_health(
     source_status = source_status_service.get_status(source_id=pipeline.source_id) if pipeline.source_id else None
     sink_status = sink_status_service.get_status(sink_id=pipeline.sink_id) if pipeline.sink_id else None
     inference_status = inference_status_service.get_status(model_id=pipeline.model_id) if pipeline.model_id else None
-    if not source_status or not inference_status:
+    if not source_status or not inference_status or (pipeline.sink_id and not sink_status):
         return PipelineHealth.idle()
     status = (
         PipelineStatus.ERROR

--- a/application/backend/tests/unit/api/routers/test_pipelines.py
+++ b/application/backend/tests/unit/api/routers/test_pipelines.py
@@ -176,6 +176,48 @@ class TestPipelineEndpoints:
         fxt_sink_status_service.get_status.assert_called_once_with(sink_id=sink_id)
         fxt_inference_status_service.get_status.assert_called_once_with(model_id=model_id)
 
+    def test_get_pipeline_health_running_without_sink(
+        self,
+        fxt_pipeline,
+        fxt_pipeline_service,
+        fxt_source_status_service,
+        fxt_sink_status_service,
+        fxt_inference_status_service,
+        fxt_client,
+    ):
+        """A sink is not required to run a pipeline: with no sink configured, health is 'running' as long as
+        source and model are healthy, and the sink component is reported as 'unavailable' rather than an error.
+        """
+        project_id = fxt_pipeline.project_id
+        source_id, model_id = uuid4(), uuid4()
+        running_pipeline = MagicMock()
+        running_pipeline.status = PipelineStatus.RUNNING
+        running_pipeline.source_id = source_id
+        running_pipeline.sink_id = None
+        running_pipeline.model_id = model_id
+        fxt_pipeline_service.get_pipeline_by_id.return_value = running_pipeline
+
+        fxt_source_status_service.get_status.return_value = SourceStatus(
+            code=SourceStatusCode.OK, source_id=source_id, message="streaming"
+        )
+        fxt_inference_status_service.get_status.return_value = InferenceWorkerStatus(
+            code=InferenceWorkerStatusCode.OK, model_id=model_id, message="inferring"
+        )
+
+        response = fxt_client.get(f"/api/projects/{project_id}/pipeline/health")
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data["status"] == PipelineStatus.RUNNING
+        assert response_data["components"]["source"]["status"] == SourceStatusCode.OK
+        assert response_data["components"]["sink"]["status"] == "unavailable"
+        assert response_data["components"]["model"]["status"] == InferenceWorkerStatusCode.OK
+
+        fxt_pipeline_service.get_pipeline_by_id.assert_called_once_with(project_id)
+        fxt_source_status_service.get_status.assert_called_once_with(source_id=source_id)
+        fxt_sink_status_service.get_status.assert_not_called()
+        fxt_inference_status_service.get_status.assert_called_once_with(model_id=model_id)
+
     def test_get_pipeline_health_error(
         self,
         fxt_pipeline,

--- a/application/backend/tests/unit/api/routers/test_pipelines.py
+++ b/application/backend/tests/unit/api/routers/test_pipelines.py
@@ -218,6 +218,47 @@ class TestPipelineEndpoints:
         fxt_sink_status_service.get_status.assert_not_called()
         fxt_inference_status_service.get_status.assert_called_once_with(model_id=model_id)
 
+    def test_get_pipeline_health_running_sink_status_missing(
+        self,
+        fxt_pipeline,
+        fxt_pipeline_service,
+        fxt_source_status_service,
+        fxt_sink_status_service,
+        fxt_inference_status_service,
+        fxt_client,
+    ):
+        """A sink is configured (sink_id set) but its status cannot be retrieved (e.g. sink was removed or is
+        misconfigured): health falls back to 'idle', even though source and model are healthy.
+        """
+        project_id = fxt_pipeline.project_id
+        source_id, sink_id, model_id = uuid4(), uuid4(), uuid4()
+        running_pipeline = MagicMock()
+        running_pipeline.status = PipelineStatus.RUNNING
+        running_pipeline.source_id = source_id
+        running_pipeline.sink_id = sink_id
+        running_pipeline.model_id = model_id
+        fxt_pipeline_service.get_pipeline_by_id.return_value = running_pipeline
+
+        fxt_source_status_service.get_status.return_value = SourceStatus(
+            code=SourceStatusCode.OK, source_id=source_id, message="streaming"
+        )
+        fxt_sink_status_service.get_status.return_value = None
+        fxt_inference_status_service.get_status.return_value = InferenceWorkerStatus(
+            code=InferenceWorkerStatusCode.OK, model_id=model_id, message="inferring"
+        )
+
+        response = fxt_client.get(f"/api/projects/{project_id}/pipeline/health")
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data["status"] == PipelineStatus.IDLE
+        assert response_data["components"] is None
+
+        fxt_pipeline_service.get_pipeline_by_id.assert_called_once_with(project_id)
+        fxt_source_status_service.get_status.assert_called_once_with(source_id=source_id)
+        fxt_sink_status_service.get_status.assert_called_once_with(sink_id=sink_id)
+        fxt_inference_status_service.get_status.assert_called_once_with(model_id=model_id)
+
     def test_get_pipeline_health_error(
         self,
         fxt_pipeline,

--- a/application/ui/mocks/mock-pipeline-health.ts
+++ b/application/ui/mocks/mock-pipeline-health.ts
@@ -1,0 +1,25 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { SchemaPipelineHealth, SchemaStatus } from './../src/api/openapi-spec.d';
+
+export const getMockedStatus = (customStatus?: Partial<SchemaStatus>): SchemaStatus => {
+    return {
+        status: 'ok',
+        updated_at: '2026-01-01T00:00:00Z',
+        message: null,
+        ...customStatus,
+    };
+};
+
+export const getMockedPipelineHealth = (customHealth?: Partial<SchemaPipelineHealth>): SchemaPipelineHealth => {
+    return {
+        status: 'running',
+        components: {
+            source: getMockedStatus(),
+            sink: getMockedStatus(),
+            model: getMockedStatus(),
+        },
+        ...customHealth,
+    };
+};

--- a/application/ui/mocks/mock-pipeline-health.ts
+++ b/application/ui/mocks/mock-pipeline-health.ts
@@ -1,9 +1,9 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { SchemaPipelineHealth, SchemaStatus } from './../src/api/openapi-spec.d';
+import type { PipelineHealth, PipelineStatus } from '../src/constants/shared-types';
 
-export const getMockedStatus = (customStatus?: Partial<SchemaStatus>): SchemaStatus => {
+export const getMockedStatus = (customStatus?: Partial<PipelineStatus>): PipelineStatus => {
     return {
         status: 'ok',
         updated_at: '2026-01-01T00:00:00Z',
@@ -12,7 +12,7 @@ export const getMockedStatus = (customStatus?: Partial<SchemaStatus>): SchemaSta
     };
 };
 
-export const getMockedPipelineHealth = (customHealth?: Partial<SchemaPipelineHealth>): SchemaPipelineHealth => {
+export const getMockedPipelineHealth = (customHealth?: Partial<PipelineHealth>): PipelineHealth => {
     return {
         status: 'running',
         components: {

--- a/application/ui/src/constants/shared-types.ts
+++ b/application/ui/src/constants/shared-types.ts
@@ -142,3 +142,7 @@ export type MediaWithPagination = components['schemas']['MediaWithPagination'];
 export type DatasetFormat = components['schemas']['DatasetFormat'];
 export type DeviceInfo = components['schemas']['DeviceInfoView'];
 export type MediaListPredictionRequest = components['schemas']['MediaListPredictionRequest'];
+
+export type PipelineHealth = components['schemas']['PipelineHealth'];
+export type PipelineComponentsHealth = components['schemas']['PipelineComponentsHealth'];
+export type PipelineStatus = components['schemas']['Status'];

--- a/application/ui/src/features/inference/footer/footer.component.tsx
+++ b/application/ui/src/features/inference/footer/footer.component.tsx
@@ -7,7 +7,7 @@ import { PipelineHealth } from './pipeline-health.component';
 
 export const Footer = () => {
     return (
-        <View backgroundColor={'gray-100'} paddingY={'size-150'} paddingX={'size-100'}>
+        <View gridArea={'footer'} backgroundColor={'gray-100'} paddingY={'size-150'} paddingX={'size-100'}>
             <PipelineHealth />
         </View>
     );

--- a/application/ui/src/features/inference/footer/footer.component.tsx
+++ b/application/ui/src/features/inference/footer/footer.component.tsx
@@ -7,7 +7,7 @@ import { PipelineHealth } from './pipeline-health.component';
 
 export const Footer = () => {
     return (
-        <View backgroundColor={'gray-100'} paddingY={'size-150'} paddingX={'size-300'}>
+        <View backgroundColor={'gray-100'} paddingY={'size-150'} paddingX={'size-100'}>
             <PipelineHealth />
         </View>
     );

--- a/application/ui/src/features/inference/footer/footer.component.tsx
+++ b/application/ui/src/features/inference/footer/footer.component.tsx
@@ -1,0 +1,14 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { View } from '@geti-ui/ui';
+
+import { PipelineHealth } from './pipeline-health.component';
+
+export const Footer = () => {
+    return (
+        <View backgroundColor={'gray-100'} paddingY={'size-150'} paddingX={'size-300'}>
+            <PipelineHealth />
+        </View>
+    );
+};

--- a/application/ui/src/features/inference/footer/pipeline-health.component.test.tsx
+++ b/application/ui/src/features/inference/footer/pipeline-health.component.test.tsx
@@ -1,0 +1,84 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { getMockedPipelineHealth, getMockedStatus } from 'mocks/mock-pipeline-health';
+import { HttpResponse } from 'msw';
+import { render } from 'test-utils/render';
+
+import { http } from '../../../api/utils';
+import { type PipelineHealth as PipelineHealthType } from '../../../constants/shared-types';
+import { server } from '../../../msw-node-setup';
+import { PipelineHealth } from './pipeline-health.component';
+
+const CONTEXTUAL_HELP_TRIGGER_NAME = 'Pipeline component health';
+
+const renderApp = (health: PipelineHealthType) => {
+    server.use(http.get('/api/projects/{project_id}/pipeline/health', () => HttpResponse.json(health)));
+
+    return render(<PipelineHealth />);
+};
+
+describe('PipelineHealth', () => {
+    it('shows "Running" without a contextual-help trigger when there are no component messages', async () => {
+        renderApp(
+            getMockedPipelineHealth({
+                status: 'running',
+                components: {
+                    source: getMockedStatus({ status: 'ok', message: null }),
+                    sink: getMockedStatus({ status: 'ok', message: null }),
+                    model: getMockedStatus({ status: 'ok', message: null }),
+                },
+            })
+        );
+
+        expect(await screen.findByRole('status')).toHaveTextContent('Running');
+        expect(screen.queryByRole('button', { name: CONTEXTUAL_HELP_TRIGGER_NAME })).not.toBeInTheDocument();
+    });
+
+    it('shows "Idle" without a contextual-help trigger and without components', async () => {
+        renderApp(getMockedPipelineHealth({ status: 'idle', components: null }));
+
+        expect(await screen.findByRole('status')).toHaveTextContent('Idle');
+        expect(screen.queryByRole('button', { name: CONTEXTUAL_HELP_TRIGGER_NAME })).not.toBeInTheDocument();
+    });
+
+    it('shows "Problems detected" with a contextual-help trigger when a component has a message', async () => {
+        renderApp(
+            getMockedPipelineHealth({
+                status: 'error',
+                components: {
+                    source: getMockedStatus({ status: 'error', message: 'Camera disconnected' }),
+                    sink: getMockedStatus({ status: 'ok' }),
+                    model: getMockedStatus({ status: 'ok' }),
+                },
+            })
+        );
+
+        expect(await screen.findByRole('status')).toHaveTextContent('Problems detected');
+
+        await userEvent.click(await screen.findByRole('button', { name: CONTEXTUAL_HELP_TRIGGER_NAME }));
+
+        const popover = await screen.findByRole('dialog');
+
+        expect(within(popover).getByText('Camera disconnected')).toBeVisible();
+        expect(within(popover).getAllByText('Healthy')).toHaveLength(2);
+    });
+
+    it('does not show a contextual-help trigger when error status has no component messages', async () => {
+        renderApp(
+            getMockedPipelineHealth({
+                status: 'error',
+                components: {
+                    source: getMockedStatus({ status: 'error', message: null }),
+                    sink: getMockedStatus({ status: 'ok' }),
+                    model: getMockedStatus({ status: 'ok' }),
+                },
+            })
+        );
+
+        expect(await screen.findByRole('status')).toHaveTextContent('Problems detected');
+        expect(screen.queryByRole('button', { name: CONTEXTUAL_HELP_TRIGGER_NAME })).not.toBeInTheDocument();
+    });
+});

--- a/application/ui/src/features/inference/footer/pipeline-health.component.tsx
+++ b/application/ui/src/features/inference/footer/pipeline-health.component.tsx
@@ -1,11 +1,23 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Content, ContextualHelp, Flex, StatusLight, Text } from '@geti-ui/ui';
+import {
+    ActionButton,
+    Content,
+    Dialog,
+    DialogTrigger,
+    dimensionValue,
+    Flex,
+    Grid,
+    StatusLight,
+    Text,
+} from '@geti-ui/ui';
+import { InfoOutline } from '@geti-ui/ui/icons';
 import { usePipelineHealth } from 'hooks/api/pipeline.hook';
+import { Fragment } from 'react/jsx-runtime';
 
 import { PipelineComponentsHealth } from '../../../constants/shared-types';
-import { getComponentStatusMeta, getOverallStatusMeta, hasComponentMessage } from './utils';
+import { getComponentStatusMeta, getOverallStatusMeta, shouldShowPipelineHealthDetails } from './utils';
 
 const COMPONENT_ORDER = ['source', 'sink', 'model'] as const;
 
@@ -15,28 +27,39 @@ const COMPONENT_LABELS: Record<(typeof COMPONENT_ORDER)[number], string> = {
     model: 'Model',
 };
 
-interface PipelineComponentsHelpProps {
+interface PipelineComponentsDetailsInfoProps {
     components: PipelineComponentsHealth;
 }
 
-const PipelineComponentsHelp = ({ components }: PipelineComponentsHelpProps) => {
+const PipelineComponentsDetailsInfo = ({ components }: PipelineComponentsDetailsInfoProps) => {
     return (
-        <ContextualHelp variant={'info'} aria-label={'Pipeline component health'}>
-            <Content>
-                <Flex direction={'column'} gap={'size-100'}>
-                    {COMPONENT_ORDER.map((key) => {
-                        const { label, variant } = getComponentStatusMeta(components[key]);
+        <DialogTrigger type={'popover'} placement={'top'}>
+            <ActionButton isQuiet aria-label={'Pipeline component health'}>
+                <InfoOutline />
+            </ActionButton>
+            <Dialog>
+                <Content>
+                    <Grid gap={'size-50'} columns={['max-content', 'max-content', 'auto']} alignContent={'start'}>
+                        {COMPONENT_ORDER.map((key) => {
+                            const { label, variant, message } = getComponentStatusMeta(components[key]);
 
-                        return (
-                            <Flex key={key} alignItems={'center'} gap={'size-100'}>
-                                <Text>{COMPONENT_LABELS[key]}</Text>
-                                <StatusLight variant={variant}>{label}</StatusLight>
-                            </Flex>
-                        );
-                    })}
-                </Flex>
-            </Content>
-        </ContextualHelp>
+                            return (
+                                <Fragment key={key}>
+                                    <Text>{COMPONENT_LABELS[key]}</Text>
+                                    <StatusLight
+                                        variant={variant}
+                                        UNSAFE_style={{ padding: 0, paddingRight: dimensionValue('size-50') }}
+                                    >
+                                        {label}
+                                    </StatusLight>
+                                    <Text marginStart={'size-150'}>{message}</Text>
+                                </Fragment>
+                            );
+                        })}
+                    </Grid>
+                </Content>
+            </Dialog>
+        </DialogTrigger>
     );
 };
 
@@ -49,15 +72,15 @@ export const PipelineHealth = () => {
 
     const { label, variant } = getOverallStatusMeta(data.status);
     const components = data.components;
-    const showComponentsHelp = components != null && hasComponentMessage(components);
+    const showPipelineHealthDetails = components != null && shouldShowPipelineHealthDetails(components);
 
     return (
-        <Flex alignItems={'center'} gap={'size-100'}>
-            <StatusLight role={'status'} variant={variant}>
+        <Flex alignItems={'center'} gap={'size-100'} height={'100%'}>
+            <StatusLight role='status' variant={variant} UNSAFE_style={{ padding: 0, alignItems: 'center' }}>
                 {label}
             </StatusLight>
 
-            {showComponentsHelp && <PipelineComponentsHelp components={components} />}
+            {showPipelineHealthDetails && <PipelineComponentsDetailsInfo components={components} />}
         </Flex>
     );
 };

--- a/application/ui/src/features/inference/footer/pipeline-health.component.tsx
+++ b/application/ui/src/features/inference/footer/pipeline-health.component.tsx
@@ -1,6 +1,8 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { Fragment } from 'react';
+
 import {
     ActionButton,
     Content,
@@ -14,7 +16,6 @@ import {
 } from '@geti-ui/ui';
 import { InfoOutline } from '@geti-ui/ui/icons';
 import { usePipelineHealth } from 'hooks/api/pipeline.hook';
-import { Fragment } from 'react/jsx-runtime';
 
 import { PipelineComponentsHealth } from '../../../constants/shared-types';
 import { getComponentStatusMeta, getOverallStatusMeta, shouldShowPipelineHealthDetails } from './utils';

--- a/application/ui/src/features/inference/footer/pipeline-health.component.tsx
+++ b/application/ui/src/features/inference/footer/pipeline-health.component.tsx
@@ -1,0 +1,63 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Content, ContextualHelp, Flex, StatusLight, Text } from '@geti-ui/ui';
+import { usePipelineHealth } from 'hooks/api/pipeline.hook';
+
+import { PipelineComponentsHealth } from '../../../constants/shared-types';
+import { getComponentStatusMeta, getOverallStatusMeta, hasComponentMessage } from './utils';
+
+const COMPONENT_ORDER = ['source', 'sink', 'model'] as const;
+
+const COMPONENT_LABELS: Record<(typeof COMPONENT_ORDER)[number], string> = {
+    source: 'Source',
+    sink: 'Sink',
+    model: 'Model',
+};
+
+interface PipelineComponentsHelpProps {
+    components: PipelineComponentsHealth;
+}
+
+const PipelineComponentsHelp = ({ components }: PipelineComponentsHelpProps) => {
+    return (
+        <ContextualHelp variant={'info'} aria-label={'Pipeline component health'}>
+            <Content>
+                <Flex direction={'column'} gap={'size-100'}>
+                    {COMPONENT_ORDER.map((key) => {
+                        const { label, variant } = getComponentStatusMeta(components[key]);
+
+                        return (
+                            <Flex key={key} alignItems={'center'} gap={'size-100'}>
+                                <Text>{COMPONENT_LABELS[key]}</Text>
+                                <StatusLight variant={variant}>{label}</StatusLight>
+                            </Flex>
+                        );
+                    })}
+                </Flex>
+            </Content>
+        </ContextualHelp>
+    );
+};
+
+export const PipelineHealth = () => {
+    const { data, isPending, isError } = usePipelineHealth();
+
+    if (isPending || isError) {
+        return null;
+    }
+
+    const { label, variant } = getOverallStatusMeta(data.status);
+    const components = data.components;
+    const showComponentsHelp = components != null && hasComponentMessage(components);
+
+    return (
+        <Flex alignItems={'center'} gap={'size-100'}>
+            <StatusLight role={'status'} variant={variant}>
+                {label}
+            </StatusLight>
+
+            {showComponentsHelp && <PipelineComponentsHelp components={components} />}
+        </Flex>
+    );
+};

--- a/application/ui/src/features/inference/footer/pipeline-health.component.tsx
+++ b/application/ui/src/features/inference/footer/pipeline-health.component.tsx
@@ -28,9 +28,9 @@ const COMPONENT_LABELS: Record<(typeof COMPONENT_ORDER)[number], string> = {
     model: 'Model',
 };
 
-interface PipelineComponentsDetailsInfoProps {
+type PipelineComponentsDetailsInfoProps = {
     components: PipelineComponentsHealth;
-}
+};
 
 const PipelineComponentsDetailsInfo = ({ components }: PipelineComponentsDetailsInfoProps) => {
     return (

--- a/application/ui/src/features/inference/footer/utils.test.ts
+++ b/application/ui/src/features/inference/footer/utils.test.ts
@@ -1,0 +1,107 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import type { SchemaStatus } from '../../../api/openapi-spec';
+import { getComponentStatusMeta, getOverallStatusMeta, hasComponentMessage } from './utils';
+
+const getStatus = (custom?: Partial<SchemaStatus>): SchemaStatus => ({
+    status: 'ok',
+    updated_at: '2026-01-01T00:00:00Z',
+    message: null,
+    ...custom,
+});
+
+describe('getOverallStatusMeta', () => {
+    it.each([
+        ['running', 'Running', 'positive'],
+        ['idle', 'Idle', 'neutral'],
+        ['error', 'Problems detected', 'negative'],
+    ])('maps known status "%s" to label "%s" and variant "%s"', (status, label, variant) => {
+        expect(getOverallStatusMeta(status)).toEqual({ label, variant });
+    });
+
+    it('falls back to a capitalized label and neutral variant for an unknown status', () => {
+        expect(getOverallStatusMeta('mystery_state')).toEqual({ label: 'Mystery_state', variant: 'neutral' });
+    });
+});
+
+describe('getComponentStatusMeta', () => {
+    it.each([
+        ['ok', 'Healthy', 'positive'],
+        ['finished', 'Finished', 'info'],
+        ['unavailable', 'Unavailable', 'neutral'],
+        ['error', 'Error', 'negative'],
+    ])('maps known status "%s" (no message) to label "%s" and variant "%s"', (status, label, variant) => {
+        expect(getComponentStatusMeta(getStatus({ status, message: null }))).toEqual({ label, variant });
+    });
+
+    it('falls back to a capitalized label and neutral variant for an unknown status', () => {
+        expect(getComponentStatusMeta(getStatus({ status: 'mystery_state', message: null }))).toEqual({
+            label: 'Mystery_state',
+            variant: 'neutral',
+        });
+    });
+
+    it('prefers the raw message over the friendly status label when a message is present', () => {
+        const component = getStatus({ status: 'error', message: 'Connection refused' });
+
+        expect(getComponentStatusMeta(component)).toEqual({ label: 'Connection refused', variant: 'negative' });
+    });
+
+    it('falls back to the friendly "Error" label when status is error but message is null', () => {
+        const component = getStatus({ status: 'error', message: null });
+
+        expect(getComponentStatusMeta(component)).toEqual({ label: 'Error', variant: 'negative' });
+    });
+});
+
+describe('hasComponentMessage', () => {
+    it('returns false when components is null', () => {
+        expect(hasComponentMessage(null)).toBe(false);
+    });
+
+    it('returns false when components is undefined', () => {
+        expect(hasComponentMessage(undefined)).toBe(false);
+    });
+
+    it('returns false when no component has a message', () => {
+        expect(
+            hasComponentMessage({
+                source: getStatus({ message: null }),
+                sink: getStatus({ message: null }),
+                model: getStatus({ message: null }),
+            })
+        ).toBe(false);
+    });
+
+    it('returns false when status is error but the message is null (edge case)', () => {
+        expect(
+            hasComponentMessage({
+                source: getStatus({ status: 'error', message: null }),
+                sink: getStatus({ message: null }),
+                model: getStatus({ message: null }),
+            })
+        ).toBe(false);
+    });
+
+    it.each(['source', 'sink', 'model'] as const)('returns true when the %s component has a message', (key) => {
+        expect(
+            hasComponentMessage({
+                source: getStatus({ message: null }),
+                sink: getStatus({ message: null }),
+                model: getStatus({ message: null }),
+                [key]: getStatus({ status: 'error', message: 'Something went wrong' }),
+            })
+        ).toBe(true);
+    });
+
+    it('returns true when multiple components have messages simultaneously', () => {
+        expect(
+            hasComponentMessage({
+                source: getStatus({ status: 'error', message: 'Camera disconnected' }),
+                sink: getStatus({ message: null }),
+                model: getStatus({ status: 'error', message: 'Model load failed' }),
+            })
+        ).toBe(true);
+    });
+});

--- a/application/ui/src/features/inference/footer/utils.test.ts
+++ b/application/ui/src/features/inference/footer/utils.test.ts
@@ -1,10 +1,10 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import type { SchemaStatus } from '../../../api/openapi-spec';
-import { getComponentStatusMeta, getOverallStatusMeta, hasComponentMessage } from './utils';
+import { PipelineStatus } from '../../../constants/shared-types';
+import { getComponentStatusMeta, getOverallStatusMeta, shouldShowPipelineHealthDetails } from './utils';
 
-const getStatus = (custom?: Partial<SchemaStatus>): SchemaStatus => ({
+const getStatus = (custom?: Partial<PipelineStatus>): PipelineStatus => ({
     status: 'ok',
     updated_at: '2026-01-01T00:00:00Z',
     message: null,
@@ -32,41 +32,46 @@ describe('getComponentStatusMeta', () => {
         ['unavailable', 'Unavailable', 'neutral'],
         ['error', 'Error', 'negative'],
     ])('maps known status "%s" (no message) to label "%s" and variant "%s"', (status, label, variant) => {
-        expect(getComponentStatusMeta(getStatus({ status, message: null }))).toEqual({ label, variant });
+        expect(getComponentStatusMeta(getStatus({ status, message: null }))).toEqual({ label, variant, message: null });
     });
 
     it('falls back to a capitalized label and neutral variant for an unknown status', () => {
         expect(getComponentStatusMeta(getStatus({ status: 'mystery_state', message: null }))).toEqual({
             label: 'Mystery_state',
             variant: 'neutral',
+            message: null,
         });
     });
 
     it('prefers the raw message over the friendly status label when a message is present', () => {
         const component = getStatus({ status: 'error', message: 'Connection refused' });
 
-        expect(getComponentStatusMeta(component)).toEqual({ label: 'Connection refused', variant: 'negative' });
+        expect(getComponentStatusMeta(component)).toEqual({
+            label: 'Error',
+            variant: 'negative',
+            message: 'Connection refused',
+        });
     });
 
     it('falls back to the friendly "Error" label when status is error but message is null', () => {
         const component = getStatus({ status: 'error', message: null });
 
-        expect(getComponentStatusMeta(component)).toEqual({ label: 'Error', variant: 'negative' });
+        expect(getComponentStatusMeta(component)).toEqual({ label: 'Error', variant: 'negative', message: null });
     });
 });
 
-describe('hasComponentMessage', () => {
+describe('shouldShowPipelineHealthDetails', () => {
     it('returns false when components is null', () => {
-        expect(hasComponentMessage(null)).toBe(false);
+        expect(shouldShowPipelineHealthDetails(null)).toBe(false);
     });
 
     it('returns false when components is undefined', () => {
-        expect(hasComponentMessage(undefined)).toBe(false);
+        expect(shouldShowPipelineHealthDetails(undefined)).toBe(false);
     });
 
     it('returns false when no component has a message', () => {
         expect(
-            hasComponentMessage({
+            shouldShowPipelineHealthDetails({
                 source: getStatus({ message: null }),
                 sink: getStatus({ message: null }),
                 model: getStatus({ message: null }),
@@ -76,7 +81,7 @@ describe('hasComponentMessage', () => {
 
     it('returns false when status is error but the message is null (edge case)', () => {
         expect(
-            hasComponentMessage({
+            shouldShowPipelineHealthDetails({
                 source: getStatus({ status: 'error', message: null }),
                 sink: getStatus({ message: null }),
                 model: getStatus({ message: null }),
@@ -86,7 +91,7 @@ describe('hasComponentMessage', () => {
 
     it.each(['source', 'sink', 'model'] as const)('returns true when the %s component has a message', (key) => {
         expect(
-            hasComponentMessage({
+            shouldShowPipelineHealthDetails({
                 source: getStatus({ message: null }),
                 sink: getStatus({ message: null }),
                 model: getStatus({ message: null }),
@@ -97,7 +102,7 @@ describe('hasComponentMessage', () => {
 
     it('returns true when multiple components have messages simultaneously', () => {
         expect(
-            hasComponentMessage({
+            shouldShowPipelineHealthDetails({
                 source: getStatus({ status: 'error', message: 'Camera disconnected' }),
                 sink: getStatus({ message: null }),
                 model: getStatus({ status: 'error', message: 'Model load failed' }),

--- a/application/ui/src/features/inference/footer/utils.ts
+++ b/application/ui/src/features/inference/footer/utils.ts
@@ -1,0 +1,54 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import type { StatusLightProps } from '@geti-ui/ui';
+import { capitalize } from 'lodash-es';
+
+import { PipelineComponentsHealth, PipelineStatus } from '../../../constants/shared-types';
+
+export type StatusVariant = StatusLightProps['variant'];
+
+export interface StatusMeta {
+    label: string;
+    variant: StatusVariant;
+}
+
+export const getOverallStatusMeta = (status: string): StatusMeta => {
+    switch (status) {
+        case 'running':
+            return { label: 'Running', variant: 'positive' };
+        case 'idle':
+            return { label: 'Idle', variant: 'neutral' };
+        case 'error':
+            return { label: 'Problems detected', variant: 'negative' };
+        default:
+            return { label: capitalize(status), variant: 'neutral' };
+    }
+};
+
+export const getComponentStatusMeta = (component: PipelineStatus): StatusMeta => {
+    if (component.message != null) {
+        return { label: component.message, variant: 'negative' };
+    }
+
+    switch (component.status) {
+        case 'ok':
+            return { label: 'Healthy', variant: 'positive' };
+        case 'finished':
+            return { label: 'Finished', variant: 'info' };
+        case 'unavailable':
+            return { label: 'Unavailable', variant: 'neutral' };
+        case 'error':
+            return { label: 'Error', variant: 'negative' };
+        default:
+            return { label: capitalize(component.status), variant: 'neutral' };
+    }
+};
+
+export const hasComponentMessage = (components: PipelineComponentsHealth | null | undefined): boolean => {
+    if (components == null) {
+        return false;
+    }
+
+    return [components.source, components.sink, components.model].some((component) => component.message != null);
+};

--- a/application/ui/src/features/inference/footer/utils.ts
+++ b/application/ui/src/features/inference/footer/utils.ts
@@ -14,10 +14,10 @@ export type ComponentStatusMeta = {
     message: string | null | undefined;
 };
 
-export interface StatusMeta {
+export type StatusMeta = {
     label: string;
     variant: StatusVariant;
-}
+};
 
 export const getOverallStatusMeta = (status: string): StatusMeta => {
     switch (status) {

--- a/application/ui/src/features/inference/footer/utils.ts
+++ b/application/ui/src/features/inference/footer/utils.ts
@@ -47,14 +47,6 @@ export const getComponentStatusMeta = (component: PipelineStatus): ComponentStat
     }
 };
 
-export const hasComponentMessage = (components: PipelineComponentsHealth | null | undefined): boolean => {
-    if (components == null) {
-        return false;
-    }
-
-    return [components.source, components.sink, components.model].some((component) => component.message != null);
-};
-
 export const shouldShowPipelineHealthDetails = (components: PipelineComponentsHealth | null | undefined): boolean => {
     if (components == null) {
         return false;

--- a/application/ui/src/features/inference/footer/utils.ts
+++ b/application/ui/src/features/inference/footer/utils.ts
@@ -8,6 +8,12 @@ import { PipelineComponentsHealth, PipelineStatus } from '../../../constants/sha
 
 export type StatusVariant = StatusLightProps['variant'];
 
+export type ComponentStatusMeta = {
+    label: string;
+    variant: StatusVariant;
+    message: string | null | undefined;
+};
+
 export interface StatusMeta {
     label: string;
     variant: StatusVariant;
@@ -26,26 +32,30 @@ export const getOverallStatusMeta = (status: string): StatusMeta => {
     }
 };
 
-export const getComponentStatusMeta = (component: PipelineStatus): StatusMeta => {
-    if (component.message != null) {
-        return { label: component.message, variant: 'negative' };
-    }
-
+export const getComponentStatusMeta = (component: PipelineStatus): ComponentStatusMeta => {
     switch (component.status) {
         case 'ok':
-            return { label: 'Healthy', variant: 'positive' };
+            return { label: 'Healthy', variant: 'positive', message: component.message };
         case 'finished':
-            return { label: 'Finished', variant: 'info' };
+            return { label: 'Finished', variant: 'info', message: component.message };
         case 'unavailable':
-            return { label: 'Unavailable', variant: 'neutral' };
+            return { label: 'Unavailable', variant: 'neutral', message: component.message };
         case 'error':
-            return { label: 'Error', variant: 'negative' };
+            return { label: 'Error', variant: 'negative', message: component.message };
         default:
-            return { label: capitalize(component.status), variant: 'neutral' };
+            return { label: capitalize(component.status), variant: 'neutral', message: component.message };
     }
 };
 
 export const hasComponentMessage = (components: PipelineComponentsHealth | null | undefined): boolean => {
+    if (components == null) {
+        return false;
+    }
+
+    return [components.source, components.sink, components.model].some((component) => component.message != null);
+};
+
+export const shouldShowPipelineHealthDetails = (components: PipelineComponentsHealth | null | undefined): boolean => {
     if (components == null) {
         return false;
     }

--- a/application/ui/src/hooks/api/pipeline.hook.ts
+++ b/application/ui/src/hooks/api/pipeline.hook.ts
@@ -61,6 +61,7 @@ export const usePipelineHealth = () => {
         },
         {
             refetchInterval: POLLING_INTERVAL,
+            retry: false,
         }
     );
 };

--- a/application/ui/src/hooks/api/pipeline.hook.ts
+++ b/application/ui/src/hooks/api/pipeline.hook.ts
@@ -50,6 +50,21 @@ export const usePipelineMetrics = () => {
     );
 };
 
+export const usePipelineHealth = () => {
+    const projectId = useProjectIdentifier();
+
+    return $api.useQuery(
+        'get',
+        '/api/projects/{project_id}/pipeline/health',
+        {
+            params: { path: { project_id: projectId } },
+        },
+        {
+            refetchInterval: POLLING_INTERVAL,
+        }
+    );
+};
+
 export const usePatchPipeline = () => {
     const queryClient = useQueryClient();
 

--- a/application/ui/src/routes/inference/inference.tsx
+++ b/application/ui/src/routes/inference/inference.tsx
@@ -5,19 +5,20 @@ import { Grid } from '@geti-ui/ui';
 
 import { ZoomProvider } from '../../components/zoom/zoom.provider';
 import { Sidebar } from '../../features/inference/aside/sidebar-tabs.component';
+import { Footer } from '../../features/inference/footer/footer.component';
 import { Header } from '../../features/inference/header/inference-header.component';
 import { StreamContainer } from '../../features/inference/stream/stream-container';
 
 export const Inference = () => {
     return (
         <Grid
-            areas={['toolbar aside', 'canvas aside']}
+            areas={['toolbar aside', 'canvas aside', 'footer aside']}
+            rows={['size-800', 'minmax(0, 1fr)', 'size-600']}
+            columns={['minmax(0, 1fr)', 'auto']}
+            height={'100%'}
+            gap={'size-10'}
             UNSAFE_style={{
-                gridTemplateRows: 'var(--spectrum-global-dimension-size-800, 4rem) minmax(0, 1fr)',
-                gridTemplateColumns: 'minmax(0, 1fr) auto',
-                height: '100%',
                 overflow: 'hidden',
-                gap: 'var(--spectrum-global-dimension-size-10)',
             }}
         >
             <Header />
@@ -25,6 +26,7 @@ export const Inference = () => {
                 <StreamContainer />
             </ZoomProvider>
             <Sidebar />
+            <Footer />
         </Grid>
     );
 };

--- a/application/ui/tests/fixtures.ts
+++ b/application/ui/tests/fixtures.ts
@@ -212,6 +212,16 @@ const test = testBase.extend<Fixtures>({
                     http.get('/api/sinks', () => {
                         return HttpResponse.json([]);
                     }),
+                    http.get('/api/projects/{project_id}/pipeline/health', () => {
+                        return HttpResponse.json({
+                            status: 'running',
+                            components: {
+                                source: { status: 'ok', updated_at: '2026-01-01T00:00:00Z', message: null },
+                                sink: { status: 'ok', updated_at: '2026-01-01T00:00:00Z', message: null },
+                                model: { status: 'ok', updated_at: '2026-01-01T00:00:00Z', message: null },
+                            },
+                        });
+                    }),
                 ],
             });
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

1. Fixes server to return status when sink is not configured (sink is not required to run pipeline).
2. Adds UI to display health status.
3. Use polling to fetch the health status - will check how much effort will need to change to SSE (in a separate PR).

<img width="806" height="268" alt="image" src="https://github.com/user-attachments/assets/540abf62-4584-4fc0-b207-7d58e832a7ff" />
<img width="573" height="266" alt="image" src="https://github.com/user-attachments/assets/64cecbc5-efd2-4342-8f76-3991d8512a6b" />
<img width="563" height="279" alt="image" src="https://github.com/user-attachments/assets/41b30d27-07e6-404b-88f2-3b8cc4a949ff" />

Close #6593 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
