### PR TITLE
feat: Add source and sink validation when creating and updating

### DIFF
--- a/application/backend/app/api/routers/sinks.py
+++ b/application/backend/app/api/routers/sinks.py
@@ -18,6 +18,7 @@ from app.api.schemas.test_result import TestResult
 from app.models import Sink
 from app.services import (
     ResourceInUseError,
+    ResourceValidationError,
     ResourceWithIdAlreadyExistsError,
     ResourceWithNameAlreadyExistsError,
     SinkService,
@@ -93,7 +94,11 @@ def create_sink(
     ],
     sink_service: Annotated[SinkService, Depends(get_sink_service)],
 ) -> SinkView:
-    """Create and configure a new sink"""
+    """Create and configure a new sink.
+
+    Returns 422 if the request body fails validation, or if the sink configuration
+    is well-formed but not reachable (e.g. missing output folder, unreachable broker).
+    """
     try:
         sink = sink_service.create_sink(
             name=sink_create.name,
@@ -106,6 +111,8 @@ def create_sink(
         return SinkViewAdapter.validate_python(sink, from_attributes=True)
     except (ResourceWithNameAlreadyExistsError, ResourceWithIdAlreadyExistsError) as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+    except ResourceValidationError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
 
 
 @router.get(
@@ -155,7 +162,12 @@ def update_sink(
     ],
     sink_service: Annotated[SinkService, Depends(get_sink_service)],
 ) -> SinkView:
-    """Reconfigure an existing sink"""
+    """Reconfigure an existing sink.
+
+    Returns 422 if the request body fails validation, or if the updated sink
+    configuration is well-formed but not reachable (e.g. missing output folder,
+    unreachable broker).
+    """
     if "sink_type" in sink_config:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="The 'sink_type' field cannot be changed")
     try:
@@ -173,6 +185,8 @@ def update_sink(
         return SinkViewAdapter.validate_python(sink, from_attributes=True)
     except ResourceWithNameAlreadyExistsError as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+    except ResourceValidationError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
 
 
 @router.post(
@@ -233,6 +247,8 @@ def import_sink(
     except (ResourceWithNameAlreadyExistsError, ResourceWithIdAlreadyExistsError) as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
     except ValidationError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
+    except ResourceValidationError as e:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
 
 

--- a/application/backend/app/api/routers/sources.py
+++ b/application/backend/app/api/routers/sources.py
@@ -18,6 +18,7 @@ from app.api.schemas.test_result import TestResult
 from app.models import Source
 from app.services import (
     ResourceInUseError,
+    ResourceValidationError,
     ResourceWithIdAlreadyExistsError,
     ResourceWithNameAlreadyExistsError,
     SourceUpdateService,
@@ -109,7 +110,11 @@ def create_source(
     ],
     source_update_service: Annotated[SourceUpdateService, Depends(get_source_update_service)],
 ) -> SourceView:
-    """Create and configure a new source"""
+    """Create and configure a new source.
+
+    Returns 422 if the request body fails validation, or if the source configuration
+    is well-formed but not reachable (e.g. missing video file, unreachable camera).
+    """
     try:
         source = source_update_service.create_source(
             name=source_create.name,
@@ -120,6 +125,8 @@ def create_source(
         return SourceViewAdapter.validate_python(source, from_attributes=True)
     except (ResourceWithNameAlreadyExistsError, ResourceWithIdAlreadyExistsError) as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+    except ResourceValidationError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
 
 
 @router.get(
@@ -169,7 +176,12 @@ def update_source(
     ],
     source_update_service: Annotated[SourceUpdateService, Depends(get_source_update_service)],
 ) -> SourceView:
-    """Reconfigure an existing source"""
+    """Reconfigure an existing source.
+
+    Returns 422 if the request body fails validation, or if the updated source
+    configuration is well-formed but not reachable (e.g. missing video file,
+    unreachable camera).
+    """
     if "source_type" in source_config:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="The 'source_type' field cannot be changed")
 
@@ -186,6 +198,8 @@ def update_source(
         return SourceViewAdapter.validate_python(source, from_attributes=True)
     except ResourceWithNameAlreadyExistsError as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+    except ResourceValidationError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
 
 
 @router.post(
@@ -244,6 +258,8 @@ def import_source(
     except (ResourceWithNameAlreadyExistsError, ResourceWithIdAlreadyExistsError) as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
     except ValidationError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
+    except ResourceValidationError as e:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
 
 

--- a/application/backend/app/services/__init__.py
+++ b/application/backend/app/services/__init__.py
@@ -7,6 +7,7 @@ from .base import (
     ResourceInUseError,
     ResourceNotFoundError,
     ResourceType,
+    ResourceValidationError,
     ResourceWithIdAlreadyExistsError,
     ResourceWithNameAlreadyExistsError,
 )
@@ -54,6 +55,7 @@ __all__ = [
     "ResourceInUseError",
     "ResourceNotFoundError",
     "ResourceType",
+    "ResourceValidationError",
     "ResourceWithIdAlreadyExistsError",
     "ResourceWithNameAlreadyExistsError",
     "SinkService",

--- a/application/backend/app/services/base.py
+++ b/application/backend/app/services/base.py
@@ -64,6 +64,14 @@ class ResourceWithIdAlreadyExistsError(ResourceError):
         super().__init__(resource_type, resource_id, msg)
 
 
+class ResourceValidationError(ResourceError):
+    """Exception raised when a resource is well-formed but not reachable/usable."""
+
+    def __init__(self, resource_type: ResourceType, resource_id: str, message: str | None = None):
+        msg = message or f"{resource_type} is not reachable."
+        super().__init__(resource_type, resource_id, msg)
+
+
 class BaseSessionManagedService(ABC):
     """
     Base class for services that require a managed database session.

--- a/application/backend/app/services/sink_service.py
+++ b/application/backend/app/services/sink_service.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 import time
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
@@ -18,6 +18,7 @@ from .base import (
     ResourceInUseError,
     ResourceNotFoundError,
     ResourceType,
+    ResourceValidationError,
     ResourceWithIdAlreadyExistsError,
     ResourceWithNameAlreadyExistsError,
 )
@@ -30,6 +31,29 @@ class SinkService:
         self._event_bus: EventBus = event_bus
         self._db_session = db_session
 
+    def _validate_candidate(
+        self,
+        *,
+        sink_id: UUID,
+        name: str,
+        sink_type: SinkType,
+        rate_limit: float | None,
+        config_data: SinkConfig,
+        output_formats: list[OutputFormat],
+    ) -> None:
+        """Assemble the post-change Sink and validate that it is reachable."""
+        candidate = SinkAdapter.validate_python(
+            {
+                "id": sink_id,
+                "name": name,
+                "sink_type": sink_type,
+                "rate_limit": rate_limit,
+                "output_formats": output_formats,
+                "config_data": config_data,
+            }
+        )
+        self.validate_sink(candidate)
+
     @parent_process_only
     def create_sink(
         self,
@@ -40,6 +64,14 @@ class SinkService:
         output_formats: list[OutputFormat],
         sink_id: UUID | None = None,
     ) -> Sink:
+        self._validate_candidate(
+            sink_id=sink_id or uuid4(),
+            name=name,
+            sink_type=sink_type,
+            rate_limit=rate_limit,
+            config_data=config_data,
+            output_formats=output_formats,
+        )
         try:
             db_sink = SinkRepository(self._db_session).save(
                 SinkDB(
@@ -66,6 +98,14 @@ class SinkService:
         new_config_data: SinkConfig,
         new_output_formats: list[OutputFormat],
     ) -> Sink:
+        self._validate_candidate(
+            sink_id=sink.id,
+            name=new_name,
+            sink_type=sink.sink_type,
+            rate_limit=new_rate_limit,
+            config_data=new_config_data,
+            output_formats=new_output_formats,
+        )
         try:
             sink_repo = SinkRepository(self._db_session)
             db_sink = sink_repo.update(
@@ -131,8 +171,9 @@ class SinkService:
 
     _TEST_TIMEOUT_SECONDS = 5
 
-    def test_sink(self, sink: Sink) -> SinkTestResult:
-        """Perform a connectivity check on the sink."""
+    def _probe_reachability(self, sink: Sink) -> SinkTestResult:
+        """Attempt to connect to the sink's destination. Never raises; failures are reported
+        via the returned result's `reachable`/`error` fields."""
         try:
             destination = DispatchService.get_destination(sink)
             if destination is None:
@@ -144,3 +185,24 @@ class SinkService:
             return SinkTestResult.success(latency_ms=round(elapsed_ms, 1))
         except Exception as e:
             return SinkTestResult.failure(str(e))
+
+    def test_sink(self, sink: Sink) -> SinkTestResult:
+        """Perform a connectivity check on the sink."""
+        return self._probe_reachability(sink)
+
+    def validate_sink(self, sink: Sink) -> None:
+        """Raise ResourceValidationError if the sink cannot be reached/used.
+
+        Reuses the same probe as `test_sink`; the resulting error message is expected
+        to already be a complete, user-facing sentence (see dispatcher `test()` methods).
+
+        ROS output is a known platform limitation (not implemented yet, see
+        DispatchService), not a user configuration error: the probe would always report
+        it as unreachable regardless of the supplied config, so create/update validation
+        is skipped for ROS sinks. Use `:test` to confirm ROS connectivity behavior.
+        """
+        if sink.sink_type == SinkType.ROS:
+            return
+        result = self._probe_reachability(sink)
+        if not result.reachable:
+            raise ResourceValidationError(ResourceType.SINK, str(sink.id), result.error)

--- a/application/backend/app/services/sink_service.py
+++ b/application/backend/app/services/sink_service.py
@@ -64,8 +64,9 @@ class SinkService:
         output_formats: list[OutputFormat],
         sink_id: UUID | None = None,
     ) -> Sink:
+        effective_sink_id = sink_id or uuid4()
         self._validate_candidate(
-            sink_id=sink_id or uuid4(),
+            sink_id=effective_sink_id,
             name=name,
             sink_type=sink_type,
             rate_limit=rate_limit,
@@ -75,7 +76,7 @@ class SinkService:
         try:
             db_sink = SinkRepository(self._db_session).save(
                 SinkDB(
-                    id=str(sink_id) if sink_id is not None else None,
+                    id=str(effective_sink_id),
                     name=name,
                     sink_type=sink_type,
                     rate_limit=rate_limit,

--- a/application/backend/app/services/source_service.py
+++ b/application/backend/app/services/source_service.py
@@ -154,10 +154,13 @@ class SourceUpdateService(SourceService):
         config_data: SourceConfig,
         source_id: UUID | None = None,
     ) -> Source:
+        effective_source_id = source_id or uuid4()
         self._validate_candidate(
-            source_id=source_id or uuid4(), name=name, source_type=source_type, config_data=config_data
+            source_id=effective_source_id, name=name, source_type=source_type, config_data=config_data
         )
-        return super().create_source(name=name, source_type=source_type, config_data=config_data, source_id=source_id)
+        return super().create_source(
+            name=name, source_type=source_type, config_data=config_data, source_id=effective_source_id
+        )
 
     @parent_process_only
     def update_source(

--- a/application/backend/app/services/source_service.py
+++ b/application/backend/app/services/source_service.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 import time
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from loguru import logger
 from sqlalchemy.exc import IntegrityError
@@ -18,6 +18,7 @@ from .base import (
     ResourceInUseError,
     ResourceNotFoundError,
     ResourceType,
+    ResourceValidationError,
     ResourceWithIdAlreadyExistsError,
     ResourceWithNameAlreadyExistsError,
 )
@@ -126,6 +127,38 @@ class SourceUpdateService(SourceService):
         self._event_bus: EventBus = event_bus
         super().__init__(db_session, source_media_service)
 
+    def _validate_candidate(
+        self,
+        *,
+        source_id: UUID,
+        name: str,
+        source_type: SourceType,
+        config_data: SourceConfig,
+    ) -> None:
+        """Assemble the post-change Source and validate that it is reachable."""
+        candidate = SourceAdapter.validate_python(
+            {
+                "id": source_id,
+                "name": name,
+                "source_type": source_type,
+                "config_data": config_data,
+            }
+        )
+        self.validate_source(candidate)
+
+    @parent_process_only
+    def create_source(
+        self,
+        name: str,
+        source_type: SourceType,
+        config_data: SourceConfig,
+        source_id: UUID | None = None,
+    ) -> Source:
+        self._validate_candidate(
+            source_id=source_id or uuid4(), name=name, source_type=source_type, config_data=config_data
+        )
+        return super().create_source(name=name, source_type=source_type, config_data=config_data, source_id=source_id)
+
     @parent_process_only
     def update_source(
         self,
@@ -133,6 +166,9 @@ class SourceUpdateService(SourceService):
         new_name: str,
         new_config_data: SourceConfig,
     ) -> Source:
+        self._validate_candidate(
+            source_id=source.id, name=new_name, source_type=source.source_type, config_data=new_config_data
+        )
         try:
             source_repo = SourceRepository(self._db_session)
             db_source = source_repo.update(
@@ -159,8 +195,9 @@ class SourceUpdateService(SourceService):
 
     _TEST_TIMEOUT_MS = 5000
 
-    def test_source(self, source: Source) -> SourceTestResult:
-        """Perform a connectivity check on the source."""
+    def _probe_reachability(self, source: Source) -> SourceTestResult:
+        """Attempt to open the source and read one frame. Never raises; failures are reported
+        via the returned result's `reachable`/`error` fields."""
         try:
             video_stream = VideoStreamService.get_video_stream(input_config=source, timeout=self._TEST_TIMEOUT_MS)
             if video_stream is None:
@@ -172,3 +209,17 @@ class SourceUpdateService(SourceService):
             return SourceTestResult.success(latency_ms=round(elapsed_ms, 1))
         except Exception as e:
             return SourceTestResult.failure(str(e))
+
+    def test_source(self, source: Source) -> SourceTestResult:
+        """Perform a connectivity check on the source."""
+        return self._probe_reachability(source)
+
+    def validate_source(self, source: Source) -> None:
+        """Raise ResourceValidationError if the source cannot be opened/reached.
+
+        Reuses the same probe as `test_source`; the resulting error message is expected
+        to already be a complete, user-facing sentence (see stream error messages).
+        """
+        result = self._probe_reachability(source)
+        if not result.reachable:
+            raise ResourceValidationError(ResourceType.SOURCE, str(source.id), result.error)

--- a/application/backend/app/stream/base_opencv_stream.py
+++ b/application/backend/app/stream/base_opencv_stream.py
@@ -48,12 +48,29 @@ class BaseOpenCVStream(VideoStream, ABC):
         """Initialize the OpenCV VideoCapture."""
         self.cap = cv2.VideoCapture(self.source, self.api_preference)  # type: ignore[call-overload]
         if not self.cap.isOpened():
-            raise RuntimeError(f"Could not open video source: {self.source}")
+            raise RuntimeError(self._not_opened_message())
         if self.codec:
             self.cap.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*self.codec))  # type: ignore[attr-defined]
         if self.timeout:
             self.cap.set(cv2.CAP_PROP_OPEN_TIMEOUT_MSEC, self.timeout)
             self.cap.set(cv2.CAP_PROP_READ_TIMEOUT_MSEC, self.timeout)
+
+    def _not_opened_message(self) -> str:
+        """Build a user-facing message for a failed-to-open capture, tailored per source type.
+
+        For IP cameras, ``self.source`` is the connection URL actually passed to OpenCV, which
+        may embed credentials (see ``IPCameraConfig.get_configured_stream_url``). The original,
+        credential-free URL is preserved in ``metadata['stream_url']`` and used here instead, so
+        error text never leaks credentials.
+        """
+        match self.source_type:
+            case SourceType.VIDEO_FILE:
+                return f"Could not open video file: {self.source}"
+            case SourceType.IP_CAMERA:
+                display_url = self.metadata.get("stream_url", self.source)
+                return f"Could not connect to IP camera stream: {display_url}"
+            case _:
+                return f"Could not open video source: {self.source}"
 
     def _read_frame(self) -> np.ndarray:
         """Read a frame from the capture device."""

--- a/application/backend/app/stream/video_file_stream.py
+++ b/application/backend/app/stream/video_file_stream.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import cv2
 import numpy as np
 
@@ -20,6 +22,12 @@ class VideoFileStream(BaseOpenCVStream):
             loop: If True, the video restarts from the beginning once it ends.
                   If False, the stream stops returning frames once the video has been fully read.
         """
+        if not os.path.isfile(video_path):
+            # Checked explicitly (rather than relying on cv2.VideoCapture.isOpened() to fail) so the
+            # user gets a specific, actionable message instead of BaseOpenCVStream's generic
+            # "Could not open video file" — which stays as the fallback for a file that exists but
+            # cv2 still can't decode (corrupt file, unsupported codec/container).
+            raise RuntimeError(f"Video file not found: {video_path}")
         self.loop = loop
         self._exhausted = False
         super().__init__(source=video_path, source_type=SourceType.VIDEO_FILE, video_path=video_path, loop=loop)

--- a/application/backend/tests/integration/services/test_sink_service.py
+++ b/application/backend/tests/integration/services/test_sink_service.py
@@ -8,8 +8,16 @@ import pytest
 
 from app.db.schema import PipelineDB, SinkDB
 from app.models import OutputFormat, SinkAdapter, SinkType
-from app.models.sink import FolderConfig, FolderSinkConfig, MqttConfig, MqttSinkConfig, WebhookConfig, WebhookSinkConfig
-from app.services import ResourceInUseError, ResourceType, SinkService
+from app.models.sink import (
+    FolderConfig,
+    FolderSinkConfig,
+    MqttConfig,
+    MqttSinkConfig,
+    SinkTestResult,
+    WebhookConfig,
+    WebhookSinkConfig,
+)
+from app.services import ResourceInUseError, ResourceType, ResourceValidationError, SinkService
 from app.services.base import ResourceWithIdAlreadyExistsError, ResourceWithNameAlreadyExistsError
 from app.services.event.event_bus import EventType
 
@@ -25,14 +33,15 @@ class TestSinkServiceIntegration:
 
     def test_create_sink(self, fxt_mqtt_sink, fxt_sink_service, db_session):
         """Test creating a new sink."""
-        fxt_sink_service.create_sink(
-            name=fxt_mqtt_sink.name,
-            sink_type=fxt_mqtt_sink.sink_type,
-            rate_limit=fxt_mqtt_sink.rate_limit,
-            config_data=fxt_mqtt_sink.config_data,
-            output_formats=fxt_mqtt_sink.output_formats,
-            sink_id=fxt_mqtt_sink.id,
-        )
+        with patch.object(fxt_sink_service, "_probe_reachability", return_value=SinkTestResult.success(1.0)):
+            fxt_sink_service.create_sink(
+                name=fxt_mqtt_sink.name,
+                sink_type=fxt_mqtt_sink.sink_type,
+                rate_limit=fxt_mqtt_sink.rate_limit,
+                config_data=fxt_mqtt_sink.config_data,
+                output_formats=fxt_mqtt_sink.output_formats,
+                sink_id=fxt_mqtt_sink.id,
+            )
 
         assert db_session.query(SinkDB).count() == 1
         created = db_session.query(SinkDB).one()
@@ -55,7 +64,10 @@ class TestSinkServiceIntegration:
 
         fxt_mqtt_sink.name = fxt_db_sinks[0].name  # Set the same name as existing resource
 
-        with pytest.raises(ResourceWithNameAlreadyExistsError) as excinfo:
+        with (
+            patch.object(fxt_sink_service, "_probe_reachability", return_value=SinkTestResult.success(1.0)),
+            pytest.raises(ResourceWithNameAlreadyExistsError) as excinfo,
+        ):
             fxt_sink_service.create_sink(
                 name=fxt_mqtt_sink.name,
                 sink_type=fxt_mqtt_sink.sink_type,
@@ -81,7 +93,10 @@ class TestSinkServiceIntegration:
 
         fxt_mqtt_sink.id = UUID(fxt_db_sinks[0].id)  # Set the same ID as existing resource
 
-        with pytest.raises(ResourceWithIdAlreadyExistsError) as excinfo:
+        with (
+            patch.object(fxt_sink_service, "_probe_reachability", return_value=SinkTestResult.success(1.0)),
+            pytest.raises(ResourceWithIdAlreadyExistsError) as excinfo,
+        ):
             fxt_sink_service.create_sink(
                 name=fxt_mqtt_sink.name,
                 sink_type=fxt_mqtt_sink.sink_type,
@@ -93,6 +108,164 @@ class TestSinkServiceIntegration:
 
         assert excinfo.value.resource_type == ResourceType.SINK
         assert excinfo.value.resource_id == fxt_db_sinks[0].id
+
+    def test_create_sink_not_reachable_folder(self, fxt_sink_service, db_session):
+        """Test creating a folder sink that points at a non-existent folder is rejected."""
+        with pytest.raises(ResourceValidationError) as excinfo:
+            fxt_sink_service.create_sink(
+                name="Missing Folder Sink",
+                sink_type=SinkType.FOLDER,
+                rate_limit=None,
+                config_data=FolderConfig(folder_path="/nonexistent/output/folder"),
+                output_formats=[OutputFormat.PREDICTIONS],
+                sink_id=uuid4(),
+            )
+
+        assert excinfo.value.resource_type == ResourceType.SINK
+        assert "Directory not found" in str(excinfo.value)
+        assert db_session.query(SinkDB).count() == 0
+
+    def test_create_sink_not_reachable_mqtt(self, fxt_sink_service, db_session):
+        """Test creating an MQTT sink whose broker cannot be reached is rejected."""
+        with (
+            patch(
+                "app.services.dispatchers.mqtt.socket.create_connection",
+                side_effect=OSError("Connection timed out"),
+            ),
+            pytest.raises(ResourceValidationError) as excinfo,
+        ):
+            fxt_sink_service.create_sink(
+                name="Unreachable MQTT Sink",
+                sink_type=SinkType.MQTT,
+                rate_limit=None,
+                config_data=MqttConfig(broker_host="192.0.2.1", broker_port=1883, topic="test"),
+                output_formats=[OutputFormat.PREDICTIONS],
+                sink_id=uuid4(),
+            )
+
+        assert excinfo.value.resource_type == ResourceType.SINK
+        assert "Cannot connect" in str(excinfo.value)
+        assert db_session.query(SinkDB).count() == 0
+
+    def test_create_sink_not_reachable_webhook(self, fxt_sink_service, db_session):
+        """Test creating a webhook sink whose URL cannot be reached is rejected."""
+        import requests
+
+        with (
+            patch(
+                "app.services.dispatchers.webhook.requests.head",
+                side_effect=requests.ConnectionError("Connection refused"),
+            ),
+            pytest.raises(ResourceValidationError) as excinfo,
+        ):
+            fxt_sink_service.create_sink(
+                name="Unreachable Webhook Sink",
+                sink_type=SinkType.WEBHOOK,
+                rate_limit=None,
+                config_data=WebhookConfig(webhook_url="http://192.0.2.1:9999/hook"),
+                output_formats=[OutputFormat.PREDICTIONS],
+                sink_id=uuid4(),
+            )
+
+        assert excinfo.value.resource_type == ResourceType.SINK
+        assert "Cannot reach webhook" in str(excinfo.value)
+        assert db_session.query(SinkDB).count() == 0
+
+    def test_update_sink_not_reachable(self, fxt_db_sinks, fxt_sink_service, db_session):
+        """Test updating a sink to a non-existent folder is rejected and not persisted."""
+        db_sink = fxt_db_sinks[0]
+        db_session.add(db_sink)
+        db_session.flush()
+        original_config_data = dict(db_sink.config_data)
+
+        sink = SinkAdapter.validate_python(db_sink, from_attributes=True)
+
+        with pytest.raises(ResourceValidationError) as excinfo:
+            fxt_sink_service.update_sink(
+                sink=sink,
+                new_name="Updated Sink",
+                new_rate_limit=sink.rate_limit,
+                new_config_data=FolderConfig(folder_path="/nonexistent/output/folder"),
+                new_output_formats=sink.output_formats,
+            )
+
+        assert excinfo.value.resource_type == ResourceType.SINK
+        assert "Directory not found" in str(excinfo.value)
+        # Verify nothing changed in DB
+        db_session.refresh(db_sink)
+        assert db_sink.name == fxt_db_sinks[0].name
+        assert db_sink.config_data == original_config_data
+
+    def test_update_sink_not_reachable_mqtt(self, fxt_db_sinks, fxt_sink_service, db_session):
+        """Test updating a sink to an unreachable MQTT broker is rejected and not persisted."""
+        db_sink = fxt_db_sinks[1]  # MQTT sink
+        db_session.add(db_sink)
+        db_session.flush()
+        original_config_data = dict(db_sink.config_data)
+
+        sink = SinkAdapter.validate_python(db_sink, from_attributes=True)
+
+        with (
+            patch(
+                "app.services.dispatchers.mqtt.socket.create_connection",
+                side_effect=OSError("Connection timed out"),
+            ),
+            pytest.raises(ResourceValidationError) as excinfo,
+        ):
+            fxt_sink_service.update_sink(
+                sink=sink,
+                new_name="Updated Sink",
+                new_rate_limit=sink.rate_limit,
+                new_config_data=MqttConfig(broker_host="192.0.2.1", broker_port=1883, topic="test"),
+                new_output_formats=sink.output_formats,
+            )
+
+        assert excinfo.value.resource_type == ResourceType.SINK
+        assert "Cannot connect" in str(excinfo.value)
+        # Verify nothing changed in DB
+        db_session.refresh(db_sink)
+        assert db_sink.name == fxt_db_sinks[1].name
+        assert db_sink.config_data == original_config_data
+
+    def test_update_sink_not_reachable_webhook(self, fxt_sink_service, db_session):
+        """Test updating a webhook sink to an unreachable URL is rejected and not persisted."""
+        import requests
+
+        db_sink = SinkDB(
+            id=str(uuid4()),
+            sink_type=SinkType.WEBHOOK,
+            name="Existing Webhook Sink",
+            rate_limit=None,
+            output_formats=[OutputFormat.PREDICTIONS],
+            config_data={"webhook_url": "http://example.com/hook"},
+        )
+        db_session.add(db_sink)
+        db_session.flush()
+        original_config_data = dict(db_sink.config_data)
+
+        sink = SinkAdapter.validate_python(db_sink, from_attributes=True)
+
+        with (
+            patch(
+                "app.services.dispatchers.webhook.requests.head",
+                side_effect=requests.ConnectionError("Connection refused"),
+            ),
+            pytest.raises(ResourceValidationError) as excinfo,
+        ):
+            fxt_sink_service.update_sink(
+                sink=sink,
+                new_name="Updated Sink",
+                new_rate_limit=sink.rate_limit,
+                new_config_data=WebhookConfig(webhook_url="http://192.0.2.1:9999/hook"),
+                new_output_formats=sink.output_formats,
+            )
+
+        assert excinfo.value.resource_type == ResourceType.SINK
+        assert "Cannot reach webhook" in str(excinfo.value)
+        # Verify nothing changed in DB
+        db_session.refresh(db_sink)
+        assert db_sink.name == "Existing Webhook Sink"
+        assert db_sink.config_data == original_config_data
 
     @pytest.mark.parametrize("is_running", [True, False])
     def test_get_active_sink(
@@ -157,13 +330,14 @@ class TestSinkServiceIntegration:
 
         sink = SinkAdapter.validate_python(db_sink, from_attributes=True)
 
-        updated = fxt_sink_service.update_sink(
-            sink=sink,
-            new_name="Updated Sink",
-            new_rate_limit=db_sink.rate_limit,
-            new_config_data=FolderConfig(folder_path="/new/folder"),
-            new_output_formats=db_sink.output_formats,
-        )
+        with patch.object(fxt_sink_service, "_probe_reachability", return_value=SinkTestResult.success(1.0)):
+            updated = fxt_sink_service.update_sink(
+                sink=sink,
+                new_name="Updated Sink",
+                new_rate_limit=db_sink.rate_limit,
+                new_config_data=FolderConfig(folder_path="/new/folder"),
+                new_output_formats=db_sink.output_formats,
+            )
 
         assert updated.name == "Updated Sink"
         assert str(updated.id) == db_sink.id
@@ -181,7 +355,10 @@ class TestSinkServiceIntegration:
 
         sink = SinkAdapter.validate_python(db_sink, from_attributes=True)
 
-        with pytest.raises(ResourceWithNameAlreadyExistsError) as excinfo:
+        with (
+            patch.object(fxt_sink_service, "_probe_reachability", return_value=SinkTestResult.success(1.0)),
+            pytest.raises(ResourceWithNameAlreadyExistsError) as excinfo,
+        ):
             fxt_sink_service.update_sink(
                 sink=sink,
                 new_name=fxt_db_sinks[1].name,
@@ -213,13 +390,14 @@ class TestSinkServiceIntegration:
 
         sink = SinkAdapter.validate_python(db_sink, from_attributes=True)
 
-        updated = fxt_sink_service.update_sink(
-            sink=sink,
-            new_name="Updated Sink",
-            new_rate_limit=db_sink.rate_limit,
-            new_config_data=FolderConfig(folder_path="/new/folder"),
-            new_output_formats=db_sink.output_formats,
-        )
+        with patch.object(fxt_sink_service, "_probe_reachability", return_value=SinkTestResult.success(1.0)):
+            updated = fxt_sink_service.update_sink(
+                sink=sink,
+                new_name="Updated Sink",
+                new_rate_limit=db_sink.rate_limit,
+                new_config_data=FolderConfig(folder_path="/new/folder"),
+                new_output_formats=db_sink.output_formats,
+            )
 
         assert updated.name == "Updated Sink"
         assert str(updated.id) == db_sink.id

--- a/application/backend/tests/integration/services/test_source_service.py
+++ b/application/backend/tests/integration/services/test_source_service.py
@@ -439,11 +439,14 @@ class TestSourceUpdateServiceIntegration:
 
         source = SourceAdapter.validate_python(db_source, from_attributes=True)
 
-        fxt_source_update_service_with_media.update_source(
-            source=source,
-            new_name=source.name,
-            new_config_data=VideoFileConfig(video_path="/new/path"),
-        )
+        with patch.object(
+            fxt_source_update_service_with_media, "_probe_reachability", return_value=SourceTestResult.success(1.0)
+        ):
+            fxt_source_update_service_with_media.update_source(
+                source=source,
+                new_name=source.name,
+                new_config_data=VideoFileConfig(video_path="/new/path"),
+            )
 
         fxt_source_media_service.delete_video.assert_called_once_with("/path/to/video.mp4")
 
@@ -461,11 +464,14 @@ class TestSourceUpdateServiceIntegration:
 
         source = SourceAdapter.validate_python(db_source, from_attributes=True)
 
-        fxt_source_update_service_with_media.update_source(
-            source=source,
-            new_name="Renamed Source",
-            new_config_data=VideoFileConfig(video_path="/path/to/video.mp4"),
-        )
+        with patch.object(
+            fxt_source_update_service_with_media, "_probe_reachability", return_value=SourceTestResult.success(1.0)
+        ):
+            fxt_source_update_service_with_media.update_source(
+                source=source,
+                new_name="Renamed Source",
+                new_config_data=VideoFileConfig(video_path="/path/to/video.mp4"),
+            )
 
         fxt_source_media_service.delete_video.assert_not_called()
 
@@ -483,11 +489,14 @@ class TestSourceUpdateServiceIntegration:
 
         source = SourceAdapter.validate_python(db_source, from_attributes=True)
 
-        fxt_source_update_service_with_media.update_source(
-            source=source,
-            new_name="Renamed Source",
-            new_config_data=USBCameraConfig(device_id=2, codec=None),
-        )
+        with patch.object(
+            fxt_source_update_service_with_media, "_probe_reachability", return_value=SourceTestResult.success(1.0)
+        ):
+            fxt_source_update_service_with_media.update_source(
+                source=source,
+                new_name="Renamed Source",
+                new_config_data=USBCameraConfig(device_id=2, codec=None),
+            )
 
         fxt_source_media_service.delete_video.assert_not_called()
 

--- a/application/backend/tests/integration/services/test_source_service.py
+++ b/application/backend/tests/integration/services/test_source_service.py
@@ -13,12 +13,13 @@ from app.models.source import (
     ImagesFolderSourceConfig,
     IPCameraConfig,
     IPCameraSourceConfig,
+    SourceTestResult,
     USBCameraConfig,
     USBCameraSourceConfig,
     VideoFileConfig,
     VideoFileSourceConfig,
 )
-from app.services import ResourceInUseError, ResourceType, SourceUpdateService
+from app.services import ResourceInUseError, ResourceType, ResourceValidationError, SourceUpdateService
 from app.services.base import ResourceWithIdAlreadyExistsError, ResourceWithNameAlreadyExistsError
 from app.services.event.event_bus import EventType
 from app.services.source_media_service import SourceMediaService
@@ -46,12 +47,13 @@ class TestSourceUpdateServiceIntegration:
 
     def test_create_source(self, fxt_usb_camera_source, fxt_source_update_service, db_session):
         """Test creating a new configuration."""
-        fxt_source_update_service.create_source(
-            name=fxt_usb_camera_source.name,
-            source_type=fxt_usb_camera_source.source_type,
-            config_data=fxt_usb_camera_source.config_data,
-            source_id=fxt_usb_camera_source.id,
-        )
+        with patch.object(fxt_source_update_service, "_probe_reachability", return_value=SourceTestResult.success(1.0)):
+            fxt_source_update_service.create_source(
+                name=fxt_usb_camera_source.name,
+                source_type=fxt_usb_camera_source.source_type,
+                config_data=fxt_usb_camera_source.config_data,
+                source_id=fxt_usb_camera_source.id,
+            )
 
         assert db_session.query(SourceDB).count() == 1
         created = db_session.query(SourceDB).one()
@@ -71,7 +73,10 @@ class TestSourceUpdateServiceIntegration:
 
         fxt_usb_camera_source.name = fxt_db_sources[0].name  # Set the same name as existing resource
 
-        with pytest.raises(ResourceWithNameAlreadyExistsError) as excinfo:
+        with (
+            patch.object(fxt_source_update_service, "_probe_reachability", return_value=SourceTestResult.success(1.0)),
+            pytest.raises(ResourceWithNameAlreadyExistsError) as excinfo,
+        ):
             fxt_source_update_service.create_source(
                 name=fxt_usb_camera_source.name,
                 source_type=fxt_usb_camera_source.source_type,
@@ -95,7 +100,10 @@ class TestSourceUpdateServiceIntegration:
 
         fxt_usb_camera_source.id = UUID(fxt_db_sources[0].id)  # Set the same ID as existing resource
 
-        with pytest.raises(ResourceWithIdAlreadyExistsError) as excinfo:
+        with (
+            patch.object(fxt_source_update_service, "_probe_reachability", return_value=SourceTestResult.success(1.0)),
+            pytest.raises(ResourceWithIdAlreadyExistsError) as excinfo,
+        ):
             fxt_source_update_service.create_source(
                 name=fxt_usb_camera_source.name,
                 source_type=fxt_usb_camera_source.source_type,
@@ -105,6 +113,181 @@ class TestSourceUpdateServiceIntegration:
 
         assert excinfo.value.resource_type == ResourceType.SOURCE
         assert excinfo.value.resource_id == fxt_db_sources[0].id
+
+    def test_create_source_not_reachable_video_file(self, fxt_source_update_service, db_session):
+        """Test creating a video_file source that points at a non-existent file is rejected."""
+        with pytest.raises(ResourceValidationError) as excinfo:
+            fxt_source_update_service.create_source(
+                name="Missing Video Source",
+                source_type=SourceType.VIDEO_FILE,
+                config_data=VideoFileConfig(video_path="/nonexistent/path/video.mp4"),
+                source_id=uuid4(),
+            )
+
+        assert excinfo.value.resource_type == ResourceType.SOURCE
+        assert "Video file not found" in str(excinfo.value)
+        assert db_session.query(SourceDB).count() == 0
+
+    def test_create_source_not_reachable_images_folder(self, fxt_source_update_service, db_session):
+        """Test creating an images_folder source that points at a non-existent folder is rejected."""
+        with pytest.raises(ResourceValidationError) as excinfo:
+            fxt_source_update_service.create_source(
+                name="Missing Folder Source",
+                source_type=SourceType.IMAGES_FOLDER,
+                config_data=ImagesFolderConfig(images_folder_path="/nonexistent/folder", ignore_existing_images=False),
+                source_id=uuid4(),
+            )
+
+        assert excinfo.value.resource_type == ResourceType.SOURCE
+        assert "Directory not found" in str(excinfo.value)
+        assert db_session.query(SourceDB).count() == 0
+
+    def test_create_source_not_reachable_usb_camera(self, fxt_source_update_service, db_session):
+        """Test creating a USB camera source that cannot be opened is rejected."""
+        mock_cap = MagicMock()
+        mock_cap.isOpened.return_value = False
+        with (
+            patch("app.stream.usb_camera_stream.cv2.VideoCapture", return_value=mock_cap),
+            pytest.raises(ResourceValidationError) as excinfo,
+        ):
+            fxt_source_update_service.create_source(
+                name="Unavailable USB Camera",
+                source_type=SourceType.USB_CAMERA,
+                config_data=USBCameraConfig(device_id=999),
+                source_id=uuid4(),
+            )
+
+        assert excinfo.value.resource_type == ResourceType.SOURCE
+        assert "Could not open USB camera device" in str(excinfo.value)
+        assert db_session.query(SourceDB).count() == 0
+
+    def test_create_source_not_reachable_ip_camera(self, fxt_source_update_service, db_session):
+        """Test creating an IP camera source that cannot be connected to is rejected."""
+        mock_cap = MagicMock()
+        mock_cap.isOpened.return_value = False
+        with (
+            patch("app.stream.base_opencv_stream.cv2.VideoCapture", return_value=mock_cap),
+            pytest.raises(ResourceValidationError) as excinfo,
+        ):
+            fxt_source_update_service.create_source(
+                name="Unreachable IP Camera",
+                source_type=SourceType.IP_CAMERA,
+                config_data=IPCameraConfig(stream_url="rtsp://192.0.2.1:554/stream", auth_required=False),
+                source_id=uuid4(),
+            )
+
+        assert excinfo.value.resource_type == ResourceType.SOURCE
+        assert "Could not connect to IP camera stream" in str(excinfo.value)
+        assert db_session.query(SourceDB).count() == 0
+
+    def test_update_source_not_reachable(self, fxt_db_sources, fxt_source_update_service, db_session):
+        """Test updating a source to a non-existent video file is rejected and not persisted."""
+        db_source = fxt_db_sources[0]
+        db_session.add(db_source)
+        db_session.flush()
+        original_config_data = dict(db_source.config_data)
+
+        source = SourceAdapter.validate_python(db_source, from_attributes=True)
+
+        with pytest.raises(ResourceValidationError) as excinfo:
+            fxt_source_update_service.update_source(
+                source=source,
+                new_name="Updated Source",
+                new_config_data=VideoFileConfig(video_path="/nonexistent/path/video.mp4"),
+            )
+
+        assert excinfo.value.resource_type == ResourceType.SOURCE
+        assert "Video file not found" in str(excinfo.value)
+        # Verify nothing changed in DB
+        db_session.refresh(db_source)
+        assert db_source.name == fxt_db_sources[0].name
+        assert db_source.config_data == original_config_data
+
+    def test_update_source_not_reachable_images_folder(self, fxt_source_update_service, db_session, tmp_path):
+        """Test updating an images_folder source to a non-existent folder is rejected and not persisted."""
+        db_source = SourceDB(
+            id=str(uuid4()),
+            source_type=SourceType.IMAGES_FOLDER,
+            name="Existing Folder Source",
+            config_data={"images_folder_path": str(tmp_path), "ignore_existing_images": False},
+        )
+        db_session.add(db_source)
+        db_session.flush()
+        original_config_data = dict(db_source.config_data)
+
+        source = SourceAdapter.validate_python(db_source, from_attributes=True)
+
+        with pytest.raises(ResourceValidationError) as excinfo:
+            fxt_source_update_service.update_source(
+                source=source,
+                new_name="Updated Source",
+                new_config_data=ImagesFolderConfig(
+                    images_folder_path="/nonexistent/folder", ignore_existing_images=False
+                ),
+            )
+
+        assert excinfo.value.resource_type == ResourceType.SOURCE
+        assert "Directory not found" in str(excinfo.value)
+        # Verify nothing changed in DB
+        db_session.refresh(db_source)
+        assert db_source.name == "Existing Folder Source"
+        assert db_source.config_data == original_config_data
+
+    def test_update_source_not_reachable_usb_camera(self, fxt_db_sources, fxt_source_update_service, db_session):
+        """Test updating a source to an unavailable USB camera device is rejected and not persisted."""
+        db_source = fxt_db_sources[1]  # USB camera source
+        db_session.add(db_source)
+        db_session.flush()
+        original_config_data = dict(db_source.config_data)
+
+        source = SourceAdapter.validate_python(db_source, from_attributes=True)
+
+        mock_cap = MagicMock()
+        mock_cap.isOpened.return_value = False
+        with (
+            patch("app.stream.usb_camera_stream.cv2.VideoCapture", return_value=mock_cap),
+            pytest.raises(ResourceValidationError) as excinfo,
+        ):
+            fxt_source_update_service.update_source(
+                source=source,
+                new_name="Updated Source",
+                new_config_data=USBCameraConfig(device_id=999),
+            )
+
+        assert excinfo.value.resource_type == ResourceType.SOURCE
+        assert "Could not open USB camera device" in str(excinfo.value)
+        # Verify nothing changed in DB
+        db_session.refresh(db_source)
+        assert db_source.name == fxt_db_sources[1].name
+        assert db_source.config_data == original_config_data
+
+    def test_update_source_not_reachable_ip_camera(self, fxt_db_sources, fxt_source_update_service, db_session):
+        """Test updating a source to an unreachable IP camera stream is rejected and not persisted."""
+        db_source = fxt_db_sources[2]  # IP camera source
+        db_session.add(db_source)
+        db_session.flush()
+        original_config_data = dict(db_source.config_data)
+
+        source = SourceAdapter.validate_python(db_source, from_attributes=True)
+
+        mock_cap = MagicMock()
+        mock_cap.isOpened.return_value = False
+        with (
+            patch("app.stream.base_opencv_stream.cv2.VideoCapture", return_value=mock_cap),
+            pytest.raises(ResourceValidationError) as excinfo,
+        ):
+            fxt_source_update_service.update_source(
+                source=source,
+                new_name="Updated Source",
+                new_config_data=IPCameraConfig(stream_url="rtsp://192.0.2.1:554/stream", auth_required=False),
+            )
+
+        assert excinfo.value.resource_type == ResourceType.SOURCE
+        assert "Could not connect to IP camera stream" in str(excinfo.value)
+        # Verify nothing changed in DB
+        db_session.refresh(db_source)
+        assert db_source.name == fxt_db_sources[2].name
+        assert db_source.config_data == original_config_data
 
     @pytest.mark.parametrize("is_running", [True, False])
     def test_get_active_source(
@@ -167,11 +350,12 @@ class TestSourceUpdateServiceIntegration:
 
         source = SourceAdapter.validate_python(db_source, from_attributes=True)
 
-        updated = fxt_source_update_service.update_source(
-            source=source,
-            new_name="Updated Source",
-            new_config_data=VideoFileConfig(video_path="/new/path"),
-        )
+        with patch.object(fxt_source_update_service, "_probe_reachability", return_value=SourceTestResult.success(1.0)):
+            updated = fxt_source_update_service.update_source(
+                source=source,
+                new_name="Updated Source",
+                new_config_data=VideoFileConfig(video_path="/new/path"),
+            )
 
         assert updated.name == update_data["name"]
         assert str(updated.id) == db_source.id
@@ -189,7 +373,10 @@ class TestSourceUpdateServiceIntegration:
 
         source = SourceAdapter.validate_python(db_source, from_attributes=True)
 
-        with pytest.raises(ResourceWithNameAlreadyExistsError) as excinfo:
+        with (
+            patch.object(fxt_source_update_service, "_probe_reachability", return_value=SourceTestResult.success(1.0)),
+            pytest.raises(ResourceWithNameAlreadyExistsError) as excinfo,
+        ):
             fxt_source_update_service.update_source(
                 source=source,
                 new_name=fxt_db_sources[1].name,
@@ -222,11 +409,12 @@ class TestSourceUpdateServiceIntegration:
 
         source = SourceAdapter.validate_python(db_source, from_attributes=True)
 
-        updated = fxt_source_update_service.update_source(
-            source=source,
-            new_name="Updated Source",
-            new_config_data=VideoFileConfig(video_path="/new/path"),
-        )
+        with patch.object(fxt_source_update_service, "_probe_reachability", return_value=SourceTestResult.success(1.0)):
+            updated = fxt_source_update_service.update_source(
+                source=source,
+                new_name="Updated Source",
+                new_config_data=VideoFileConfig(video_path="/new/path"),
+            )
 
         assert updated.name == "Updated Source"
         assert str(updated.id) == db_source.id
@@ -418,7 +606,7 @@ class TestSourceUpdateServiceIntegration:
 
         # File exists but is not a valid video, so cv2 can't open it
         assert not result.reachable
-        assert "Could not open video source" in result.error
+        assert "Could not open video file" in result.error
 
     def test_test_source_video_file_not_found(self, fxt_source_update_service):
         """Test test_source with a non-existent video file."""
@@ -432,7 +620,7 @@ class TestSourceUpdateServiceIntegration:
         result = fxt_source_update_service.test_source(source)
 
         assert not result.reachable
-        assert "Could not open video source" in result.error
+        assert "Video file not found" in result.error
 
     def test_test_source_images_folder_exists(self, fxt_source_update_service, tmp_path):
         """Test test_source with an existing accessible images folder."""
@@ -520,7 +708,7 @@ class TestSourceUpdateServiceIntegration:
             result = fxt_source_update_service.test_source(source)
 
         assert not result.reachable
-        assert "Could not open video source" in result.error
+        assert "Could not connect to IP camera stream" in result.error
 
     def test_test_source_ip_camera_reachable(self, fxt_source_update_service):
         """Test test_source with a reachable IP camera (mocked cv2 capture)."""

--- a/application/backend/tests/integration/stream/test_ip_camera_stream.py
+++ b/application/backend/tests/integration/stream/test_ip_camera_stream.py
@@ -94,7 +94,7 @@ class TestIPCameraStream:
         )
 
         # Should raise exception during initialization
-        with pytest.raises(RuntimeError, match=f"Could not open video source: {invalid_url}"):
+        with pytest.raises(RuntimeError, match=f"Could not connect to IP camera stream: {invalid_url}"):
             IPCameraStream(config)
 
     def test_reconnects_after_transient_failure(self, config: IPCameraSourceConfig):

--- a/application/backend/tests/integration/stream/test_video_file_stream.py
+++ b/application/backend/tests/integration/stream/test_video_file_stream.py
@@ -38,6 +38,15 @@ def video_path(tmp_path: Path) -> Generator[str]:
 class TestVideoFileStream:
     """Integration tests for VideoFileStream end-of-stream semantics."""
 
+    def test_raises_specific_error_when_file_does_not_exist(self, tmp_path: Path):
+        """A missing file is rejected before ever touching cv2, with a specific message."""
+        missing_path = str(tmp_path / "does-not-exist.mp4")
+
+        with pytest.raises(RuntimeError) as excinfo:
+            VideoFileStream(video_path=missing_path)
+
+        assert str(excinfo.value) == f"Video file not found: {missing_path}"
+
     def test_is_not_real_time(self, video_path: str):
         with VideoFileStream(video_path=video_path) as stream:
             assert stream.is_real_time() is False

--- a/application/backend/tests/unit/api/routers/test_sinks.py
+++ b/application/backend/tests/unit/api/routers/test_sinks.py
@@ -19,6 +19,7 @@ from app.services import (
     ResourceInUseError,
     ResourceNotFoundError,
     ResourceType,
+    ResourceValidationError,
     ResourceWithNameAlreadyExistsError,
     SinkService,
 )
@@ -111,6 +112,18 @@ class TestSinkEndpoints:
         assert response.status_code == status.HTTP_409_CONFLICT
         fxt_sink_service.create_sink.assert_called_once()
 
+    def test_create_sink_not_reachable(self, fxt_folder_sink_create, fxt_sink_service, fxt_client):
+        err = ResourceValidationError(
+            ResourceType.SINK, str(fxt_folder_sink_create.id), "Directory not found: /test/path"
+        )
+        fxt_sink_service.create_sink.side_effect = err
+
+        response = fxt_client.post("/api/sinks", json=fxt_folder_sink_create.model_dump(exclude={"id"}))
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+        assert response.json()["detail"] == str(err)
+        fxt_sink_service.create_sink.assert_called_once()
+
     def test_list_sinks(self, fxt_folder_sink_view, fxt_mqtt_sink, fxt_sink_service, fxt_client):
         fxt_sink_service.list_all.return_value = [fxt_folder_sink_view, fxt_mqtt_sink]
 
@@ -172,6 +185,16 @@ class TestSinkEndpoints:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "_type" in response.json()["detail"]
         fxt_sink_service.update_sink.assert_not_called()
+
+    def test_update_sink_not_reachable(self, fxt_get_sink, fxt_sink_service, fxt_client):
+        sink_id = str(fxt_get_sink.id)
+        err = ResourceValidationError(ResourceType.SINK, sink_id, "Directory not found: /new/path")
+        fxt_sink_service.update_sink.side_effect = err
+
+        response = fxt_client.patch(f"/api/sinks/{sink_id}", json={"folder_path": "/new/path"})
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+        assert response.json()["detail"] == str(err)
 
     def test_delete_sink_success(self, fxt_folder_sink_view, fxt_get_sink, fxt_sink_service, fxt_client):
         sink_id = str(fxt_folder_sink_view.id)
@@ -246,6 +269,21 @@ class TestSinkEndpoints:
         response = fxt_client.post("/api/sinks:import", files=files)
 
         assert response.status_code == status.HTTP_409_CONFLICT
+        fxt_sink_service.create_sink.assert_called_once()
+
+    def test_import_sink_not_reachable(self, fxt_folder_sink_create, fxt_sink_service, fxt_client):
+        sink_data = fxt_folder_sink_create.model_dump(exclude={"id"}, mode="json")
+        yaml_content = yaml.safe_dump(sink_data)
+        err = ResourceValidationError(
+            ResourceType.SINK, str(fxt_folder_sink_create.id), "Directory not found: /test/path"
+        )
+        fxt_sink_service.create_sink.side_effect = err
+
+        files = {"yaml_file": ("test.yaml", io.BytesIO(yaml_content.encode()), "application/x-yaml")}
+        response = fxt_client.post("/api/sinks:import", files=files)
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+        assert response.json()["detail"] == str(err)
         fxt_sink_service.create_sink.assert_called_once()
 
     def test_import_sink_invalid_yaml(self, fxt_client):

--- a/application/backend/tests/unit/api/routers/test_sources.py
+++ b/application/backend/tests/unit/api/routers/test_sources.py
@@ -19,6 +19,7 @@ from app.services import (
     ResourceInUseError,
     ResourceNotFoundError,
     ResourceType,
+    ResourceValidationError,
     ResourceWithNameAlreadyExistsError,
     SourceUpdateService,
 )
@@ -100,6 +101,18 @@ class TestSourceEndpoints:
         assert response.status_code == status.HTTP_409_CONFLICT
         fxt_source_update_service.create_source.assert_called_once()
 
+    def test_create_source_not_reachable(self, fxt_usb_camera_source_create, fxt_source_update_service, fxt_client):
+        err = ResourceValidationError(
+            ResourceType.SOURCE, str(fxt_usb_camera_source_create.id), "Could not open USB camera device 1"
+        )
+        fxt_source_update_service.create_source.side_effect = err
+
+        response = fxt_client.post("/api/sources", json=fxt_usb_camera_source_create.model_dump(exclude={"id"}))
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+        assert response.json()["detail"] == str(err)
+        fxt_source_update_service.create_source.assert_called_once()
+
     def test_list_sources(
         self, fxt_usb_camera_source_view, fxt_video_source_view, fxt_source_update_service, fxt_client, request
     ):
@@ -160,6 +173,16 @@ class TestSourceEndpoints:
         response = fxt_client.patch(f"/api/sources/{source_id}", json={"name": "Updated"})
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_update_source_not_reachable(self, fxt_get_source, fxt_source_update_service, fxt_client):
+        source_id = str(fxt_get_source.id)
+        err = ResourceValidationError(ResourceType.SOURCE, source_id, "Could not open USB camera device 5")
+        fxt_source_update_service.update_source.side_effect = err
+
+        response = fxt_client.patch(f"/api/sources/{source_id}", json={"device_id": 5})
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+        assert response.json()["detail"] == str(err)
 
     def test_update_source_type_forbidden(self, fxt_usb_camera_source_create, fxt_source_update_service, fxt_client):
         source_id = str(fxt_usb_camera_source_create.id)
@@ -242,6 +265,21 @@ class TestSourceEndpoints:
         response = fxt_client.post("/api/sources:import", files=files)
 
         assert response.status_code == status.HTTP_409_CONFLICT
+        fxt_source_update_service.create_source.assert_called_once()
+
+    def test_import_source_not_reachable(self, fxt_usb_camera_source_view, fxt_source_update_service, fxt_client):
+        sink_data = fxt_usb_camera_source_view.model_dump(exclude={"id"}, mode="json")
+        yaml_content = yaml.safe_dump(sink_data)
+        err = ResourceValidationError(
+            ResourceType.SOURCE, str(fxt_usb_camera_source_view.id), "Could not open USB camera device 1"
+        )
+        fxt_source_update_service.create_source.side_effect = err
+
+        files = {"yaml_file": ("test.yaml", io.BytesIO(yaml_content.encode()), "application/x-yaml")}
+        response = fxt_client.post("/api/sources:import", files=files)
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+        assert response.json()["detail"] == str(err)
         fxt_source_update_service.create_source.assert_called_once()
 
     def test_import_source_invalid_yaml(self, fxt_client):

--- a/application/ui/src/features/inference/sinks/hooks/use-sink-mutation.hook.tsx
+++ b/application/ui/src/features/inference/sinks/hooks/use-sink-mutation.hook.tsx
@@ -40,9 +40,9 @@ export const useSinkMutation = (isNewSink: boolean) => {
     const addSink = $api.useMutation('post', '/api/sinks', {
         meta: {
             invalidateQueries: [['get', '/api/sinks']],
-        },
-        error: {
-            notify: () => false,
+            error: {
+                notify: () => false,
+            },
         },
     });
 

--- a/application/ui/src/features/inference/sinks/hooks/use-sink-mutation.hook.tsx
+++ b/application/ui/src/features/inference/sinks/hooks/use-sink-mutation.hook.tsx
@@ -15,6 +15,9 @@ const useUpdateSink = () => {
     return $api.useMutation('patch', '/api/sinks/{sink_id}', {
         meta: {
             invalidateQueries: [['get', '/api/sinks']],
+            error: {
+                notify: () => false,
+            },
         },
         onSuccess: (
             _,
@@ -37,6 +40,9 @@ export const useSinkMutation = (isNewSink: boolean) => {
     const addSink = $api.useMutation('post', '/api/sinks', {
         meta: {
             invalidateQueries: [['get', '/api/sinks']],
+        },
+        error: {
+            notify: () => false,
         },
     });
 

--- a/application/ui/src/features/inference/sources/hooks/use-source-mutation.hook.tsx
+++ b/application/ui/src/features/inference/sources/hooks/use-source-mutation.hook.tsx
@@ -16,6 +16,9 @@ const useUpdateSource = () => {
     return $api.useMutation('patch', '/api/sources/{source_id}', {
         meta: {
             invalidateQueries: [['get', '/api/sources']],
+            error: {
+                notify: () => false,
+            },
         },
         onSuccess: (
             _,
@@ -38,6 +41,9 @@ export const useSourceMutation = (isNewSource: boolean) => {
     const addSource = $api.useMutation('post', '/api/sources', {
         meta: {
             invalidateQueries: [['get', '/api/sources']],
+            error: {
+                notify: () => false,
+            },
         },
     });
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

The issue is that user is able to create video file source with invalid path, so will never be used for the inference. As a fallback, when server is not able to play a video, the video from the other video source is selected.
In this PR I fix that issue so we do the validation of the source and sink before creation and update.

In the server side I reused the logic that was already implemented for `{sink/source}:test` endpoint.
In the UI we showed two error notifications, that's why I had to pass `notify: false` to show only one.

Close #5432 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
