### PR TITLE
Sync application version with the global versioning schema

### DIFF
--- a/application/backend/app/main.py
+++ b/application/backend/app/main.py
@@ -183,7 +183,12 @@ def _asyncio_exception_handler(loop: asyncio.AbstractEventLoop, context: dict) -
 
 async def main_async() -> None:
     """Async main application entry point for Hypercorn"""
-    logger.info("Starting {} in {} mode via Hypercorn (HTTP/2)", settings.app_name, settings.environment)
+    logger.info(
+        "Starting {} version {} in {} mode via Hypercorn (HTTP/2)",
+        settings.app_name,
+        settings.version,
+        settings.environment,
+    )
 
     # WebView2 / browser clients frequently drop HTTP/2-over-TLS connections without a
     # clean TLS close, so asyncio's graceful SSL shutdown either times out or observes a

--- a/application/backend/app/settings.py
+++ b/application/backend/app/settings.py
@@ -6,11 +6,32 @@
 import os
 import sys
 from functools import lru_cache
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from pathlib import Path
 from typing import Literal
 
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+def _read_version() -> str:
+    """Read the application version, preferring installed package metadata.
+
+    In the Docker image (and any installed environment) the ``geti`` package is
+    installed and its version is stamped from the ``VERSION`` file at build time,
+    so it can be read from the package metadata. When running from source without
+    an installed distribution, fall back to reading the ``VERSION`` file directly.
+    """
+    try:
+        return _pkg_version("geti")
+    except PackageNotFoundError:
+        # settings.py -> app -> backend -> application/VERSION
+        version_file = Path(__file__).resolve().parents[2] / "VERSION"
+        try:
+            return version_file.read_text(encoding="utf-8").strip()
+        except OSError:
+            return "0.0.0"
 
 
 class Settings(BaseSettings):
@@ -20,7 +41,7 @@ class Settings(BaseSettings):
 
     # Application
     app_name: str = "Geti"
-    version: str = "0.1.0"
+    version: str = Field(default_factory=_read_version)
     summary: str = "Geti server"
     description: str = (
         "Geti allows to fine-tune computer vision models at the edge. "

--- a/application/backend/geti.spec
+++ b/application/backend/geti.spec
@@ -8,6 +8,7 @@ datas = [
     ('app/alembic.ini', 'app'),
     ('app/static/*', 'app/static'),
     ('app/supported_models/manifests/*', 'app/supported_models/manifests'),
+    *copy_metadata("geti"),
     *copy_metadata("optree"),
     *copy_metadata("torch"),
     *copy_metadata("tabulate"),


### PR DESCRIPTION
Get app used version from the geti package metadata. It's being picked from VERSION file (source of truth).
For dev mode, version is picked directly from VERSION