### PR TITLE
Add model architecture support to quantization job parameters

### DIFF
--- a/application/backend/app/api/routers/jobs.py
+++ b/application/backend/app/api/routers/jobs.py
@@ -90,15 +90,19 @@ async def submit_job(
                 )
             case JobType.QUANTIZE:
                 project = project_service.get_project_by_id(job_request.project_id)
+                arch_id = job_request.parameters.model_architecture_id
+                arch_name = ModelManifestService.get_model_manifest_by_id(arch_id).name
                 job = QuantizationJob(
                     id=job_id,
                     project_id=project.id,
                     log_dir=job_dir,
                     data_dir=data_dir,
                     params=QuantizationJobParams(
-                        model_id=job_request.parameters.model_id,
-                        project_id=project.id,
                         job_id=job_id,
+                        project_id=project.id,
+                        model_id=job_request.parameters.model_id,
+                        model_architecture_id=arch_id,
+                        model_architecture_name=arch_name,
                         max_calibration_subset_size=job_request.parameters.max_calibration_subset_size,
                         max_drop=job_request.parameters.max_drop,
                         max_num_iterations=job_request.parameters.max_num_iterations,

--- a/application/backend/app/api/schemas/jobs/quantization.py
+++ b/application/backend/app/api/schemas/jobs/quantization.py
@@ -16,6 +16,7 @@ class QuantizationRequestParams(BaseModel):
     """Request parameters for the quantization job."""
 
     model_id: UUID = Field(..., description="ID of the model revision to quantize")
+    model_architecture_id: str = Field(..., description="Model architecture identifier")
     max_calibration_subset_size: int = Field(
         100, description="Maximum number of samples from the dataset revision to be used for calibration"
     )
@@ -58,6 +59,7 @@ class QuantizationRequest(BaseJobRequest):
                 "project_id": "7b073838-99d3-42ff-9018-4e901eb047fc",
                 "parameters": {
                     "model_id": "6b7bb928-5d6f-46ea-8fd2-5ce80dd1e12b",
+                    "model_architecture_id": "object-detection-atss-mobilenet-v2",
                     "max_calibration_subset_size": 100,
                     "max_drop": 0.01,
                     "max_num_iterations": 10,
@@ -77,6 +79,8 @@ class QuantizationModelMetadata(BaseModel):
     """Metadata about the model being quantized."""
 
     id: UUID = Field(..., description="Model revision identifier")
+    name: str = Field(..., description="Model name")
+    architecture: str = Field(..., description="Model architecture identifier")
 
 
 class QuantizationModelVariantMetadata(BaseModel):
@@ -103,7 +107,9 @@ class QuantizationMetadata(BaseModel):
         if isinstance(data, QuantizationJob):
             return {
                 "project": QuantizationProjectMetadata(id=data.project_id),
-                "model": QuantizationModelMetadata(id=data.params.model_id),
+                "model": QuantizationModelMetadata(
+                    id=data.params.model_id, name=data.params.model_name, architecture=data.params.model_architecture_id
+                ),
                 "model_variant": QuantizationModelVariantMetadata(id=data.params.model_variant_id),
                 "max_calibration_subset_size": data.params.max_calibration_subset_size,
                 "max_drop": data.params.max_drop,

--- a/application/backend/app/models/jobs/quantization_job.py
+++ b/application/backend/app/models/jobs/quantization_job.py
@@ -6,7 +6,7 @@ from typing import Literal
 from uuid import UUID, uuid4
 
 from loguru import logger
-from pydantic import Field
+from pydantic import Field, computed_field
 
 from app.core.jobs.models import JobParams, JobType, ProjectJob
 
@@ -15,6 +15,8 @@ class QuantizationJobParams(JobParams):
     job_id: UUID
     project_id: UUID
     model_id: UUID  # Source model revision to quantize
+    model_architecture_id: str
+    model_architecture_name: str
     model_variant_id: UUID = Field(default_factory=uuid4)
     max_calibration_subset_size: int = Field(default=100, description="Max samples for calibration")
     max_drop: float | None = Field(default=None, description="Max accuracy drop for accuracy-aware quantization")
@@ -22,6 +24,12 @@ class QuantizationJobParams(JobParams):
         default=10,
         description="Max number of iterations for accuracy-aware quantization (None means unlimited)",
     )
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def model_name(self) -> str:
+        """User-friendly model name derived from architecture name and model ID."""
+        return f"{self.model_architecture_name} ({str(self.model_id).split('-')[0]})"
 
 
 class QuantizationJob(ProjectJob[QuantizationJobParams]):

--- a/application/backend/tests/unit/api/routers/test_jobs.py
+++ b/application/backend/tests/unit/api/routers/test_jobs.py
@@ -121,12 +121,15 @@ class TestJobEndpoints:
         fxt_project_service.get_project_by_id.return_value = project
 
         model_id = uuid4()
+        mock_manifest = Mock()
+        mock_manifest.name = "ViT Tiny"
         job_request = JobRequestAdapter.validate_python(
             {
                 "project_id": project.id,
                 "job_type": JobType.QUANTIZE,
                 "parameters": {
                     "model_id": model_id,
+                    "model_architecture_id": "image-classification-vit-tiny",
                     "max_calibration_subset_size": 200,
                     "max_drop": 0.01,
                     "max_num_iterations": 5,
@@ -134,7 +137,8 @@ class TestJobEndpoints:
             }
         )
 
-        response = fxt_client.post("/api/jobs", json=job_request.model_dump(mode="json"))
+        with patch("app.api.routers.jobs.ModelManifestService.get_model_manifest_by_id", return_value=mock_manifest):
+            response = fxt_client.post("/api/jobs", json=job_request.model_dump(mode="json"))
 
         assert response.status_code == status.HTTP_202_ACCEPTED
         assert response.json()["job_id"]
@@ -144,6 +148,8 @@ class TestJobEndpoints:
         submitted_job = fxt_jobs_queue.submit.call_args[0][0]
         assert submitted_job.job_type == JobType.QUANTIZE
         assert submitted_job.params.model_id == model_id
+        assert submitted_job.params.model_architecture_id == "image-classification-vit-tiny"
+        assert submitted_job.params.model_architecture_name == "ViT Tiny"
         assert submitted_job.params.max_calibration_subset_size == 200
         assert submitted_job.params.max_drop == 0.01
         assert submitted_job.params.max_num_iterations == 5
@@ -161,17 +167,21 @@ class TestJobEndpoints:
         fxt_project_service.get_project_by_id.return_value = project
 
         model_id = uuid4()
+        mock_manifest = Mock()
+        mock_manifest.name = "ViT Tiny"
         job_request = JobRequestAdapter.validate_python(
             {
                 "project_id": project.id,
                 "job_type": JobType.QUANTIZE,
                 "parameters": {
                     "model_id": model_id,
+                    "model_architecture_id": "image-classification-vit-tiny",
                 },
             }
         )
 
-        response = fxt_client.post("/api/jobs", json=job_request.model_dump(mode="json"))
+        with patch("app.api.routers.jobs.ModelManifestService.get_model_manifest_by_id", return_value=mock_manifest):
+            response = fxt_client.post("/api/jobs", json=job_request.model_dump(mode="json"))
 
         assert response.status_code == status.HTTP_202_ACCEPTED
         submitted_job = fxt_jobs_queue.submit.call_args[0][0]

--- a/application/backend/tests/unit/execution/quantization/test_getitune_quantizer.py
+++ b/application/backend/tests/unit/execution/quantization/test_getitune_quantizer.py
@@ -94,6 +94,8 @@ def fxt_quantization_params() -> QuantizationJobParams:
         job_id=uuid4(),
         project_id=uuid4(),
         model_id=uuid4(),
+        model_architecture_id="test_arch",
+        model_architecture_name="Test Arch",
         max_calibration_subset_size=100,
         max_drop=None,
     )
@@ -793,6 +795,8 @@ class TestGetiTuneQuantizerExecute:
             job_id=uuid4(),
             project_id=project_id,
             model_id=model_id,
+            model_architecture_id="test_arch",
+            model_architecture_name="Test Arch",
             model_variant_id=model_variant_id,
             max_calibration_subset_size=50,
             max_drop=None,
@@ -929,6 +933,8 @@ class TestGetiTuneQuantizerExecute:
             job_id=uuid4(),
             project_id=project_id,
             model_id=model_id,
+            model_architecture_id="test_arch",
+            model_architecture_name="Test Arch",
             model_variant_id=model_variant_id,
             max_calibration_subset_size=200,
             max_drop=0.02,
@@ -1015,6 +1021,8 @@ class TestGetiTuneQuantizerExecute:
             job_id=uuid4(),
             project_id=project_id,
             model_id=model_id,
+            model_architecture_id="test_arch",
+            model_architecture_name="Test Arch",
             max_calibration_subset_size=100,
         )
 

--- a/application/backend/tests/unit/models/jobs/test_quantization_job.py
+++ b/application/backend/tests/unit/models/jobs/test_quantization_job.py
@@ -17,6 +17,8 @@ def fxt_quantization_params() -> Callable[[UUID, UUID], QuantizationJobParams]:
             job_id=job_id,
             project_id=project_id,
             model_id=uuid4(),
+            model_architecture_id="test_arch",
+            model_architecture_name="Test Arch",
         )
 
     return _make_quantization_job_params

--- a/application/ui/src/features/models/model-listing/model-variants/model-variant-tabs.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-variants/model-variant-tabs.component.tsx
@@ -42,7 +42,7 @@ export const ModelVariantsTabs = ({ model }: ModelVariantsTabsProps) => {
             <TabPanels width={0} minWidth={'100%'} UNSAFE_className={classes.tabPanels}>
                 <Item key='openvino'>
                     <ModelVariantTable model={model} format='openvino' />
-                    <QuantizationRow modelId={model.id} />
+                    <QuantizationRow modelId={model.id} modelArchitectureId={model.architecture} />
                 </Item>
                 <Item key='pytorch'>
                     <ModelVariantTable model={model} format='pytorch' />

--- a/application/ui/src/features/models/model-listing/model-variants/model-variant-tabs.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-variants/model-variant-tabs.component.tsx
@@ -42,7 +42,7 @@ export const ModelVariantsTabs = ({ model }: ModelVariantsTabsProps) => {
             <TabPanels width={0} minWidth={'100%'} UNSAFE_className={classes.tabPanels}>
                 <Item key='openvino'>
                     <ModelVariantTable model={model} format='openvino' />
-                    <QuantizationRow modelId={model.id} modelArchitectureId={model.architecture} />
+                    <QuantizationRow model={model} />
                 </Item>
                 <Item key='pytorch'>
                     <ModelVariantTable model={model} format='pytorch' />

--- a/application/ui/src/features/models/model-listing/model-variants/quantization-dialog/quantization-dialog.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-variants/quantization-dialog/quantization-dialog.component.tsx
@@ -10,6 +10,7 @@ import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import { $api } from '../../../../../api/client';
 import { toast } from '../../../../../components/toast/toast.component';
+import type { Model } from '../../../../../constants/shared-types';
 import {
     CalibrationDatasetSizeField,
     DEFAULT_QUANTIZATION_PARAMETERS,
@@ -34,12 +35,11 @@ const useDatasetItemsCount = () => {
 };
 
 type QuantizationDialogProps = {
-    modelId: string;
-    modelArchitectureId: string;
+    model: Model;
     onClose: () => void;
 };
 
-export const QuantizationDialog = ({ modelId, modelArchitectureId, onClose }: QuantizationDialogProps) => {
+export const QuantizationDialog = ({ model, onClose }: QuantizationDialogProps) => {
     const [accuracyDrop, setAccuracyDrop] = useState(DEFAULT_QUANTIZATION_PARAMETERS.accuracyDrop);
     const [hasNoMaxAccuracyDrop, setHasNoMaxAccuracyDrop] = useState(
         DEFAULT_QUANTIZATION_PARAMETERS.hasNoMaxAccuracyDrop
@@ -66,8 +66,8 @@ export const QuantizationDialog = ({ modelId, modelArchitectureId, onClose }: Qu
                     project_id: projectId,
                     job_type: 'quantize',
                     parameters: {
-                        model_id: modelId,
-                        model_architecture_id: modelArchitectureId,
+                        model_id: model.id,
+                        model_architecture_id: model.architecture,
                         max_drop: hasNoMaxAccuracyDrop ? null : accuracyDrop / 100,
                         max_num_iterations: hasNoMaxAccuracyDrop ? null : maxNumIterations,
                         max_calibration_subset_size: usesFullCalibrationDataset ? totalCount : effectiveCalibrationSize,

--- a/application/ui/src/features/models/model-listing/model-variants/quantization-dialog/quantization-dialog.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-variants/quantization-dialog/quantization-dialog.component.tsx
@@ -4,13 +4,13 @@
 import { useState } from 'react';
 
 import { $api } from '@/api';
+import type { Model } from '@/api/types';
 import { Button, ButtonGroup, Content, Dialog, dimensionValue, Divider, Flex, Heading, Text, View } from '@geti-ui/ui';
 import { InfoOutline } from '@geti-ui/ui/icons';
 import { useSubmitJob } from 'hooks/api/jobs/jobs.hook';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import { toast } from '../../../../../components/toast/toast.component';
-import type { Model } from '../../../../../constants/shared-types';
 import {
     CalibrationDatasetSizeField,
     DEFAULT_QUANTIZATION_PARAMETERS,

--- a/application/ui/src/features/models/model-listing/model-variants/quantization-dialog/quantization-dialog.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-variants/quantization-dialog/quantization-dialog.component.tsx
@@ -35,10 +35,11 @@ const useDatasetItemsCount = () => {
 
 type QuantizationDialogProps = {
     modelId: string;
+    modelArchitectureId: string;
     onClose: () => void;
 };
 
-export const QuantizationDialog = ({ modelId, onClose }: QuantizationDialogProps) => {
+export const QuantizationDialog = ({ modelId, modelArchitectureId, onClose }: QuantizationDialogProps) => {
     const [accuracyDrop, setAccuracyDrop] = useState(DEFAULT_QUANTIZATION_PARAMETERS.accuracyDrop);
     const [hasNoMaxAccuracyDrop, setHasNoMaxAccuracyDrop] = useState(
         DEFAULT_QUANTIZATION_PARAMETERS.hasNoMaxAccuracyDrop
@@ -66,6 +67,7 @@ export const QuantizationDialog = ({ modelId, onClose }: QuantizationDialogProps
                     job_type: 'quantize',
                     parameters: {
                         model_id: modelId,
+                        model_architecture_id: modelArchitectureId,
                         max_drop: hasNoMaxAccuracyDrop ? null : accuracyDrop / 100,
                         max_num_iterations: hasNoMaxAccuracyDrop ? null : maxNumIterations,
                         max_calibration_subset_size: usesFullCalibrationDataset ? totalCount : effectiveCalibrationSize,

--- a/application/ui/src/features/models/model-listing/model-variants/quantization-row.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-variants/quantization-row.component.tsx
@@ -23,12 +23,7 @@ export const QuantizationRow = ({ model }: QuantizationRowProps) => {
             </Flex>
             <DialogTrigger>
                 <Button variant={'secondary'}>Start quantization</Button>
-                {(close) => (
-                    <QuantizationDialog
-                        model={model}
-                        onClose={close}
-                    />
-                )}
+                {(close) => <QuantizationDialog model={model} onClose={close} />}
             </DialogTrigger>
         </Flex>
     );

--- a/application/ui/src/features/models/model-listing/model-variants/quantization-row.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-variants/quantization-row.component.tsx
@@ -7,8 +7,9 @@ import { QuantizationDialog } from './quantization-dialog/quantization-dialog.co
 
 type QuantizationRowProps = {
     modelId: string;
+    modelArchitectureId: string;
 };
-export const QuantizationRow = ({ modelId }: QuantizationRowProps) => {
+export const QuantizationRow = ({ modelId, modelArchitectureId }: QuantizationRowProps) => {
     return (
         <Flex marginTop={'size-150'} alignItems={'center'} justifyContent={'space-between'}>
             <Flex>
@@ -22,7 +23,13 @@ export const QuantizationRow = ({ modelId }: QuantizationRowProps) => {
             </Flex>
             <DialogTrigger>
                 <Button variant={'secondary'}>Start quantization</Button>
-                {(close) => <QuantizationDialog modelId={modelId} onClose={close} />}
+                {(close) => (
+                    <QuantizationDialog
+                        modelId={modelId}
+                        modelArchitectureId={modelArchitectureId}
+                        onClose={close}
+                    />
+                )}
             </DialogTrigger>
         </Flex>
     );

--- a/application/ui/src/features/models/model-listing/model-variants/quantization-row.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-variants/quantization-row.component.tsx
@@ -1,9 +1,9 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import type { Model } from '@/api/types';
 import { Button, Content, ContextualHelp, DialogTrigger, Flex, Text } from '@geti-ui/ui';
 
-import type { Model } from '../../../../constants/shared-types';
 import { QuantizationDialog } from './quantization-dialog/quantization-dialog.component';
 
 type QuantizationRowProps = {

--- a/application/ui/src/features/models/model-listing/model-variants/quantization-row.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-variants/quantization-row.component.tsx
@@ -3,13 +3,13 @@
 
 import { Button, Content, ContextualHelp, DialogTrigger, Flex, Text } from '@geti-ui/ui';
 
+import type { Model } from '../../../../constants/shared-types';
 import { QuantizationDialog } from './quantization-dialog/quantization-dialog.component';
 
 type QuantizationRowProps = {
-    modelId: string;
-    modelArchitectureId: string;
+    model: Model;
 };
-export const QuantizationRow = ({ modelId, modelArchitectureId }: QuantizationRowProps) => {
+export const QuantizationRow = ({ model }: QuantizationRowProps) => {
     return (
         <Flex marginTop={'size-150'} alignItems={'center'} justifyContent={'space-between'}>
             <Flex>
@@ -25,8 +25,7 @@ export const QuantizationRow = ({ modelId, modelArchitectureId }: QuantizationRo
                 <Button variant={'secondary'}>Start quantization</Button>
                 {(close) => (
                     <QuantizationDialog
-                        modelId={modelId}
-                        modelArchitectureId={modelArchitectureId}
+                        model={model}
                         onClose={close}
                     />
                 )}

--- a/application/ui/tests/models/model-details.spec.ts
+++ b/application/ui/tests/models/model-details.spec.ts
@@ -291,6 +291,7 @@ test.describe('Model Details', () => {
                 project_id: 'id-1',
                 parameters: {
                     model_id: 'model-1',
+                    model_architecture_id: 'Object_Detection_YOLOX_X',
                     max_drop: 0.05,
                     max_num_iterations: 7,
                     max_calibration_subset_size: 300,


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Adds the model name to the jobs card for quantization.

<img width="1845" height="219" alt="image" src="https://github.com/user-attachments/assets/ea356e83-47a7-435d-a2a9-0a758da5f6d2" />

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
