### PR TITLE
feat: Pin active project, improve UX of filtering, searching and sorting

### DIFF
--- a/application/ui/src/components/project-panel/projects-list.component.tsx
+++ b/application/ui/src/components/project-panel/projects-list.component.tsx
@@ -16,7 +16,7 @@ type ProjectListProps = {
 export const ProjectsList = ({ projects, onRename, onDelete, onEnableBlocked }: ProjectListProps) => {
     const projectNames = projects.map(({ name }) => name);
     const projectsWithActiveProjectInFront = projects.toSorted((projectA, projectB) =>
-        projectA.active_pipeline ? -1 : projectB.active_pipeline ? -1 : 0
+        projectA.active_pipeline ? -1 : projectB.active_pipeline ? 1 : 0
     );
 
     return (

--- a/application/ui/src/components/project-panel/projects-list.component.tsx
+++ b/application/ui/src/components/project-panel/projects-list.component.tsx
@@ -15,10 +15,13 @@ type ProjectListProps = {
 
 export const ProjectsList = ({ projects, onRename, onDelete, onEnableBlocked }: ProjectListProps) => {
     const projectNames = projects.map(({ name }) => name);
+    const projectsWithActiveProjectInFront = projects.toSorted((projectA, projectB) =>
+        projectA.active_pipeline ? -1 : projectB.active_pipeline ? -1 : 0
+    );
 
     return (
         <ul>
-            {projects.map((project) => (
+            {projectsWithActiveProjectInFront.map((project) => (
                 <ProjectListItem
                     key={project.id}
                     project={project}

--- a/application/ui/src/features/project/list/filter-projects/no-matching-projects.module.scss
+++ b/application/ui/src/features/project/list/filter-projects/no-matching-projects.module.scss
@@ -1,6 +1,5 @@
 .container {
-    height: 100%;
-    min-height: var(--spectrum-global-dimension-size-3600);
+    height: var(--spectrum-global-dimension-size-3600);
     border: 1px dashed var(--spectrum-global-color-gray-700);
     padding: var(--spectrum-global-dimension-size-500) var(--spectrum-global-dimension-size-200);
     background: var(--spectrum-global-color-gray-300);

--- a/application/ui/src/features/project/list/filter-projects/project-filters.component.tsx
+++ b/application/ui/src/features/project/list/filter-projects/project-filters.component.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { TaskType } from '@/api/types';
-import { Checkbox, CheckboxGroup, SearchField } from '@geti-ui/ui';
+import { Checkbox, CheckboxGroup, Flex, SearchField, View } from '@geti-ui/ui';
 import { isEmpty } from 'lodash-es';
 
 import { FilterPopoverButton } from '../../../../components/filter-popover-button/filter-popover-button.component';
@@ -28,32 +28,36 @@ export const ProjectFilters = ({
         : `${selectedTaskTypes.length} ${pluralize(selectedTaskTypes.length, 'type', 'types')} selected`;
 
     return (
-        <>
-            <FilterPopoverButton
-                ariaLabel={'Filter by task type'}
-                placeholder={'Filter by task type'}
-                summary={summary}
-            >
-                <CheckboxGroup
-                    aria-label={'Filter by task type'}
-                    value={selectedTaskTypes}
-                    onChange={(values) => onSelectedTaskTypesChange(values as TaskType[])}
-                >
-                    {TASK_TYPE_OPTIONS.map((taskType) => (
-                        <Checkbox key={taskType} value={taskType}>
-                            {MAP_PROJECT_TYPE_TO_TITLE[taskType]}
-                        </Checkbox>
-                    ))}
-                </CheckboxGroup>
-            </FilterPopoverButton>
-
+        <Flex alignItems={'center'} gap={'size-200'} flex={1}>
             <SearchField
                 value={searchName}
                 onChange={onSearchChange}
                 placeholder={'Search by name...'}
                 aria-label={'Search projects by name'}
-                marginStart={'auto'}
+                flex={1}
             />
-        </>
+
+            <View backgroundColor={'gray-50'}>
+                <FilterPopoverButton
+                    ariaLabel={'Filter by task type'}
+                    placeholder={'Filter by task type'}
+                    summary={summary}
+                    minWidth={'size-2400'}
+                    dialogWidth={'size-1600'}
+                >
+                    <CheckboxGroup
+                        aria-label={'Filter by task type'}
+                        value={selectedTaskTypes}
+                        onChange={(values) => onSelectedTaskTypesChange(values as TaskType[])}
+                    >
+                        {TASK_TYPE_OPTIONS.map((taskType) => (
+                            <Checkbox key={taskType} value={taskType}>
+                                {MAP_PROJECT_TYPE_TO_TITLE[taskType]}
+                            </Checkbox>
+                        ))}
+                    </CheckboxGroup>
+                </FilterPopoverButton>
+            </View>
+        </Flex>
     );
 };

--- a/application/ui/src/features/project/list/filter-projects/utils.ts
+++ b/application/ui/src/features/project/list/filter-projects/utils.ts
@@ -4,7 +4,7 @@
 import type { Project, TaskType } from '@/api/types';
 import { isEmpty } from 'lodash-es';
 
-export const TASK_TYPE_OPTIONS: TaskType[] = ['classification', 'detection', 'instance_segmentation'];
+export const TASK_TYPE_OPTIONS: TaskType[] = ['detection', 'instance_segmentation', 'classification'];
 
 export const filterProjects = (projects: Project[], searchName: string, selectedTaskTypes: TaskType[]): Project[] => {
     const normalizedSearch = searchName.trim().toLocaleLowerCase();

--- a/application/ui/src/features/project/list/import-jobs-list/import-jobs-list.component.tsx
+++ b/application/ui/src/features/project/list/import-jobs-list/import-jobs-list.component.tsx
@@ -4,7 +4,7 @@
 import { Flex } from '@geti-ui/ui';
 import { useQueryClient } from '@tanstack/react-query';
 import { useImportDatasetAsNewProject } from 'hooks/storage/use-import-dataset-as-new-project.hook';
-import { partition } from 'lodash-es';
+import { isEmpty, partition } from 'lodash-es';
 
 import { StagedImportDataset } from '../../../../components/import-card-status/staged-import-dataset/staged-import-dataset.component';
 import { LoadingImportDataset } from '../../../../components/loading-import-dataset/loading-import-dataset.component';
@@ -41,6 +41,15 @@ export const ImportJobsList = () => {
         setCurrentStagedId(stagedDatasetId);
         datasetImportDialogState.open();
     };
+
+    if (
+        isEmpty(preparingImportsQueue) &&
+        isEmpty(taskTypeSelectionImportsQueue) &&
+        isEmpty(labelMappingImportsQueue) &&
+        isEmpty(importingJobQueue)
+    ) {
+        return null;
+    }
 
     return (
         <Flex

--- a/application/ui/src/features/project/list/new-project-card/new-project-card.component.tsx
+++ b/application/ui/src/features/project/list/new-project-card/new-project-card.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { ActionButton, Text, View } from '@geti-ui/ui';
+import { ActionButton, Flex, Text, View } from '@geti-ui/ui';
 import { AddCircle } from '@geti-ui/ui/icons';
 import { useNavigate } from 'react-router-dom';
 
@@ -26,8 +26,8 @@ export const NewProjectCard = () => {
     };
 
     return (
-        <>
-            <View UNSAFE_className={classes.card}>
+        <Flex gap={'size-300'}>
+            <View UNSAFE_className={classes.card} flex={1}>
                 <ActionButton onPress={handleCreateProject} UNSAFE_className={classes.buttonText}>
                     <AddCircle />
                     <Text>
@@ -37,7 +37,7 @@ export const NewProjectCard = () => {
                     </Text>
                 </ActionButton>
             </View>
-            <View UNSAFE_className={classes.card}>
+            <View UNSAFE_className={classes.card} flex={1}>
                 <ActionButton onPress={handleCreateFromDataset} UNSAFE_className={classes.buttonText}>
                     <AddCircle />
                     <Text>
@@ -48,6 +48,6 @@ export const NewProjectCard = () => {
                 </ActionButton>
             </View>
             <ImportDatasetAsNewProject dialogState={datasetImportDialogState} />
-        </>
+        </Flex>
     );
 };

--- a/application/ui/src/features/project/list/new-project-card/new-project-card.component.tsx
+++ b/application/ui/src/features/project/list/new-project-card/new-project-card.component.tsx
@@ -36,6 +36,8 @@ export const NewProjectCard = () => {
                         new project
                     </Text>
                 </ActionButton>
+            </View>
+            <View UNSAFE_className={classes.card}>
                 <ActionButton onPress={handleCreateFromDataset} UNSAFE_className={classes.buttonText}>
                     <AddCircle />
                     <Text>

--- a/application/ui/src/features/project/list/new-project-card/new-project-menu.module.scss
+++ b/application/ui/src/features/project/list/new-project-card/new-project-menu.module.scss
@@ -3,7 +3,6 @@
     display: flex;
     border: 1px dashed var(--spectrum-gray-700) !important;
     border-radius: var(--spectrum-alias-border-radius-regular);
-    background-color: var(--spectrum-global-color-gray-300);
     gap: var(--spectrum-global-dimension-size-10);
 
     button {
@@ -13,6 +12,7 @@
         align-items: center;
         flex-direction: column;
         justify-content: center;
+        background-color: var(--spectrum-global-color-gray-300);
         gap: var(--spectrum-global-dimension-size-200);
     }
 }

--- a/application/ui/src/features/project/list/project-list.component.tsx
+++ b/application/ui/src/features/project/list/project-list.component.tsx
@@ -59,7 +59,7 @@ const ProjectGrid = () => {
         'projects'
     )}`;
 
-    const columns = activeProject === undefined ? ['1fr', '1fr'] : ['1fr', '1fr', '2fr'];
+    const columns = activeProject === undefined ? ['1fr'] : ['1fr', '1fr'];
 
     return (
         <Flex direction={'column'} gap={'size-300'} height={'100%'}>

--- a/application/ui/src/features/project/list/project-list.component.tsx
+++ b/application/ui/src/features/project/list/project-list.component.tsx
@@ -100,7 +100,9 @@ const ProjectGrid = () => {
                 </>
             )}
             {sortedProjects.length === 0 ? (
-                <NoMatchingProjects />
+                isFiltering ? (
+                    <NoMatchingProjects />
+                ) : null
             ) : (
                 <Grid
                     flex={1}

--- a/application/ui/src/features/project/list/project-list.component.tsx
+++ b/application/ui/src/features/project/list/project-list.component.tsx
@@ -3,8 +3,9 @@
 
 import { Suspense, useMemo, useState } from 'react';
 
-import { Content, Flex, Grid, Heading, Loading, Text, View } from '@geti-ui/ui';
+import { Content, Divider, Flex, Grid, Heading, Loading, Text, View } from '@geti-ui/ui';
 import { useProjects } from 'hooks/api/project.hook';
+import { partition } from 'lodash-es';
 
 import { version } from '../../../../package.json';
 import { isNonEmptyArray, pluralize } from '../../../shared/util';
@@ -21,49 +22,83 @@ import { SortBy } from './sort-projects/utils';
 import backgroundStyles from '../project-background.module.scss';
 import classes from './project-list.module.scss';
 
+const MIN_NUMBER_OF_PROJECTS_TO_SHOW_FILTERS = 8;
+
 const ProjectGrid = () => {
-    const projects = useProjects();
+    const projectsQuery = useProjects();
+    const projects = projectsQuery.data;
     const [sortBy, setSortBy] = useState<SortBy>('createdAt-descending');
-    const hasProjects = isNonEmptyArray(projects.data);
+    const hasProjects = isNonEmptyArray(projects);
+
+    const shouldShowFilters = projects.length >= MIN_NUMBER_OF_PROJECTS_TO_SHOW_FILTERS;
+
+    const [[activeProject], projectsWithoutActivePipeline] = partition(projects, (project) => project.active_pipeline);
 
     const { searchName, setSearchName, selectedTaskTypes, setSelectedTaskTypes, filteredProjects, isFiltering } =
-        useProjectFilters(projects.data);
+        useProjectFilters(projectsWithoutActivePipeline);
 
     const sortedProjects = useMemo(() => {
         return SORT_BY_HANDLERS[sortBy](filteredProjects);
     }, [filteredProjects, sortBy]);
 
-    const projectNames = projects.data.map((project) => project.name);
+    const projectNames = projectsQuery.data.map((project) => project.name);
 
     if (!hasProjects) {
         return <EmptyProjectList />;
     }
 
-    const matchCountLabel = `${sortedProjects.length} of ${projects.data.length} ${pluralize(
-        projects.data.length,
+    const matchCountLabel = `${sortedProjects.length} of ${projectsWithoutActivePipeline.length} ${pluralize(
+        projectsWithoutActivePipeline.length,
         'project',
         'projects'
     )}`;
 
+    const totalCountLabel = `${projectsWithoutActivePipeline.length} ${pluralize(
+        projectsWithoutActivePipeline.length,
+        'project',
+        'projects'
+    )}`;
+
+    const columns = activeProject === undefined ? ['1fr', '1fr'] : ['1fr', '1fr', '2fr'];
+
     return (
-        <Flex direction={'column'} gap={'size-100'} height={'100%'}>
-            <Grid
-                gap={'size-200'}
-                columns={['1fr', '1fr', '1fr']}
-                marginBottom={'size-200'}
-                UNSAFE_className={classes.filtersContainer}
-            >
-                <SortProjects sortBy={sortBy} onSort={setSortBy} />
-                <ProjectFilters
-                    searchName={searchName}
-                    onSearchChange={setSearchName}
-                    selectedTaskTypes={selectedTaskTypes}
-                    onSelectedTaskTypesChange={setSelectedTaskTypes}
-                />
+        <Flex direction={'column'} gap={'size-300'} height={'100%'}>
+            <Divider size={'S'} />
+            <Grid columns={columns} gap={'size-300'} rows={['size-2000']}>
+                <NewProjectCard />
+
+                {activeProject !== undefined && (
+                    <ProjectCard
+                        item={activeProject}
+                        prioritizeImage
+                        projectNames={projectNames.filter((projectName) => projectName !== activeProject.name)}
+                    />
+                )}
             </Grid>
+            {shouldShowFilters && (
+                <>
+                    <Divider size={'S'} />
 
-            {isFiltering && <Text UNSAFE_className={classes.projectMetadata}>{matchCountLabel}</Text>}
+                    <Flex width={'100%'} gap={'size-200'}>
+                        <SortProjects sortBy={sortBy} onSort={setSortBy} />
 
+                        <Divider size={'S'} orientation={'vertical'} />
+
+                        <Flex flex={1} alignItems={'center'} gap={'size-200'}>
+                            <Text UNSAFE_className={classes.projectMetadata}>
+                                {isFiltering ? matchCountLabel : totalCountLabel}
+                            </Text>
+
+                            <ProjectFilters
+                                searchName={searchName}
+                                onSearchChange={setSearchName}
+                                selectedTaskTypes={selectedTaskTypes}
+                                onSelectedTaskTypesChange={setSelectedTaskTypes}
+                            />
+                        </Flex>
+                    </Flex>
+                </>
+            )}
             {sortedProjects.length === 0 ? (
                 <NoMatchingProjects />
             ) : (
@@ -72,11 +107,9 @@ const ProjectGrid = () => {
                     gap={'size-300'}
                     autoRows={'size-2000'}
                     justifyContent={'center'}
-                    UNSAFE_style={{ overflowY: 'auto', scrollbarGutter: 'stable' }}
+                    UNSAFE_style={{ overflowY: 'auto' }}
                     columns={['1fr', '1fr']}
                 >
-                    <NewProjectCard />
-
                     {sortedProjects.map((item, index) => (
                         <ProjectCard
                             key={item.id}

--- a/application/ui/src/features/project/list/project-list.module.scss
+++ b/application/ui/src/features/project/list/project-list.module.scss
@@ -96,14 +96,10 @@
 
 .projectMetadata {
     line-height: var(--spectrum-global-dimension-font-size-200);
+    font-size: var(--spectrum-global-dimension-font-size-50);
 }
 
 .version {
     font-size: var(--spectrum-global-dimension-font-size-75);
     color: var(--spectrum-global-color-gray-800);
-}
-.filtersContainer {
-    background-color: var(--spectrum-global-color-gray-50);
-    padding: var(--spectrum-global-dimension-size-150);
-    border-radius: var(--spectrum-global-dimension-size-50);
 }

--- a/application/ui/src/features/project/list/projects-list.test.tsx
+++ b/application/ui/src/features/project/list/projects-list.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getMockedPipeline } from 'mocks/mock-pipeline';
 import { getMockedProject } from 'mocks/mock-project';
@@ -59,7 +59,22 @@ const projects = [
         created_at: '2026-05-01T10:00:00Z',
         task: { exclusive_labels: true, labels: [], task_type: 'instance_segmentation' },
     }),
+    getMockedProject({
+        id: 'project-7',
+        name: 'Theta Project',
+        created_at: '2026-07-01T10:00:00Z',
+        task: { exclusive_labels: true, labels: [], task_type: 'instance_segmentation' },
+    }),
+    getMockedProject({
+        id: 'project-8',
+        name: 'Iota Project',
+        created_at: '2026-08-01T10:00:00Z',
+        task: { exclusive_labels: true, labels: [], task_type: 'detection' },
+    }),
 ];
+
+// Below MIN_NUMBER_OF_PROJECTS_TO_SHOW_FILTERS (8), sort/filter controls are hidden.
+const fewProjects = projects.slice(0, 6);
 
 describe('ProjectList', () => {
     describe('with projects', () => {
@@ -186,12 +201,13 @@ describe('ProjectList', () => {
             );
         });
 
-        it('does not show the match count label by default', async () => {
+        it('shows the project count label by default (not filtering)', async () => {
             renderProjectList();
 
             expect(await screen.findByRole('heading', { name: 'Alpha Project' })).toBeInTheDocument();
 
-            expect(screen.queryByText(/of 6 projects/i)).not.toBeInTheDocument();
+            expect(screen.getByText('8 projects')).toBeInTheDocument();
+            expect(screen.queryByText(/of 8 projects/i)).not.toBeInTheDocument();
         });
 
         it('filters projects by name search', async () => {
@@ -202,7 +218,7 @@ describe('ProjectList', () => {
 
             await user.type(screen.getByRole('searchbox', { name: /search projects by name/i }), 'beta');
 
-            expect(await screen.findByText('1 of 6 projects')).toBeInTheDocument();
+            expect(await screen.findByText('1 of 8 projects')).toBeInTheDocument();
             expect(screen.getByRole('heading', { name: 'Beta Project' })).toBeInTheDocument();
             expect(screen.queryByRole('heading', { name: 'Alpha Project' })).not.toBeInTheDocument();
             expect(screen.queryByRole('heading', { name: 'Zeta Project' })).not.toBeInTheDocument();
@@ -224,7 +240,7 @@ describe('ProjectList', () => {
             await user.keyboard('{Escape}');
 
             expect(await screen.findByText('1 type selected')).toBeInTheDocument();
-            expect(await screen.findByText('2 of 6 projects')).toBeInTheDocument();
+            expect(await screen.findByText('2 of 8 projects')).toBeInTheDocument();
             expect(screen.getByRole('heading', { name: 'Beta Project' })).toBeInTheDocument();
             expect(screen.getByRole('heading', { name: 'Gamma Project' })).toBeInTheDocument();
             expect(screen.queryByRole('heading', { name: 'Alpha Project' })).not.toBeInTheDocument();
@@ -243,7 +259,7 @@ describe('ProjectList', () => {
 
             await user.type(screen.getByRole('searchbox', { name: /search projects by name/i }), 'alpha');
 
-            expect(await screen.findByText('1 of 6 projects')).toBeInTheDocument();
+            expect(await screen.findByText('1 of 8 projects')).toBeInTheDocument();
             expect(screen.getByRole('heading', { name: 'Alpha Project' })).toBeInTheDocument();
             expect(screen.queryByRole('heading', { name: 'Beta Project' })).not.toBeInTheDocument();
             expect(screen.queryByRole('heading', { name: 'Zeta Project' })).not.toBeInTheDocument();
@@ -262,7 +278,7 @@ describe('ProjectList', () => {
             await user.type(screen.getByRole('searchbox', { name: /search projects by name/i }), 'beta');
 
             expect(await screen.findByText('No projects match your filters')).toBeInTheDocument();
-            expect(screen.getByText('0 of 6 projects')).toBeInTheDocument();
+            expect(screen.getByText('0 of 8 projects')).toBeInTheDocument();
             expect(
                 screen.queryByRole('heading', { name: /Alpha Project|Beta Project|Zeta Project/ })
             ).not.toBeInTheDocument();
@@ -275,6 +291,100 @@ describe('ProjectList', () => {
             expect(await screen.findByRole('heading', { name: 'Alpha Project' })).toBeInTheDocument();
 
             await user.type(screen.getByRole('searchbox', { name: /search projects by name/i }), 'does-not-exist');
+
+            expect(await screen.findByText('No projects match your filters')).toBeInTheDocument();
+        });
+    });
+
+    describe('with fewer than 8 projects', () => {
+        beforeEach(() => {
+            server.use(
+                http.get('/api/projects', () => {
+                    return HttpResponse.json(fewProjects);
+                }),
+                http.get('/api/projects/{project_id}/pipeline', () => {
+                    return HttpResponse.json(getMockedPipeline({ status: 'idle' }));
+                })
+            );
+        });
+
+        it('hides the sort control', async () => {
+            renderProjectList();
+
+            expect(await screen.findByRole('heading', { name: 'Alpha Project' })).toBeInTheDocument();
+
+            expect(screen.queryByRole('button', { name: /sort/i })).not.toBeInTheDocument();
+        });
+
+        it('hides the task type filter control', async () => {
+            renderProjectList();
+
+            expect(await screen.findByRole('heading', { name: 'Alpha Project' })).toBeInTheDocument();
+
+            expect(screen.queryByRole('button', { name: 'Filter by task type' })).not.toBeInTheDocument();
+        });
+
+        it('hides the search box', async () => {
+            renderProjectList();
+
+            expect(await screen.findByRole('heading', { name: 'Alpha Project' })).toBeInTheDocument();
+
+            expect(screen.queryByRole('searchbox', { name: /search projects by name/i })).not.toBeInTheDocument();
+        });
+
+        it('does not show a project count label', async () => {
+            renderProjectList();
+
+            expect(await screen.findByRole('heading', { name: 'Alpha Project' })).toBeInTheDocument();
+
+            expect(screen.queryByText(/^\d+ projects?$/i)).not.toBeInTheDocument();
+        });
+    });
+
+    describe('with an active pipeline project', () => {
+        const activeProject = getMockedProject({
+            id: 'project-active',
+            name: 'Running Project',
+            created_at: '2026-09-01T10:00:00Z',
+            active_pipeline: true,
+            task: { exclusive_labels: true, labels: [], task_type: 'detection' },
+        });
+
+        beforeEach(() => {
+            server.use(
+                http.get('/api/projects', () => {
+                    return HttpResponse.json([...projects, activeProject]);
+                }),
+                http.get('/api/projects/{project_id}/pipeline', () => {
+                    return HttpResponse.json(getMockedPipeline({ status: 'idle' }));
+                })
+            );
+        });
+
+        it('pins the active project card next to the "create new project" card with an "Active" badge', async () => {
+            renderProjectList();
+
+            const activeCard = await screen.findByLabelText('Project: Running Project');
+            expect(activeCard).not.toBeNull();
+            expect(activeCard && within(activeCard as HTMLElement).getByText('Active')).toBeInTheDocument();
+        });
+
+        it('excludes the active project from the project count', async () => {
+            renderProjectList();
+
+            expect(await screen.findByRole('heading', { name: 'Running Project' })).toBeInTheDocument();
+
+            // 9 projects total, 1 is pinned as active, so 8 remain in the sortable/filterable list.
+            expect(await screen.findByText('8 projects')).toBeInTheDocument();
+        });
+
+        it('excludes the active project from name search results', async () => {
+            const user = userEvent.setup();
+            renderProjectList();
+
+            expect(await screen.findByRole('heading', { name: 'Running Project' })).toBeInTheDocument();
+
+            await user.type(screen.getByRole('searchbox', { name: /search projects by name/i }), 'running');
 
             expect(await screen.findByText('No projects match your filters')).toBeInTheDocument();
         });


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

I met with Mariusz to discuss how that feature should look like, got more feedback about filtering and the result is this PR.
Major changes:
1. Active project (with enabled pipeline) is always at the top.
2. Filtering, sorting, searching is not needed for a few projects, decided that we enable these features when there are at least 8 projects.
3. Active project is not considered in filtering, sorting, searching.

<img width="1334" height="930" alt="image" src="https://github.com/user-attachments/assets/e431b1e1-6fc8-4235-809f-9042d51cd1b5" />
<img width="1335" height="932" alt="image" src="https://github.com/user-attachments/assets/7194e8d1-5015-4f3a-b1b7-be8c36cd1546" />
<img width="1557" height="932" alt="image" src="https://github.com/user-attachments/assets/da9140f7-2e83-4d00-8008-03715ce3479f" />
<img width="1556" height="928" alt="image" src="https://github.com/user-attachments/assets/0f2a07b0-ca1c-4e81-b1d5-0257f46fc38f" />
<img width="1557" height="929" alt="image" src="https://github.com/user-attachments/assets/73945a55-e8de-45ff-a2c6-a301be5bbd6f" />
<img width="1556" height="931" alt="image" src="https://github.com/user-attachments/assets/3bcff9ef-d551-4677-a738-caf0870b0f9b" />


Closes #7011 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
