### PR TITLE
fix: serve benchmark MLflow artifacts via proxy so tracebacks reach reports

### DIFF
--- a/library/src/getitune/benchmark/cli.py
+++ b/library/src/getitune/benchmark/cli.py
@@ -422,16 +422,31 @@ def _cmd_report(args: argparse.Namespace) -> int:
     for run in failed_runs:
         tags = run.data.tags
 
+        error_summary = tags.get("error", "Unknown error")
+
         # The full traceback is stored as an artifact (see
         # ``BenchmarkTracker.log_run``) rather than a tag, to keep tag values
-        # short. Best-effort download; missing artifacts must not break the
-        # report.
+        # short. Best-effort download; a missing or unreachable artifact must
+        # not break the report. This commonly fails when the MLflow server
+        # uses a local-filesystem artifact store (``artifact_uri`` without a
+        # scheme) that the reporting host cannot read, in which case the
+        # artifact endpoint returns an error. Log the reason at WARNING so the
+        # failure is diagnosable, and fall back to the one-line ``error`` tag
+        # so the report still surfaces the failure cause instead of silently
+        # dropping the entire Tracebacks section.
         traceback_text: str | None = None
         try:
             local_path = client.download_artifacts(run.info.run_id, "traceback.txt")
             traceback_text = Path(local_path).read_text()
-        except Exception:
-            logger.debug("Could not download traceback artifact for run %s.", run.info.run_id, exc_info=True)
+        except Exception as exc:  # never let a bad or unreachable artifact break the report
+            logger.warning(
+                "Could not download traceback artifact for run %s (%s on %s): %s. Falling back to the short error tag.",
+                run.info.run_id,
+                tags.get("model", "unknown"),
+                tags.get("dataset", "unknown"),
+                exc,
+            )
+            traceback_text = error_summary
 
         failures.append(
             ExperimentResult(
@@ -442,7 +457,7 @@ def _cmd_report(args: argparse.Namespace) -> int:
                 seed=int(tags.get("seed", "0")),
                 success=False,
                 phases=[],
-                error=tags.get("error", "Unknown error"),
+                error=error_summary,
                 traceback=traceback_text,
                 failed_phase=tags.get("error_phase"),
             )

--- a/library/src/getitune/benchmark/cli.py
+++ b/library/src/getitune/benchmark/cli.py
@@ -437,7 +437,7 @@ def _cmd_report(args: argparse.Namespace) -> int:
         traceback_text: str | None = None
         try:
             local_path = client.download_artifacts(run.info.run_id, "traceback.txt")
-            traceback_text = Path(local_path).read_text()
+            traceback_text = Path(local_path).read_text(encoding="utf-8", errors="replace")
         except Exception as exc:  # never let a bad or unreachable artifact break the report
             logger.warning(
                 "Could not download traceback artifact for run %s (%s on %s): %s. Falling back to the short error tag.",

--- a/library/src/getitune/benchmark/docker-compose.yaml
+++ b/library/src/getitune/benchmark/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
       - "${MLFLOW_PORT:-5000}:5000"
     environment:
       MLFLOW_BACKEND_STORE_URI: "postgresql://mlflow:${MLFLOW_DB_PASSWORD:-mlflow}@db:5432/mlflow"
-      MLFLOW_DEFAULT_ARTIFACT_ROOT: /mlflow/artifacts
+      MLFLOW_DEFAULT_ARTIFACT_ROOT: mlflow-artifacts:/
     volumes:
       - mlflow-artifacts:/mlflow/artifacts
     command: >
@@ -55,7 +55,9 @@ services:
         --host 0.0.0.0
         --port 5000
         --backend-store-uri "postgresql://mlflow:${MLFLOW_DB_PASSWORD:-mlflow}@db:5432/mlflow"
-        --default-artifact-root /mlflow/artifacts
+        --serve-artifacts
+        --artifacts-destination /mlflow/artifacts
+        --default-artifact-root mlflow-artifacts:/
         --workers 2
         --allowed-hosts "*"
         --cors-allowed-origins "*"

--- a/library/src/getitune/benchmark/tracking.py
+++ b/library/src/getitune/benchmark/tracking.py
@@ -431,7 +431,17 @@ class BenchmarkTracker:
         experiment_name = self.config.experiment_name
         experiment = mlflow.get_experiment_by_name(experiment_name)
         if experiment is None:
-            self._experiment_id = mlflow.create_experiment(experiment_name)
+            # Against a remote tracking server, pin the artifact location to the
+            # ``mlflow-artifacts:/`` proxy scheme so every client uploads and
+            # downloads artifacts over HTTP through the server, independent of
+            # its ``--default-artifact-root``. A bare local path there makes
+            # remote clients silently fail to store artifacts (e.g.
+            # ``traceback.txt``). Local file-store URIs cannot use the proxy,
+            # so fall back to MLflow's default (None).
+            artifact_location = (
+                "mlflow-artifacts:/" if self.config.tracking_uri.startswith(("http://", "https://")) else None
+            )
+            self._experiment_id = mlflow.create_experiment(experiment_name, artifact_location=artifact_location)
             logger.info("Created MLflow experiment: %s (id=%s)", experiment_name, self._experiment_id)
         else:
             self._experiment_id = experiment.experiment_id

--- a/library/tests/unit/benchmark/test_cli.py
+++ b/library/tests/unit/benchmark/test_cli.py
@@ -405,6 +405,97 @@ class TestCmdReport:
     @patch("mlflow.create_experiment")
     @patch("mlflow.get_experiment_by_name")
     @patch("mlflow.set_tracking_uri")
+    def test_report_falls_back_to_error_tag_when_traceback_unavailable(
+        self,
+        _mock_set_uri: MagicMock,
+        mock_get_exp: MagicMock,
+        _mock_create_exp: MagicMock,
+        _mock_set_exp: MagicMock,
+        mock_client_cls: MagicMock,
+        _mock_git_branch: MagicMock,
+        _mock_git_sha: MagicMock,
+        mock_generate_report: MagicMock,
+        manifest_file: Path,
+        tmp_path: Path,
+    ) -> None:
+        """When the traceback artifact cannot be downloaded (e.g. the MLflow
+        server uses an unreachable local-filesystem artifact store), the report
+        must still surface the failure by falling back to the short ``error``
+        tag rather than dropping the traceback entirely.
+        """
+        mock_experiment = MagicMock()
+        mock_experiment.experiment_id = "1"
+        mock_get_exp.return_value = mock_experiment
+
+        mock_client = mock_client_cls.return_value
+        mock_client.get_experiment_by_name.return_value = mock_experiment
+        mock_client.search_experiments.return_value = []
+
+        failed_run = MagicMock()
+        failed_run.info.run_id = "run-failed-1"
+        failed_run.data.tags = {
+            "task": "detection",
+            "model": "model_a",
+            "dataset": "ds_a",
+            "scenario": "default",
+            "seed": "1",
+            "error": "RuntimeError: Masks are required for metric computation",
+            "error_phase": "test/export",
+        }
+        failed_run.data.metrics = {}
+
+        def _search_runs(
+            *,
+            experiment_ids: list[str],
+            filter_string: str,
+            order_by: list[str],
+            max_results: int,
+        ) -> list[MagicMock]:
+            if "status = 'failed'" in filter_string:
+                return [failed_run]
+            return []
+
+        mock_client.search_runs.side_effect = _search_runs
+
+        # Simulate an unreachable artifact store (HTTP 500 / missing file).
+        mock_client.download_artifacts.side_effect = RuntimeError("500 Internal Server Error")
+
+        parser = _build_parser()
+        args = parser.parse_args(
+            [
+                "report",
+                "--manifest",
+                str(manifest_file),
+                "--output-root",
+                str(tmp_path / "results"),
+                "--mlflow-uri",
+                "http://localhost:5000",
+                "--branch",
+                "develop",
+            ]
+        )
+
+        rc = _cmd_report(args)
+
+        assert rc == 0
+        call_kwargs = mock_generate_report.call_args.kwargs
+        failures = call_kwargs["failures"]
+        assert len(failures) == 1
+        failure = failures[0]
+        assert failure.success is False
+        assert failure.failed_phase == "test/export"
+        # Fallback: traceback is populated from the short error tag.
+        assert failure.error == "RuntimeError: Masks are required for metric computation"
+        assert failure.traceback == failure.error
+
+    @patch("getitune.benchmark.report.generate_report")
+    @patch("getitune.benchmark.tracking.get_git_sha", return_value="abc123")
+    @patch("getitune.benchmark.tracking.get_git_branch", return_value="develop")
+    @patch("mlflow.tracking.MlflowClient")
+    @patch("mlflow.set_experiment")
+    @patch("mlflow.create_experiment")
+    @patch("mlflow.get_experiment_by_name")
+    @patch("mlflow.set_tracking_uri")
     def test_report_no_runs_returns_zero(
         self,
         _mock_set_uri: MagicMock,

--- a/library/tests/unit/benchmark/test_tracking.py
+++ b/library/tests/unit/benchmark/test_tracking.py
@@ -166,8 +166,34 @@ class TestBenchmarkTrackerSetup:
 
         mock_mlflow.set_tracking_uri.assert_called_once_with("/tmp/test_mlruns")  # noqa: S108
         mock_mlflow.get_experiment_by_name.assert_called_once_with("getitune-benchmark/develop/manual")
-        mock_mlflow.create_experiment.assert_called_once_with("getitune-benchmark/develop/manual")
+        # Local file-store URI: no proxy scheme available, so artifact_location
+        # must fall back to MLflow's default (None).
+        mock_mlflow.create_experiment.assert_called_once_with(
+            "getitune-benchmark/develop/manual", artifact_location=None
+        )
         assert tracker._experiment_id == "1"
+
+    @patch("getitune.benchmark.tracking.mlflow")
+    def test_setup_creates_experiment_with_proxy_artifacts_for_http_server(self, mock_mlflow: MagicMock) -> None:
+        """Against a remote MLflow server, new experiments must pin the
+        ``mlflow-artifacts:/`` proxy scheme so artifacts upload/download over
+        HTTP regardless of the server's ``--default-artifact-root``.
+        """
+        config = TrackingConfig(
+            tracking_uri="http://mlflow.example:5000",
+            branch="develop",
+            trigger="weekly",
+        )
+        mock_mlflow.get_experiment_by_name.return_value = None
+        mock_mlflow.create_experiment.return_value = "7"
+
+        tracker = BenchmarkTracker(config)
+        tracker.setup()
+
+        mock_mlflow.create_experiment.assert_called_once_with(
+            "getitune-benchmark/develop/weekly", artifact_location="mlflow-artifacts:/"
+        )
+        assert tracker._experiment_id == "7"
 
     @patch("getitune.benchmark.tracking.mlflow")
     def test_setup_reuses_existing_experiment(self, mock_mlflow: MagicMock) -> None:


### PR DESCRIPTION
## Problem

Benchmark reports never showed failure **tracebacks** — the `#### Tracebacks` section was silently absent from every report, even though 36 experiments failed in the last weekly run.

Root cause is the MLflow server configuration. The tracking server ran with a **bare local-filesystem artifact root**:

```
mlflow server ... --default-artifact-root /mlflow/artifacts
```

With a scheme-less artifact root, MLflow hands each run an `artifact_uri` like `/mlflow/artifacts/<exp>/<run>/artifacts` and expects the **client** to read/write that path directly on its own filesystem. Consequences:

- During `run`, the CI runner cannot write to `/mlflow/artifacts` (root-owned, not present on the runner), so `mlflow.log_text("traceback.txt")` silently failed — the server's artifact volume stayed **empty**.
- During `report`, `download_artifacts("traceback.txt")` returned **HTTP 500 / "Failed to download"**, which was swallowed at `DEBUG`, so the whole Tracebacks section was dropped.

Verified directly against the servers: `artifacts/list` returned no files for any run and the artifact volume was empty.

## Fix

Switch to MLflow's **proxied artifact serving** so every client (CI runner, local, or another host) uploads/downloads artifacts over HTTP through the tracking server, regardless of where it runs.

- **`docker-compose.yaml`** — add `--serve-artifacts`, `--artifacts-destination /mlflow/artifacts` (the persistent volume), and `--default-artifact-root mlflow-artifacts:/`.
- **`tracking.py`** — create experiments with an explicit `mlflow-artifacts:/` artifact location when tracking against an HTTP(S) server, so new experiments never depend on the server default. Local file-store URIs keep MLflow's default (`None`).
- **`cli.py`** — when a `traceback.txt` artifact can't be downloaded, log the reason at `WARNING` (was a swallowed `DEBUG`) and fall back to the short `error` tag so the report still renders the failure cause.

Added unit tests for the proxied-artifact experiment creation and the report fallback path.
