### PR TITLE
chore(ci): add skill-validator into CI

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -174,6 +174,16 @@
       schedule: ["* * 1,15 * *"], // twice a month
     },
 
+    // Custom semver versioning for geti-ci actions to support tags like zizmor/v0.1.0
+    {
+      enabled: true,
+      groupName: "GitHub Actions",
+      matchManagers: ["github-actions"],
+      matchPackageNames: ["open-edge-platform/geti-ci"],
+      schedule: ["* * 1,15 * *"], // twice a month
+      versioning: "regex:^(?<compatibility>[^/]+)/v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+    },
+
     // uv version used in GitHub Actions is updated manually
     {
       enabled: false,

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -46,7 +46,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Zizmor scan
-        uses: open-edge-platform/geti-ci/actions/zizmor@7e686c1248b3939f8ee8e04e2612da727e379d91
+        uses: open-edge-platform/geti-ci/actions/zizmor@0bed754fc7db24b5f9f15e7ead2eb4acdb0c7263 # zizmor/v0.1.2
         with:
           scan-scope: ${{ github.event_name == 'pull_request' && 'changed' || 'all' }}
           severity-level: ${{ github.event_name == 'pull_request' && 'MEDIUM' || 'LOW' }}
@@ -62,7 +62,7 @@ jobs:
       - *checkout
 
       - name: Run Bandit scan
-        uses: open-edge-platform/geti-ci/actions/bandit@7e686c1248b3939f8ee8e04e2612da727e379d91
+        uses: open-edge-platform/geti-ci/actions/bandit@d5b1283a2618b816cfce50d597754e8b8ea3a2b6 # bandit/v0.1.1
         with:
           scan-scope: ${{ github.event_name == 'pull_request' && 'changed' || 'all' }}
           severity-level: "LOW"

--- a/.github/workflows/skills.yaml
+++ b/.github/workflows/skills.yaml
@@ -1,41 +1,167 @@
 name: Skills
 
 on:
-  push:
+  merge_group:
     branches:
       - develop
-    paths:
-      - "skills/**"
-      - ".claude/skills/**"
-      - ".agents/skills/**"
-      - ".github/scripts/skills/**"
-      - ".github/workflows/skills.yaml"
+      - release/**
   pull_request:
-    paths:
-      - "skills/**"
-      - ".claude/skills/**"
-      - ".agents/skills/**"
-      - ".github/scripts/skills/**"
-      - ".github/workflows/skills.yaml"
   workflow_dispatch:
+    inputs:
+      severity:
+        description: "Severity level (CRITICAL, HIGH, MEDIUM, LOW)"
+        required: false
+        default: "LOW"
+        type: choice
+        options:
+          - CRITICAL
+          - HIGH
+          - MEDIUM
+          - LOW
 
-permissions: {} # No permissions by default on workflow level
+permissions: {}
 
 concurrency:
   group: skills-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  validate:
-    name: Validate skills layout
+  check-paths:
+    name: Check if workflow should run
     runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    outputs:
+      run_workflow: ${{ steps.check_paths.outputs.run }}
     permissions:
       contents: read
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          disable-sudo: true
+          disable-telemetry: true
+          egress-policy: audit
+
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Check paths
+        id: check_paths
+        uses: open-edge-platform/geti-ci/actions/check-paths@7e686c1248b3939f8ee8e04e2612da727e379d91
+        with:
+          files_yaml: |
+            test:
+              - skills/**
+              - .claude/skills/**
+              - .agents/skills/**
+              - .github/scripts/skills/**
+              - .github/workflows/skills.yml
+
+  layout-check:
+    name: Validate skills layout
+    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    needs: check-paths
+    if: needs.check-paths.outputs.run_workflow == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          disable-sudo: true
+          disable-telemetry: true
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Validate skills and adapter symlinks
         run: python3 .github/scripts/skills/agent_skills.py validate
+
+  skillspector-scan:
+    name: SkillSpector scan
+    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    needs: check-paths
+    if: needs.check-paths.outputs.run_workflow == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          disable-sudo: true
+          disable-telemetry: true
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Run SkillSpector scan
+        uses: open-edge-platform/geti-ci/actions/skill-scan@0745e2b1612e4c25c3e83eb37bddeba8743a2439 # skill-scan/v0.1.1
+        with:
+          severity-level: ${{ github.event_name == 'pull_request' && 'HIGH' || github.event.inputs.severity || 'LOW' }}
+          fail-on-findings: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+          skills-path: skills
+
+  skill-validator-scan:
+    name: skill-validator scan
+    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    needs: check-paths
+    if: needs.check-paths.outputs.run_workflow == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          disable-sudo: true
+          disable-telemetry: true
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Run skill-validator
+        uses: open-edge-platform/geti-ci/actions/skill-validator@dd2b6e59ed10c4937d18c0596502b0a9408ab52a # skill-validator/v0.1.1
+        with:
+          skills-path: skills
+          strict: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+          fail-on-findings: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+
+  required-check:
+    name: Required Check skills
+    needs:
+      - check-paths
+      - layout-check
+      - skillspector-scan
+      - skill-validator-scan
+    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    env:
+      CHECKS: ${{ join(needs.*.result, ' ') }}
+    if: always() && !cancelled()
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          disable-sudo: true
+          disable-telemetry: true
+          egress-policy: audit
+
+      - name: Check jobs results
+        run: |
+          for check in ${CHECKS}; do
+            echo "::notice::check=${check}"
+            if [[ "$check" != "success" && "$check" != "skipped" ]]; then
+              echo "::error ::Required status checks failed. They must succeed before this pull request can be merged."
+              exit 1
+            fi
+          done

--- a/.github/workflows/skills.yaml
+++ b/.github/workflows/skills.yaml
@@ -56,7 +56,7 @@ jobs:
               - .claude/skills/**
               - .agents/skills/**
               - .github/scripts/skills/**
-              - .github/workflows/skills.yml
+              - .github/workflows/skills.yaml
 
   layout-check:
     name: Validate skills layout
@@ -105,8 +105,8 @@ jobs:
       - name: Run SkillSpector scan
         uses: open-edge-platform/geti-ci/actions/skill-scan@0745e2b1612e4c25c3e83eb37bddeba8743a2439 # skill-scan/v0.1.1
         with:
-          severity-level: ${{ github.event_name == 'pull_request' && 'HIGH' || github.event.inputs.severity || 'LOW' }}
-          fail-on-findings: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+          severity-level: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'HIGH' || github.event.inputs.severity || 'LOW' }}
+          fail-on-findings: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'true' || 'false' }}
           skills-path: skills
 
   skill-validator-scan:
@@ -134,8 +134,8 @@ jobs:
         uses: open-edge-platform/geti-ci/actions/skill-validator@dd2b6e59ed10c4937d18c0596502b0a9408ab52a # skill-validator/v0.1.1
         with:
           skills-path: skills
-          strict: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
-          fail-on-findings: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+          strict: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'true' || 'false' }}
+          fail-on-findings: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'true' || 'false' }}
 
   required-check:
     name: Required Check skills


### PR DESCRIPTION
### Summary

This PR extends the Skills CI workflow to add an additional validation pass (`skill-validator`) alongside the existing SkillSpector scan, and adjusts Renovate scheduling for geti-ci action updates.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
