### PR TITLE
fix: Display media item in the annotator that is not fetched in the first media page

### DIFF
--- a/application/ui/src/features/dataset/api/use-get-dataset-media-item.ts
+++ b/application/ui/src/features/dataset/api/use-get-dataset-media-item.ts
@@ -1,0 +1,50 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { useMemo } from 'react';
+
+import { $api } from '@/api';
+import type { Media, MediaDTO } from '@/api/types';
+import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
+
+import { getErrorMessage } from '../../../query-client/query-client';
+
+// We will never get the video frame using '/api/projects/{project_id}/dataset/media/{media_id}',
+// it's added only because of documentation reasons. We use MediaVideoFrame as a local type to
+// work with the played frame in the video. Mirrors `getMediaEntities` in
+// `use-get-dataset-media-items.hook.ts`.
+const getMediaEntity = (item: MediaDTO): Media => {
+    if (item.type === 'video_frame') {
+        return {
+            duration: 0,
+            frame_count: 0,
+            annotated_frame_count: 0,
+            fps: 0,
+            frame_number: 0,
+            frame_stride: 0,
+            ...item,
+        };
+    }
+
+    return item;
+};
+
+interface UseGetDatasetMediaItemOptions {
+    enabled?: boolean;
+}
+
+export const useGetDatasetMediaItem = (mediaId: string | undefined, options?: UseGetDatasetMediaItemOptions) => {
+    const projectId = useProjectIdentifier();
+
+    const { data, isPending, isError, error } = $api.useQuery(
+        'get',
+        '/api/projects/{project_id}/dataset/media/{media_id}',
+        { params: { path: { project_id: projectId, media_id: String(mediaId) } } },
+        { enabled: Boolean(mediaId) && (options?.enabled ?? true) }
+    );
+
+    const mediaItem = useMemo(() => (data === undefined ? null : getMediaEntity(data)), [data]);
+    const errorMessage = useMemo(() => (isError ? getErrorMessage(error) : null), [isError, error]);
+
+    return { mediaItem, isPending, isError, errorMessage };
+};

--- a/application/ui/src/features/dataset/gallery/gallery.component.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.tsx
@@ -12,6 +12,8 @@ import { MediaThumbnail } from '../../../components/media-thumbnail/media-thumbn
 import { VirtualizerGridLayout } from '../../../components/virtualizer-grid-layout/virtualizer-grid-layout.component';
 import { type GalleryViewMode } from '../../../shared/gallery-view-modes';
 import { getMediaDownloadUrl, getThumbnailUrl } from '../../../shared/media-url.utils';
+import { MediaPreviewError } from '../media-preview/media-preview-error.component';
+import { MediaPreviewLoading } from '../media-preview/media-preview-loading.component';
 import { MediaPreview } from '../media-preview/media-preview.component';
 import { useSelectedData } from '../providers/selected-data-provider.component';
 import { AnnotationStatusIcon } from './annotation-state-icon.component';
@@ -134,7 +136,8 @@ export const Gallery = ({
     fetchNextPage,
     isMediaItemReviewedById,
 }: GalleryProps) => {
-    const { selectedMediaItem, onSelectedMediaItemChange } = useSelectDatasetItem();
+    const { selectedMediaItem, selectedDatasetItemId, isResolving, fetchErrorMessage, onSelectedMediaItemChange } =
+        useSelectDatasetItem();
 
     const { isClassification, uploadFiles, clearFilesForLabelAssignment, filesForLabelAssignment } = useUploadFiles();
 
@@ -159,13 +162,21 @@ export const Gallery = ({
                 {content}
 
                 <DialogContainer type={'fullscreenTakeover'} onDismiss={() => onSelectedMediaItemChange(null)}>
-                    {selectedMediaItem !== null && (
-                        <MediaPreview
-                            mediaItem={selectedMediaItem}
-                            close={() => onSelectedMediaItemChange(null)}
-                            onSelectedMediaItem={onSelectedMediaItemChange}
-                        />
-                    )}
+                    {selectedDatasetItemId != null &&
+                        (selectedMediaItem !== null ? (
+                            <MediaPreview
+                                mediaItem={selectedMediaItem}
+                                close={() => onSelectedMediaItemChange(null)}
+                                onSelectedMediaItem={onSelectedMediaItemChange}
+                            />
+                        ) : fetchErrorMessage !== null ? (
+                            <MediaPreviewError
+                                message={fetchErrorMessage}
+                                onClose={() => onSelectedMediaItemChange(null)}
+                            />
+                        ) : (
+                            isResolving && <MediaPreviewLoading />
+                        ))}
                 </DialogContainer>
             </DatasetDropZone>
 

--- a/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.test.ts
+++ b/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.test.ts
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Media } from '@/api/types';
-import { act } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 import { getMockedMediaImage, getMockedVideo, getMockedVideoFrame } from 'mocks/mock-media';
+import { HttpResponse } from 'msw';
 import { renderHook } from 'test-utils/render';
 
+import { http } from '../../../../api/utils';
 import { paths } from '../../../../constants/paths';
 import { useGetDatasetMediaItems } from '../../../../hooks/use-get-dataset-media-items.hook';
+import { server } from '../../../../msw-node-setup';
 import { useSelectDatasetItem } from './use-select-dataset-item.hook';
 
 const mockNavigate = vi.fn();
@@ -170,6 +173,11 @@ describe('useSelectDatasetItem', () => {
         it('returns null when datasetItemId does not match any item', () => {
             const image = getMockedMediaImage({ id: 'img-other' });
             vi.mocked(useGetDatasetMediaItems).mockReturnValue({ ...mockDatasetMediaItems, items: [image] });
+            server.use(
+                http.get('/api/projects/{project_id}/dataset/media/{media_id}', () => {
+                    return new HttpResponse(null, { status: 404 });
+                })
+            );
 
             const route = `${paths.project.dataset.item.index({ projectId: MOCKED_PROJECT_ID, datasetItemId: `${image.id}-23` })}${SEARCH}`;
             const { result } = renderHook(() => useSelectDatasetItem(), {
@@ -180,8 +188,75 @@ describe('useSelectDatasetItem', () => {
             expect(result.current.selectedMediaItem).toBeNull();
         });
 
+        it('is resolving while the direct fetch for an off-list item is in flight', async () => {
+            const image = getMockedMediaImage({ id: 'img-off-page' });
+            vi.mocked(useGetDatasetMediaItems).mockReturnValue({ ...mockDatasetMediaItems, items: [] });
+            server.use(
+                http.get('/api/projects/{project_id}/dataset/media/{media_id}', async () => {
+                    return HttpResponse.json(image);
+                })
+            );
+
+            const route = `${paths.project.dataset.item.index({ projectId: MOCKED_PROJECT_ID, datasetItemId: image.id })}${SEARCH}`;
+            const { result } = renderHook(() => useSelectDatasetItem(), {
+                route,
+                path: paths.project.dataset.item.index.pattern,
+            });
+
+            expect(result.current.isResolving).toBe(true);
+            expect(result.current.fetchErrorMessage).toBeNull();
+
+            await waitFor(() => expect(result.current.selectedMediaItem).toEqual(image));
+        });
+
+        it('returns the fetched item when it is not in the loaded list but the direct fetch resolves it', async () => {
+            const image = getMockedMediaImage({ id: 'img-off-page' });
+            vi.mocked(useGetDatasetMediaItems).mockReturnValue({ ...mockDatasetMediaItems, items: [] });
+            server.use(
+                http.get('/api/projects/{project_id}/dataset/media/{media_id}', () => {
+                    return HttpResponse.json(image);
+                })
+            );
+
+            const route = `${paths.project.dataset.item.index({ projectId: MOCKED_PROJECT_ID, datasetItemId: image.id })}${SEARCH}`;
+            const { result } = renderHook(() => useSelectDatasetItem(), {
+                route,
+                path: paths.project.dataset.item.index.pattern,
+            });
+
+            await waitFor(() => expect(result.current.selectedMediaItem).toEqual(image));
+            expect(result.current.isResolving).toBe(false);
+            expect(result.current.fetchErrorMessage).toBeNull();
+        });
+
+        it('surfaces the server error message when the direct fetch errors', async () => {
+            vi.mocked(useGetDatasetMediaItems).mockReturnValue({ ...mockDatasetMediaItems, items: [] });
+            server.use(
+                http.get('/api/projects/{project_id}/dataset/media/{media_id}', () => {
+                    // @ts-expect-error MSW's typed response doesn't document a JSON body for 404s,
+                    // but the server does return one at runtime.
+                    return HttpResponse.json({ detail: 'Media or project not found' }, { status: 404 });
+                })
+            );
+
+            const route = `${paths.project.dataset.item.index({ projectId: MOCKED_PROJECT_ID, datasetItemId: 'deleted-item' })}${SEARCH}`;
+            const { result } = renderHook(() => useSelectDatasetItem(), {
+                route,
+                path: paths.project.dataset.item.index.pattern,
+            });
+
+            await waitFor(() => expect(result.current.fetchErrorMessage).toBe('Media or project not found'));
+            expect(result.current.selectedMediaItem).toBeNull();
+            expect(result.current.isResolving).toBe(false);
+        });
+
         it('returns null when there are no items', () => {
             vi.mocked(useGetDatasetMediaItems).mockReturnValue({ ...mockDatasetMediaItems, items: [] });
+            server.use(
+                http.get('/api/projects/{project_id}/dataset/media/{media_id}', () => {
+                    return new HttpResponse(null, { status: 404 });
+                })
+            );
 
             const route = `${paths.project.dataset.item.index({ projectId: MOCKED_PROJECT_ID, datasetItemId: `img-selected` })}${SEARCH}`;
             const { result } = renderHook(() => useSelectDatasetItem(), {

--- a/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.ts
+++ b/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.ts
@@ -1,14 +1,34 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect } from 'react';
 
 import type { Media } from '@/api/types';
 import { useDatasetMediaWithReviewStatus } from 'hooks/use-dataset-media-with-review-status.hook';
+import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { useLocation, useNavigate, useParams } from 'react-router';
 
 import { paths } from '../../../../constants/paths';
-import { useProjectIdentifier } from '../../../../hooks/use-project-identifier.hook';
 import { isVideo, isVideoFrame } from '../../../../shared/media-item-utils';
 import { useGetDatasetMediaItem } from '../../api/use-get-dataset-media-item';
+
+const useFetchMediaItemsUntilSelectedMediaIsPresent = ({
+    selectedMediaInTheFetchedList,
+}: {
+    selectedMediaInTheFetchedList: Media | null;
+}) => {
+    const { fetchNextPage } = useDatasetMediaWithReviewStatus();
+
+    useEffect(() => {
+        if (selectedMediaInTheFetchedList) {
+            return;
+        }
+
+        fetchNextPage();
+    }, [selectedMediaInTheFetchedList, fetchNextPage]);
+};
 
 export const useSelectDatasetItem = () => {
     const navigate = useNavigate();
@@ -17,16 +37,20 @@ export const useSelectDatasetItem = () => {
     const { items } = useDatasetMediaWithReviewStatus();
     const { datasetItemId: selectedDatasetItemId } = useParams<{ datasetItemId: string }>();
 
-    const fromList = items.find((item) => item.id === selectedDatasetItemId) ?? null;
+    const selectedMediaInTheFetchedList = items.find((item) => item.id === selectedDatasetItemId) ?? null;
 
     const {
         mediaItem: fetchedMediaItem,
         isPending: isFetchPending,
         isError,
         errorMessage,
-    } = useGetDatasetMediaItem(selectedDatasetItemId, { enabled: selectedDatasetItemId != null && fromList === null });
+    } = useGetDatasetMediaItem(selectedDatasetItemId, {
+        enabled: selectedDatasetItemId != null && selectedMediaInTheFetchedList === null,
+    });
 
-    const selectedMediaItem = fromList ?? fetchedMediaItem ?? null;
+    useFetchMediaItemsUntilSelectedMediaIsPresent({ selectedMediaInTheFetchedList });
+
+    const selectedMediaItem = selectedMediaInTheFetchedList ?? fetchedMediaItem ?? null;
 
     const isResolving = selectedDatasetItemId != null && selectedMediaItem === null && isFetchPending && !isError;
     const fetchErrorMessage =

--- a/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.ts
+++ b/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.ts
@@ -8,6 +8,7 @@ import { useLocation, useNavigate, useParams } from 'react-router';
 import { paths } from '../../../../constants/paths';
 import { useProjectIdentifier } from '../../../../hooks/use-project-identifier.hook';
 import { isVideo, isVideoFrame } from '../../../../shared/media-item-utils';
+import { useGetDatasetMediaItem } from '../../api/use-get-dataset-media-item';
 
 export const useSelectDatasetItem = () => {
     const navigate = useNavigate();
@@ -15,6 +16,21 @@ export const useSelectDatasetItem = () => {
     const projectId = useProjectIdentifier();
     const { items } = useDatasetMediaWithReviewStatus();
     const { datasetItemId: selectedDatasetItemId } = useParams<{ datasetItemId: string }>();
+
+    const fromList = items.find((item) => item.id === selectedDatasetItemId) ?? null;
+
+    const {
+        mediaItem: fetchedMediaItem,
+        isPending: isFetchPending,
+        isError,
+        errorMessage,
+    } = useGetDatasetMediaItem(selectedDatasetItemId, { enabled: selectedDatasetItemId != null && fromList === null });
+
+    const selectedMediaItem = fromList ?? fetchedMediaItem ?? null;
+
+    const isResolving = selectedDatasetItemId != null && selectedMediaItem === null && isFetchPending && !isError;
+    const fetchErrorMessage =
+        selectedDatasetItemId != null && selectedMediaItem === null && isError ? errorMessage : null;
 
     const onSelectedMediaItemChange = (item: Media | null) => {
         if (item === null) {
@@ -46,7 +62,10 @@ export const useSelectDatasetItem = () => {
     };
 
     return {
-        selectedMediaItem: items.find((item) => item.id === selectedDatasetItemId) ?? null,
+        selectedMediaItem,
+        selectedDatasetItemId,
+        isResolving,
+        fetchErrorMessage,
         onSelectedMediaItemChange,
     };
 };

--- a/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.ts
+++ b/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.ts
@@ -1,7 +1,5 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2025-2026 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
 
 import { useEffect } from 'react';
 
@@ -16,18 +14,20 @@ import { useGetDatasetMediaItem } from '../../api/use-get-dataset-media-item';
 
 const useFetchMediaItemsUntilSelectedMediaIsPresent = ({
     selectedMediaInTheFetchedList,
+    selectedDatasetItemId,
 }: {
     selectedMediaInTheFetchedList: Media | null;
+    selectedDatasetItemId: string | undefined;
 }) => {
     const { fetchNextPage } = useDatasetMediaWithReviewStatus();
 
     useEffect(() => {
-        if (selectedMediaInTheFetchedList) {
+        if (selectedDatasetItemId === undefined || selectedMediaInTheFetchedList === null) {
             return;
         }
 
         fetchNextPage();
-    }, [selectedMediaInTheFetchedList, fetchNextPage]);
+    }, [selectedMediaInTheFetchedList, selectedDatasetItemId, fetchNextPage]);
 };
 
 export const useSelectDatasetItem = () => {
@@ -48,7 +48,7 @@ export const useSelectDatasetItem = () => {
         enabled: selectedDatasetItemId != null && selectedMediaInTheFetchedList === null,
     });
 
-    useFetchMediaItemsUntilSelectedMediaIsPresent({ selectedMediaInTheFetchedList });
+    useFetchMediaItemsUntilSelectedMediaIsPresent({ selectedMediaInTheFetchedList, selectedDatasetItemId });
 
     const selectedMediaItem = selectedMediaInTheFetchedList ?? fetchedMediaItem ?? null;
 

--- a/application/ui/src/features/dataset/media-preview/media-preview-error.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview-error.component.tsx
@@ -1,0 +1,38 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Button, Content, Dialog, Flex, Heading } from '@geti-ui/ui';
+
+type MediaPreviewErrorProps = {
+    message: string;
+    onClose: () => void;
+};
+
+export const MediaPreviewError = ({ message, onClose }: MediaPreviewErrorProps) => {
+    return (
+        <Dialog
+            UNSAFE_style={{
+                backgroundColor: 'var(--spectrum-global-color-gray-50)',
+            }}
+        >
+            <Content>
+                <Flex
+                    direction={'column'}
+                    gap={'size-200'}
+                    alignItems={'center'}
+                    justifyContent={'center'}
+                    height={'100%'}
+                >
+                    <Heading level={2} UNSAFE_style={{ textAlign: 'center' }}>
+                        Couldn&apos;t load this media item.
+                        <br />
+                        {message}
+                    </Heading>
+                    <Button variant={'accent'} onPress={onClose}>
+                        Back to dataset
+                    </Button>
+                </Flex>
+            </Content>
+        </Dialog>
+    );
+};

--- a/application/ui/src/features/dataset/media-preview/media-preview-loading.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview-loading.component.tsx
@@ -1,0 +1,20 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Content, Dialog, Flex, Loading } from '@geti-ui/ui';
+
+export const MediaPreviewLoading = () => {
+    return (
+        <Dialog
+            UNSAFE_style={{
+                backgroundColor: 'var(--spectrum-global-color-gray-50)',
+            }}
+        >
+            <Content>
+                <Flex alignItems={'center'} justifyContent={'center'} height={'100%'} width={'100%'}>
+                    <Loading variant={'spinner'} mode={'inline'} />
+                </Flex>
+            </Content>
+        </Dialog>
+    );
+};


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

The issue is that when user selects a media item (either in the dataset view or in the annotator in the sidebar) that is not fetched in the first page when fetching media AND tries to refresh a page (or share a link with anyone), annotator is not opened because such media is not present in the UI's memory.
This PR fixes that issue.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
