### PR TITLE
feat: Remove threshold of 8 projects to show filters feature

### DIFF
--- a/application/ui/src/features/project/list/project-list.component.tsx
+++ b/application/ui/src/features/project/list/project-list.component.tsx
@@ -22,17 +22,15 @@ import { SortBy } from './sort-projects/utils';
 import backgroundStyles from '../project-background.module.scss';
 import classes from './project-list.module.scss';
 
-const MIN_NUMBER_OF_PROJECTS_TO_SHOW_FILTERS = 8;
-
 const ProjectGrid = () => {
     const projectsQuery = useProjects();
     const projects = projectsQuery.data;
     const [sortBy, setSortBy] = useState<SortBy>('createdAt-descending');
     const hasProjects = isNonEmptyArray(projects);
 
-    const shouldShowFilters = projects.length >= MIN_NUMBER_OF_PROJECTS_TO_SHOW_FILTERS;
-
     const [[activeProject], projectsWithoutActivePipeline] = partition(projects, (project) => project.active_pipeline);
+
+    const shouldShowFilters = projectsWithoutActivePipeline.length > 0;
 
     const { searchName, setSearchName, selectedTaskTypes, setSelectedTaskTypes, filteredProjects, isFiltering } =
         useProjectFilters(projectsWithoutActivePipeline);

--- a/application/ui/src/features/project/list/projects-list.test.tsx
+++ b/application/ui/src/features/project/list/projects-list.test.tsx
@@ -73,9 +73,6 @@ const projects = [
     }),
 ];
 
-// Below MIN_NUMBER_OF_PROJECTS_TO_SHOW_FILTERS (8), sort/filter controls are hidden.
-const fewProjects = projects.slice(0, 6);
-
 describe('ProjectList', () => {
     describe('with projects', () => {
         beforeEach(() => {
@@ -296,11 +293,11 @@ describe('ProjectList', () => {
         });
     });
 
-    describe('with fewer than 8 projects', () => {
+    describe('with exactly one non-active project (boundary)', () => {
         beforeEach(() => {
             server.use(
                 http.get('/api/projects', () => {
-                    return HttpResponse.json(fewProjects);
+                    return HttpResponse.json(projects.slice(0, 1));
                 }),
                 http.get('/api/projects/{project_id}/pipeline', () => {
                     return HttpResponse.json(getMockedPipeline({ status: 'idle' }));
@@ -308,10 +305,48 @@ describe('ProjectList', () => {
             );
         });
 
-        it('hides the sort control', async () => {
+        it('shows the filters and a singular project count label', async () => {
             renderProjectList();
 
             expect(await screen.findByRole('heading', { name: 'Alpha Project' })).toBeInTheDocument();
+
+            expect(screen.getByRole('button', { name: /sort/i })).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: 'Filter by task type' })).toBeInTheDocument();
+            expect(screen.getByRole('searchbox', { name: /search projects by name/i })).toBeInTheDocument();
+            expect(screen.getByText('1 project')).toBeInTheDocument();
+        });
+    });
+
+    describe('with only an active pipeline project (no non-active projects)', () => {
+        const onlyActiveProject = getMockedProject({
+            id: 'project-active-only',
+            name: 'Running Project',
+            created_at: '2026-09-01T10:00:00Z',
+            active_pipeline: true,
+            task: { exclusive_labels: true, labels: [], task_type: 'detection' },
+        });
+
+        beforeEach(() => {
+            server.use(
+                http.get('/api/projects', () => {
+                    return HttpResponse.json([onlyActiveProject]);
+                }),
+                http.get('/api/projects/{project_id}/pipeline', () => {
+                    return HttpResponse.json(getMockedPipeline({ status: 'idle' }));
+                })
+            );
+        });
+
+        it('still pins the active project card', async () => {
+            renderProjectList();
+
+            expect(await screen.findByRole('heading', { name: 'Running Project' })).toBeInTheDocument();
+        });
+
+        it('hides the sort control', async () => {
+            renderProjectList();
+
+            expect(await screen.findByRole('heading', { name: 'Running Project' })).toBeInTheDocument();
 
             expect(screen.queryByRole('button', { name: /sort/i })).not.toBeInTheDocument();
         });
@@ -319,7 +354,7 @@ describe('ProjectList', () => {
         it('hides the task type filter control', async () => {
             renderProjectList();
 
-            expect(await screen.findByRole('heading', { name: 'Alpha Project' })).toBeInTheDocument();
+            expect(await screen.findByRole('heading', { name: 'Running Project' })).toBeInTheDocument();
 
             expect(screen.queryByRole('button', { name: 'Filter by task type' })).not.toBeInTheDocument();
         });
@@ -327,7 +362,7 @@ describe('ProjectList', () => {
         it('hides the search box', async () => {
             renderProjectList();
 
-            expect(await screen.findByRole('heading', { name: 'Alpha Project' })).toBeInTheDocument();
+            expect(await screen.findByRole('heading', { name: 'Running Project' })).toBeInTheDocument();
 
             expect(screen.queryByRole('searchbox', { name: /search projects by name/i })).not.toBeInTheDocument();
         });
@@ -335,7 +370,7 @@ describe('ProjectList', () => {
         it('does not show a project count label', async () => {
             renderProjectList();
 
-            expect(await screen.findByRole('heading', { name: 'Alpha Project' })).toBeInTheDocument();
+            expect(await screen.findByRole('heading', { name: 'Running Project' })).toBeInTheDocument();
 
             expect(screen.queryByText(/^\d+ projects?$/i)).not.toBeInTheDocument();
         });


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

1. Remove the current threshold of showing the filters.
2. Leave pinned behavior as is.
3. Show the filters only when there is at least one not active project - this is because we don't include pinned project in the filters.

Follow up to #7001 and #7013.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
