### PR TITLE
fix: Annotator crash when filtering by `Media with missing annotations`

### DIFF
--- a/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.test.ts
+++ b/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.test.ts
@@ -191,5 +191,24 @@ describe('useSelectDatasetItem', () => {
 
             expect(result.current.selectedMediaItem).toBeNull();
         });
+
+        it('stays set once hydrated even after a filter shrinks items to exclude it', () => {
+            const image = getMockedMediaImage({ id: 'img-selected' });
+            vi.mocked(useGetDatasetMediaItems).mockReturnValue({ ...mockDatasetMediaItems, items: [image] });
+
+            const route = `${paths.project.dataset.item.index({ projectId: MOCKED_PROJECT_ID, datasetItemId: image.id })}${SEARCH}`;
+            const { result, rerender } = renderHook(() => useSelectDatasetItem(), {
+                route,
+                path: paths.project.dataset.item.index.pattern,
+            });
+
+            expect(result.current.selectedMediaItem).toEqual(image);
+
+            // Simulate an active filter now excluding the open item from the filtered list.
+            vi.mocked(useGetDatasetMediaItems).mockReturnValue({ ...mockDatasetMediaItems, items: [] });
+            rerender();
+
+            expect(result.current.selectedMediaItem).toEqual(image);
+        });
     });
 });

--- a/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.ts
+++ b/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.ts
@@ -20,12 +20,11 @@ export const useSelectDatasetItem = () => {
 
     const prevSelectedMediaItem = useRef<Media | null>(null);
 
-    // This state is responsible for deciding that is the currently displayed media item in the annotator.
-    // This state is computed based on the `selectedDatasetItemId` param and the `items` list.
-    // If the `selectedDatasetItemId` is not found in the `items` list, we will keep the previous selected media item.
-    // That case might happen when we use filters, e.g. current media is annotated and user filters media by status
-    // "Media with missing annotations". It would cause the current media to be null (not found in the list) and would
-    // close the annotator unexpectedly.
+    // This state determines the currently displayed media item in the annotator.
+    // It is computed based on the `selectedDatasetItemId` param and the `items` list.
+    // If the `selectedDatasetItemId` is not found in the `items` list, we keep the previously selected media item.
+    // This can happen when filters change (e.g. opening an annotated item and then filtering by
+    // "Media with missing annotations"), which would otherwise close the annotator unexpectedly.
     const selectedMediaItem = useMemo(() => {
         if (selectedDatasetItemId === undefined) {
             return null;
@@ -34,7 +33,7 @@ export const useSelectDatasetItem = () => {
         const newSelectedMediaItem = items.find((item) => item.id === selectedDatasetItemId);
 
         if (newSelectedMediaItem === undefined) {
-            return prevSelectedMediaItem.current;
+            return prevSelectedMediaItem.current?.id === selectedDatasetItemId ? prevSelectedMediaItem.current : null;
         }
 
         return newSelectedMediaItem;

--- a/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.ts
+++ b/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.ts
@@ -1,6 +1,8 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { useEffect, useMemo, useRef } from 'react';
+
 import type { Media } from '@/api/types';
 import { useDatasetMediaWithReviewStatus } from 'hooks/use-dataset-media-with-review-status.hook';
 import { useLocation, useNavigate, useParams } from 'react-router';
@@ -15,6 +17,32 @@ export const useSelectDatasetItem = () => {
     const projectId = useProjectIdentifier();
     const { items } = useDatasetMediaWithReviewStatus();
     const { datasetItemId: selectedDatasetItemId } = useParams<{ datasetItemId: string }>();
+
+    const prevSelectedMediaItem = useRef<Media | null>(null);
+
+    // This state is responsible for deciding that is the currently displayed media item in the annotator.
+    // This state is computed based on the `selectedDatasetItemId` param and the `items` list.
+    // If the `selectedDatasetItemId` is not found in the `items` list, we will keep the previous selected media item.
+    // That case might happen when we use filters, e.g. current media is annotated and user filters media by status
+    // "Media with missing annotations". It would case the current media to be null (not found in the list) and would
+    // close the annotator unexpectedly.
+    const selectedMediaItem = useMemo(() => {
+        if (selectedDatasetItemId === undefined) {
+            return null;
+        }
+
+        const newSelectedMediaItem = items.find((item) => item.id === selectedDatasetItemId);
+
+        if (newSelectedMediaItem === undefined) {
+            return prevSelectedMediaItem.current;
+        }
+
+        return newSelectedMediaItem;
+    }, [selectedDatasetItemId, items]);
+
+    useEffect(() => {
+        prevSelectedMediaItem.current = selectedMediaItem;
+    }, [selectedMediaItem]);
 
     const onSelectedMediaItemChange = (item: Media | null) => {
         if (item === null) {
@@ -45,8 +73,5 @@ export const useSelectDatasetItem = () => {
         navigate({ pathname: paths.project.dataset.item.index({ projectId, datasetItemId: item.id }), search });
     };
 
-    return {
-        selectedMediaItem: items.find((item) => item.id === selectedDatasetItemId) ?? null,
-        onSelectedMediaItemChange,
-    };
+    return { selectedMediaItem, onSelectedMediaItemChange };
 };

--- a/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.ts
+++ b/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.ts
@@ -24,7 +24,7 @@ export const useSelectDatasetItem = () => {
     // This state is computed based on the `selectedDatasetItemId` param and the `items` list.
     // If the `selectedDatasetItemId` is not found in the `items` list, we will keep the previous selected media item.
     // That case might happen when we use filters, e.g. current media is annotated and user filters media by status
-    // "Media with missing annotations". It would case the current media to be null (not found in the list) and would
+    // "Media with missing annotations". It would cause the current media to be null (not found in the list) and would
     // close the annotator unexpectedly.
     const selectedMediaItem = useMemo(() => {
         if (selectedDatasetItemId === undefined) {

--- a/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.test.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.test.tsx
@@ -55,6 +55,7 @@ vi.mock('../../providers/selected-data-provider.component', () => ({
         selectedKeys: new Set(),
         setSelectedKeys: vi.fn(),
         toggleSelectedKeys: vi.fn(),
+        isSelected: vi.fn().mockReturnValue(false),
     })),
 }));
 

--- a/application/ui/src/features/dataset/media-preview/sidebar-items/sidebar-items.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/sidebar-items/sidebar-items.component.tsx
@@ -5,6 +5,7 @@ import { useRef } from 'react';
 
 import type { Media } from '@/api/types';
 import { Flex, Size, useUnwrapDOMRef, View } from '@geti-ui/ui';
+import { isEmpty } from 'lodash-es';
 
 import { VirtualizerGridLayout } from '../../../../components/virtualizer-grid-layout/virtualizer-grid-layout.component';
 import { SIDEBAR_MEDIA_SIZE } from '../constants';
@@ -54,7 +55,7 @@ export const SidebarItems = ({
         <Toolbar.Container height={'100%'}>
             <Toolbar.Section height={'100%'}>
                 <Flex direction={'column'} height={'100%'} gap='size-100'>
-                    <SidebarMediaFilter />
+                    <SidebarMediaFilter hasMediaItems={!isEmpty(items)} />
                     <View ref={ref} width={'100%'} flex={1}>
                         <VirtualizerGridLayout
                             items={items}

--- a/application/ui/src/features/dataset/media-preview/sidebar-items/sidebar-media-filtering.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/sidebar-items/sidebar-media-filtering.component.tsx
@@ -1,8 +1,9 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { ActionButton, Divider, Flex } from '@geti-ui/ui';
+import { ActionButton, Divider, Flex, Text, View } from '@geti-ui/ui';
 
+import { ReactComponent as EmptyDatasetImage } from '../../../../assets/empty-dataset.svg';
 import {
     ActiveFiltersList,
     useClearAllFilters,
@@ -10,7 +11,32 @@ import {
 } from '../../gallery/active-filters/active-filters.component';
 import { AnnotatorMediaFiltering } from '../../gallery/toolbar/media-filtering/annotator-media-filtering.component';
 
-export const SidebarMediaFilter = () => {
+const NoMediaItemsMessage = () => {
+    return (
+        <View
+            marginTop={'size-100'}
+            backgroundColor={'gray-100'}
+            padding={'size-50'}
+            borderColor={'transparent'}
+            borderRadius={'medium'}
+        >
+            <Flex direction={'column'} alignItems={'center'} gap={'size-50'}>
+                <View width={'size-1250'} height={'size-1250'}>
+                    <EmptyDatasetImage height={'100%'} width={'100%'} />
+                </View>
+                <Text UNSAFE_style={{ textAlign: 'center' }}>
+                    No media items match your filter. Remove or select a new filter.
+                </Text>
+            </Flex>
+        </View>
+    );
+};
+
+type SidebarMediaFilterProps = {
+    hasMediaItems: boolean;
+};
+
+export const SidebarMediaFilter = ({ hasMediaItems }: SidebarMediaFilterProps) => {
     const hasActiveFilters = useHasActiveFilters();
     const handleClearAll = useClearAllFilters();
 
@@ -30,6 +56,8 @@ export const SidebarMediaFilter = () => {
                     <ActiveFiltersList />
                 </Flex>
             )}
+
+            {hasActiveFilters && !hasMediaItems && <NoMediaItemsMessage />}
         </Flex>
     );
 };

--- a/application/ui/src/features/dataset/media-preview/utils.test.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.test.ts
@@ -211,6 +211,14 @@ describe('useNextMediaItem', () => {
             data: { items: [nextUnannotatedItem] },
             isPending: false,
         });
+        // The candidate isn't among the already-fetched items, so there must be more
+        // pages available (and none currently in flight) for a fetch to be worthwhile.
+        // @ts-expect-error We only care about mocking these fields for this test.
+        mockUseDatasetMediaWithReviewStatus.mockReturnValue({
+            fetchNextPage: mockFetchNextPage,
+            hasNextPage: true,
+            isFetchingNextPage: false,
+        });
 
         const { result, rerender } = renderHook(() => useNextMediaItem(alreadyFetchedItems[0], alreadyFetchedItems));
 

--- a/application/ui/src/features/dataset/media-preview/utils.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.ts
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useRef } from 'react';
 
 import type { AnnotationDTO, Media } from '@/api/types';
 import { useQuery } from '@tanstack/react-query';
+import { useDatasetFiltersSearchParams } from 'hooks/use-dataset-filters-search-params.hook';
 import { useDatasetMediaWithReviewStatus } from 'hooks/use-dataset-media-with-review-status.hook';
 import { useFetchNextUnannotatedMediaItem } from 'hooks/use-get-dataset-items.hook';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
@@ -57,22 +58,51 @@ export const getNextMediaItem = (currentMediaItem: Media, allMediaItems: Media[]
 };
 
 const useNextUnannotatedMediaItem = (currentMediaItem: Media, allMediaItems: Media[]) => {
-    const { fetchNextPage } = useDatasetMediaWithReviewStatus();
+    const { annotationStatus } = useDatasetFiltersSearchParams();
+    const { fetchNextPage, hasNextPage, isFetchingNextPage } = useDatasetMediaWithReviewStatus();
     const { data, isPending } = useFetchNextUnannotatedMediaItem();
+    const items = data?.items ?? [];
 
-    const nextUnannotatedDatasetMediaItem = data?.items?.find((item) => item.id !== currentMediaItem.id);
+    // Only relevant when the gallery can actually contain unannotated media.
+    // When the active filter is restricted to "with_annotations", no unannotated
+    // item can ever appear in a list, so searching for one would just
+    // paginate through the entire filtered dataset looking for something that
+    // can never be found.
+    const canNavigateToUnannotated = annotationStatus !== 'with_annotations';
+
+    const nextUnannotatedDatasetMediaItem = canNavigateToUnannotated
+        ? items.find((item) => item.id !== currentMediaItem.id)
+        : undefined;
     const nextUnannotatedMediaItem = allMediaItems.find((item) => item.id === nextUnannotatedDatasetMediaItem?.id);
     const isInsideFetchedMediaItems = nextUnannotatedMediaItem !== undefined;
 
     useEffect(() => {
-        if (isPending || isInsideFetchedMediaItems) {
+        // Nothing to do if we can't/shouldn't look for an unannotated item, the
+        // candidate is already loaded, or there's no known candidate to look for
+        // (fetching further pages wouldn't help find something that doesn't exist).
+        if (
+            !canNavigateToUnannotated ||
+            isPending ||
+            isInsideFetchedMediaItems ||
+            nextUnannotatedDatasetMediaItem === undefined ||
+            !hasNextPage ||
+            isFetchingNextPage
+        ) {
             return;
         }
 
         fetchNextPage();
-    }, [isInsideFetchedMediaItems, fetchNextPage, isPending]);
+    }, [
+        canNavigateToUnannotated,
+        isPending,
+        isInsideFetchedMediaItems,
+        nextUnannotatedDatasetMediaItem,
+        hasNextPage,
+        isFetchingNextPage,
+        fetchNextPage,
+    ]);
 
-    if (isPending) {
+    if (isPending || !canNavigateToUnannotated) {
         return undefined;
     }
 

--- a/application/ui/src/hooks/use-dataset-media-with-review-status.hook.ts
+++ b/application/ui/src/hooks/use-dataset-media-with-review-status.hook.ts
@@ -56,6 +56,7 @@ export const useDatasetMediaWithReviewStatus = () => {
         // Only true for actual next-page fetches on either query — never for
         // initial loads — so pagination doesn't trigger the full overlay.
         isFetchingNextPage: mediaItemsResponse.isFetchingNextPage || datasetItemsResponse.isFetchingNextPage,
+        hasNextPage: mediaItemsResponse.hasNextPage || datasetItemsResponse.hasNextPage,
         totalCount: mediaItemsResponse.totalCount,
         fetchNextPage,
         isMediaItemReviewedById,

--- a/application/ui/src/hooks/use-get-dataset-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-items.hook.ts
@@ -3,7 +3,7 @@
 
 import { useMemo } from 'react';
 
-import { $api } from '@/api';
+import { $api, fetchClient } from '@/api';
 import type { DatasetItemAnnotationStatus, DatasetSubset, Pagination } from '@/api/types';
 import { useQuery } from '@tanstack/react-query';
 import { isEmpty } from 'lodash-es';
@@ -23,17 +23,18 @@ type UseGetDatasetItemsOptions = {
     labelIds?: string[];
     startDate?: string;
     endDate?: string;
+    limit?: number;
 };
 
-const getDatasetItemsQueryOptions = ({
+const getDatasetItemsQueryParameter = ({
     subsets,
     annotationStatus,
     sortDirection,
-    projectId,
     labelIds,
     startDate,
     endDate,
-}: UseGetDatasetItemsOptions & { projectId: string }) => {
+    limit = DATASET_ITEMS_LIMIT,
+}: UseGetDatasetItemsOptions) => {
     const query: {
         offset: number;
         limit: number;
@@ -46,7 +47,7 @@ const getDatasetItemsQueryOptions = ({
         end_date?: string;
     } = {
         offset: 0,
-        limit: DATASET_ITEMS_LIMIT,
+        limit,
     };
 
     if (!isEmpty(subsets)) {
@@ -74,29 +75,41 @@ const getDatasetItemsQueryOptions = ({
         query.end_date = endDate;
     }
 
-    return $api.queryOptions('get', '/api/projects/{project_id}/dataset/items', {
-        params: {
-            query,
-            path: { project_id: projectId },
-        },
-    });
+    return query;
 };
 
 export const useFetchNextUnannotatedMediaItem = () => {
     const projectId = useProjectIdentifier();
 
     const { selectedSubsets, sortDirection, selectedLabelIds, startDate, endDate } = useDatasetFiltersSearchParams();
-    const queryOptions = getDatasetItemsQueryOptions({
+    const query = getDatasetItemsQueryParameter({
         subsets: selectedSubsets,
         annotationStatus: 'missing_annotations',
         sortDirection,
         labelIds: selectedLabelIds,
         startDate: startDate ?? undefined,
         endDate: endDate ?? undefined,
-        projectId,
     });
 
-    return useQuery(queryOptions);
+    return useQuery({
+        queryKey: ['next-unannotated-media-item', projectId, query],
+        queryFn: async () => {
+            const { data, error } = await fetchClient.GET('/api/projects/{project_id}/dataset/items', {
+                params: {
+                    query,
+                    path: {
+                        project_id: projectId,
+                    },
+                },
+            });
+
+            if (error) {
+                throw error;
+            }
+
+            return data;
+        },
+    });
 };
 
 export const useGetDatasetItems = ({
@@ -109,45 +122,14 @@ export const useGetDatasetItems = ({
 }: UseGetDatasetItemsOptions = {}) => {
     const project_id = useProjectIdentifier();
 
-    const query: {
-        offset: number;
-        limit: number;
-        subsets?: DatasetSubset[];
-        annotation_status?: DatasetItemAnnotationStatus;
-        sort_direction?: SortDirection;
-        sort_by?: SortBy;
-        labels?: string[];
-        start_date?: string;
-        end_date?: string;
-    } = {
-        offset: 0,
-        limit: DATASET_ITEMS_LIMIT,
-    };
-
-    if (!isEmpty(subsets)) {
-        query.subsets = subsets;
-    }
-
-    if (annotationStatus !== undefined) {
-        query.annotation_status = annotationStatus;
-    }
-
-    if (sortDirection !== undefined) {
-        query.sort_direction = sortDirection;
-        query.sort_by = 'creation_date';
-    }
-
-    if (!isEmpty(labelIds)) {
-        query.labels = labelIds;
-    }
-
-    if (startDate !== undefined) {
-        query.start_date = startDate;
-    }
-
-    if (endDate !== undefined) {
-        query.end_date = endDate;
-    }
+    const query = getDatasetItemsQueryParameter({
+        subsets,
+        annotationStatus,
+        sortDirection,
+        labelIds,
+        startDate,
+        endDate,
+    });
 
     const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } = $api.useInfiniteQuery(
         'get',
@@ -173,7 +155,7 @@ export const useGetDatasetItems = ({
     );
 
     const items = useMemo(() => {
-        return data?.pages.flatMap((page) => page.items) ?? [];
+        return data?.pages?.flatMap((page) => page.items) ?? [];
     }, [data?.pages]);
 
     const totalCount = data?.pages[0]?.pagination?.total ?? 0;

--- a/application/ui/src/hooks/use-get-dataset-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-items.hook.ts
@@ -78,6 +78,9 @@ const getDatasetItemsQueryParameter = ({
     return query;
 };
 
+// if case current media is also not unannotated, we get the next one
+const MAX_INTERESTED_MEDIA_ITEMS_LIMIT = 2;
+
 export const useFetchNextUnannotatedMediaItem = () => {
     const projectId = useProjectIdentifier();
 
@@ -89,6 +92,7 @@ export const useFetchNextUnannotatedMediaItem = () => {
         labelIds: selectedLabelIds,
         startDate: startDate ?? undefined,
         endDate: endDate ?? undefined,
+        limit: MAX_INTERESTED_MEDIA_ITEMS_LIMIT,
     });
 
     return useQuery({

--- a/application/ui/src/hooks/use-get-dataset-media-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-media-items.hook.ts
@@ -110,7 +110,7 @@ export const useGetDatasetMediaItems = (options?: UseGetDatasetMediaItemsOptions
     );
 
     const items = useMemo(() => {
-        const mediaItems = data?.pages.flatMap((page) => page.items) ?? [];
+        const mediaItems = data?.pages?.flatMap((page) => page.items) ?? [];
 
         return getMediaEntities(mediaItems);
     }, [data?.pages]);


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

1. The issue was caused by the collision of the query keys for prefetching next media item and fetching filtered data.
2. I noticed that when filtering by `Media with missing annotations` when opened media had annotations, it caused annotator to close because such media does not exist on a list anymore. That issue is also fixed.

Fix #7026

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
