### PR TITLE
Add mirror URL for EdgeCrafter model weights

### DIFF
--- a/application/backend/app/supported_models/manifests/detection/edgecrafter_l.yaml
+++ b/application/backend/app/supported_models/manifests/detection/edgecrafter_l.yaml
@@ -2,8 +2,8 @@ id: object-detection-edgecrafter-l
 name: ECDet-L
 
 pretrained_weights:
-  url: https://github.com/capsule2077/edgecrafter/releases/download/edgecrafterv1/ecdet_l.pth
-  mirror_url: https://huggingface.co/Intellindust/ECDet_L/resolve/main/model.safetensors
+  url: https://storage.geti.intel.com/weights/ecdet_l.pth
+  mirror_url: https://github.com/capsule2077/edgecrafter/releases/download/edgecrafterv1/ecdet_l.pth
   sha_sum: 60e48c51b33d70acf8e3a3faddbdb70b0876c64509b74cb623106cc7c31e85a1
 
 description: "EdgeCrafter detection model (ECDet-L) combines an efficient ECViT backbone with a hybrid encoder and transformer decoder for real-time, high-accuracy object detection with low latency."

--- a/application/backend/app/supported_models/manifests/detection/edgecrafter_m.yaml
+++ b/application/backend/app/supported_models/manifests/detection/edgecrafter_m.yaml
@@ -2,8 +2,8 @@ id: object-detection-edgecrafter-m
 name: ECDet-M
 
 pretrained_weights:
-  url: https://github.com/capsule2077/edgecrafter/releases/download/edgecrafterv1/ecdet_m.pth
-  mirror_url: https://huggingface.co/Intellindust/ECDet_M/resolve/main/model.safetensors
+  url: https://storage.geti.intel.com/weights/ecdet_m.pth
+  mirror_url: https://github.com/capsule2077/edgecrafter/releases/download/edgecrafterv1/ecdet_m.pth
   sha_sum: c4cdf8bcd3b27c7903e422acd03caf733b5e1bfd664550bce43e50e2a3bbdc6e
 
 description: "EdgeCrafter detection model (ECDet-M) combines an efficient ECViT backbone with a hybrid encoder and transformer decoder for real-time, high-accuracy object detection with low latency."

--- a/application/backend/app/supported_models/manifests/detection/edgecrafter_s.yaml
+++ b/application/backend/app/supported_models/manifests/detection/edgecrafter_s.yaml
@@ -2,8 +2,8 @@ id: object-detection-edgecrafter-s
 name: ECDet-S
 
 pretrained_weights:
-  url: https://github.com/capsule2077/edgecrafter/releases/download/edgecrafterv1/ecdet_s.pth
-  mirror_url: https://huggingface.co/Intellindust/ECDet_S/resolve/main/model.safetensors
+  url: https://storage.geti.intel.com/weights/ecdet_s.pth
+  mirror_url: https://github.com/capsule2077/edgecrafter/releases/download/edgecrafterv1/ecdet_s.pth
   sha_sum: 35340a45101d24a094becf8776aeaa327c9e6b37453e5e81dfd2923c134c4619
 
 description: "EdgeCrafter detection model (ECDet-S) combines an efficient ECViT backbone with a hybrid encoder and transformer decoder for real-time, high-accuracy object detection with low latency."

--- a/application/backend/app/supported_models/manifests/detection/edgecrafter_x.yaml
+++ b/application/backend/app/supported_models/manifests/detection/edgecrafter_x.yaml
@@ -2,8 +2,8 @@ id: object-detection-edgecrafter-x
 name: ECDet-X
 
 pretrained_weights:
-  url: https://github.com/capsule2077/edgecrafter/releases/download/edgecrafterv1/ecdet_x.pth
-  mirror_url: https://huggingface.co/Intellindust/ECDet_X/resolve/main/model.safetensors
+  url: https://storage.geti.intel.com/weights/ecdet_x.pth
+  mirror_url: https://github.com/capsule2077/edgecrafter/releases/download/edgecrafterv1/ecdet_x.pth
   sha_sum: c87394be021b573fd8e25969b85a8670127120c9d0209ac7807fbadae1a5cec6
 
 description: "EdgeCrafter detection model (ECDet-X) combines an efficient ECViT backbone with a hybrid encoder and transformer decoder for real-time, high-accuracy object detection with low latency."


### PR DESCRIPTION
### Summary

Changes:
- Fix broken mirror URL for EdgeCrafter pretrained weights
- Point main URL to Geti storage, consistently with the other algorithms

### How to test

Launch Geti and train one EdgeCrafter model of each size.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
