### PR TITLE
Fix broken libglx-mesa0 dependency in Dockerfile

### DIFF
--- a/application/docker/Dockerfile
+++ b/application/docker/Dockerfile
@@ -301,7 +301,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         git=1:2.47.3-0* \
         libgl1=1.7.0-1+b2 \
         libglib2.0-0t64=2.84.4-3~deb13u3 \
-        libglx-mesa0=25.0.7-2 \
+        libglx-mesa0=25.0.* \
         libv4l-0t64=1.30.1-1 \
         libva2=2.22.* \
         libva-drm2=2.22.* \


### PR DESCRIPTION
### Summary

Fixes #7049

### How to test

Run `just build-image -a cpu`

### Checklist

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
