### PR TITLE
fix(ci): do not use cache for daily builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -108,7 +108,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.event_name != 'pull_request' }}
-          use-cache: ${{ github.event_name != 'workflow_call' || inputs.use-cache }}
+          use-cache: ${{ github.event_name != 'workflow_call' || inputs.use-cache == true }}
           # Fork PRs cannot write packages to the upstream org, so disable
           # cache export to avoid 403 errors from GHCR.
           cache-write: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request' }}


### PR DESCRIPTION
### Summary

The `build.yml` workflow has a parameter `use-cache` that is set to `false` by daily build, so that if any build stage breaks for any reason (e.g. a dependency disappears) we can quickly find it out. However, it doesn't seem to work as intended, see e.g. this [run](https://github.com/open-edge-platform/geti/actions/runs/29302758625/job/86989824544).

This PR updates the `use-cache` condition in `.github/workflows/build.yaml` to fix it.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
