### PR TITLE
ci: Use cleanup-images action from geti-ci

### DIFF
--- a/.github/workflows/cleanup-old-app-images.yml
+++ b/.github/workflows/cleanup-old-app-images.yml
@@ -3,6 +3,10 @@ name: Cleanup Old Application Container Images
 # Deletes old geti-cpu / geti-xpu / geti-cuda container image versions from GHCR,
 # while always retaining release and release-candidate (RC) images.
 #
+# This workflow delegates to the shared `cleanup-images` composite action in the
+# geti-ci repository. See:
+# https://github.com/open-edge-platform/geti-ci/tree/main/actions/cleanup-images
+#
 # Retention rules:
 # - Release images (tags matching semver "X.Y.Z", e.g. 3.0.0) are NEVER deleted.
 # - Release-candidate images (tags matching "X.Y.ZrcN", e.g. 3.0.0rc0) are
@@ -39,135 +43,18 @@ jobs:
     runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
     permissions:
       packages: write
-    env:
-      # Ensure that a token with package write permissions is used, as the default GITHUB_TOKEN may not have sufficient scopes in some contexts (e.g. forked PRs).
-      # GH_TOKEN: ${{ secrets.WRITE_PACKAGES_TOKEN }}
-      GH_TOKEN: ${{ github.token }}
-      OWNER: ${{ github.repository_owner }}
-      # On a scheduled run inputs are empty, so fall back to sensible defaults.
-      MIN_VERSIONS_TO_KEEP: ${{ inputs.min_versions_to_keep || 10 }}
-      DRY_RUN: ${{ inputs.dry_run == false && 'false' || 'true' }}
     steps:
       - name: Harden the runner (audit all outbound calls)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
-      - name: Delete old image versions from GHCR
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          # Application container packages to clean up.
-          packages=(geti-cpu geti-xpu geti-cuda)
-
-          # Validate MIN_VERSIONS_TO_KEEP is a non-negative integer.
-          if ! [[ "${MIN_VERSIONS_TO_KEEP}" =~ ^[0-9]+$ ]]; then
-            echo "::error::Invalid min_versions_to_keep '${MIN_VERSIONS_TO_KEEP}'. Must be a non-negative integer."
-            exit 1
-          fi
-
-          deleted=0
-          candidates=0
-          retained_release=0
-          scanned_packages=0
-
-          owner_type="$(gh api "users/${OWNER}" --jq '.type')"
-          if [[ "${owner_type}" == "Organization" ]]; then
-            api_scope="orgs/${OWNER}"
-            scope_kind="organization"
-          else
-            api_scope="users/${OWNER}"
-            scope_kind="user"
-          fi
-
-          echo "Owner: ${OWNER} (type=${owner_type})"
-          echo "Using ${scope_kind} package API scope: ${api_scope}"
-          echo "Minimum non-release versions to keep per package: ${MIN_VERSIONS_TO_KEEP}"
-          echo "Dry run: ${DRY_RUN}"
-
-          for package in "${packages[@]}"; do
-            scanned_packages=$((scanned_packages + 1))
-            package_url="$(printf '%s' "${package}" | jq -sRr @uri)"
-            echo "::group::Processing package: ${package}"
-
-            # Skip packages that do not exist for this owner.
-            if ! gh api "${api_scope}/packages/container/${package_url}" >/dev/null 2>&1; then
-              echo "Package '${package}' not found for owner '${OWNER}', skipping."
-              echo "::endgroup::"
-              continue
-            fi
-
-            # Fetch all versions and normalize it to a JSON array
-            raw_versions="$(gh api --paginate "${api_scope}/packages/container/${package_url}/versions?per_page=100")"
-
-            versions_json="$(
-              printf '%s\n' "${raw_versions}" | \
-              jq -sc '
-                  map(
-                    if type=="array" then .[] else . end
-                  ) |
-                  map({id, tags: (.metadata.container.tags // []), created_at})
-              '
-            )"
-
-            if ! echo "${versions_json}" | jq -e 'type=="array"' >/dev/null; then
-              echo "::error::Failed to parse package versions JSON for ${package}"
-              exit 1
-            fi
-
-            # Count release versions retained (semver "X.Y.Z", RC "X.Y.ZrcN" tag or "latest").
-            pkg_retained="$(
-              echo "${versions_json}" | jq '[.[]
-                | select(any(.tags[]?;
-                    test("^[0-9]+\\.[0-9]+\\.[0-9]+(rc[0-9]+)?$"; "i") or . == "latest"))] | length'
-            )"
-            retained_release=$((retained_release + pkg_retained))
-
-            # Non-release candidates: versions without any release/RC/"latest" tag.
-            # Sorted newest first; the first MIN_VERSIONS_TO_KEEP are kept.
-            # Each line is "<id>\t<comma-separated tags>".
-            mapfile -t old_versions < <(
-              echo "${versions_json}" | jq -r --argjson keep "${MIN_VERSIONS_TO_KEEP}" '
-                [.[]
-                  | select((any(.tags[]?;
-                      test("^[0-9]+\\.[0-9]+\\.[0-9]+(rc[0-9]+)?$"; "i") or . == "latest")) | not)]
-                | sort_by(.created_at | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime)
-                | reverse
-                | .[$keep:]
-                | .[] | "\(.id)\t\(.tags | join(","))"'
-            )
-
-            echo "Release versions retained for ${package}: ${pkg_retained}"
-            echo "Old non-release versions to delete for ${package}: ${#old_versions[@]}"
-
-            for version_entry in "${old_versions[@]}"; do
-              version_id="${version_entry%%$'\t'*}"
-              version_tags="${version_entry#*$'\t'}"
-              [[ -n "${version_tags}" ]] || version_tags="<untagged>"
-              candidates=$((candidates + 1))
-              if [[ "${DRY_RUN}" == "true" ]]; then
-                echo "[dry-run] Would delete ${package} version id ${version_id} (tags: ${version_tags})"
-              else
-                echo "Deleting ${package} version id ${version_id} (tags: ${version_tags})"
-                gh api -X DELETE "${api_scope}/packages/container/${package_url}/versions/${version_id}"
-                deleted=$((deleted + 1))
-              fi
-            done
-
-            echo "::endgroup::"
-          done
-
-          {
-            echo "## Application Image Cleanup"
-            echo ""
-            echo "- Owner: ${OWNER}"
-            echo "- Owner type: ${owner_type}"
-            echo "- API scope: ${api_scope}"
-            echo "- Packages scanned: ${scanned_packages}"
-            echo "- Minimum non-release versions kept per package: ${MIN_VERSIONS_TO_KEEP}"
-            echo "- Release versions retained: ${retained_release}"
-            echo "- Old versions matched for deletion: ${candidates}"
-            echo "- Versions deleted: ${deleted}"
-            echo "- Dry run: ${DRY_RUN}"
-          } >> "${GITHUB_STEP_SUMMARY}"
+      - name: Cleanup old container images
+        uses: open-edge-platform/geti-ci/actions/cleanup-images@287abbfdced5c02904ab2f39a0fe944cd402c36f # cleanup-images/v0.1.0
+        with:
+          packages: |
+            geti-cpu
+            geti-xpu
+            geti-cuda
+          min-versions-to-keep: ${{ inputs.min_versions_to_keep || 10 }}
+          dry-run: ${{ inputs.dry_run == false && 'false' || 'true' }}


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Use action available from geti-ci repo instead of local one

### How to test

Dispatch the workflow

Test runs: [dry-run](https://github.com/open-edge-platform/geti/actions/runs/29818790793) and [run](https://github.com/open-edge-platform/geti/actions/runs/29818962472) with actual deletion of old images

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
