### PR TITLE
Support dynamic batch dimension in LightningModelExporter

### DIFF
--- a/library/.gitignore
+++ b/library/.gitignore
@@ -23,7 +23,6 @@ __pycache__/
 benchmark*.csv
 benchmark*.xlsx
 *.raw.csv
-csv/
 
 # ── IDE / OS ──────────────────────────────────────────────────────────
 .idea/

--- a/library/.gitignore
+++ b/library/.gitignore
@@ -23,6 +23,7 @@ __pycache__/
 benchmark*.csv
 benchmark*.xlsx
 *.raw.csv
+csv/
 
 # ── IDE / OS ──────────────────────────────────────────────────────────
 .idea/

--- a/library/Justfile
+++ b/library/Justfile
@@ -60,6 +60,10 @@ pyrefly: _ensure_uv
 test-unit *ARGS: _ensure_uv
     uv run pytest ./tests/unit -v {{ ARGS }}
 
+# Run model-related unit tests with pytest
+test-unit-models *ARGS: _ensure_uv
+    uv run pytest ./tests/unit/backend/lightning/models -v {{ ARGS }}
+
 # Run lightning backend
 test-unit-lightning *ARGS: _ensure_uv
     uv run pytest ./tests/unit/backend/lightning -v {{ ARGS }}

--- a/library/src/getitune/backend/lightning/exporter/base.py
+++ b/library/src/getitune/backend/lightning/exporter/base.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import logging as log
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Literal
 
 from onnxruntime.transformers.float16 import convert_float_to_float16
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from getitune.backend.lightning.models.base import DataInputParams, LightningModel
 
 
-class ModelExporter:
+class ModelExporter(ABC):
     """Base class for the model exporters used in getitune.
 
     Args:

--- a/library/src/getitune/backend/lightning/exporter/native.py
+++ b/library/src/getitune/backend/lightning/exporter/native.py
@@ -74,6 +74,9 @@ class LightningModelExporter(ModelExporter):
         input_size = self.data_input_params.as_ncwh()
         dummy_tensor = torch.rand(input_size).to(next(model.parameters()).device)
 
+        # Keep spatial dims static, but let the batch dimension be dynamic so any batch size works at inference.
+        dynamic_shape = openvino.PartialShape([-1, *input_size[1:]])
+
         if self.via_onnx:
             with tempfile.TemporaryDirectory() as tmpdirname:
                 tmp_dir = Path(tmpdirname)
@@ -85,19 +88,12 @@ class LightningModelExporter(ModelExporter):
                     Precision.FP32,
                     False,
                 )
-                exported_model = openvino.convert_model(
-                    tmp_dir / (base_model_name + ".onnx"),
-                    input=(openvino.PartialShape(input_size),),
-                )
+                exported_model = openvino.convert_model(tmp_dir / (base_model_name + ".onnx"), input=(dynamic_shape,))
         else:
-            exported_model = openvino.convert_model(
-                model,
-                example_input=dummy_tensor,
-                input=(openvino.PartialShape(input_size),),
-            )
+            exported_model = openvino.convert_model(model, example_input=dummy_tensor, input=(dynamic_shape,))
         exported_model = self._postprocess_openvino_model(exported_model)
 
-        # Validate the converted model before persisting.  OpenVINO's PyTorch
+        # Validate the converted model before persisting. OpenVINO's PyTorch
         # frontend will log a deserialization error on failure and then
         # silently fall back -- leaving us with a zero-op graph that passes
         # through the "Converting to OpenVINO is done." line.  Raise here

--- a/library/tests/integration/api/test_xai.py
+++ b/library/tests/integration/api/test_xai.py
@@ -30,6 +30,7 @@ UNSUPPORTED_MODEL_SUBSTRS = ("dino", "rfdetr")
 )
 def test_forward_explain(
     recipe: str,
+    tmp_path: Path,
     fxt_target_dataset_per_task: dict,
     fxt_accelerator: str,
 ) -> None:
@@ -38,6 +39,7 @@ def test_forward_explain(
 
     Args:
         recipe (str): The recipe to use for predicting. (eg. 'classification/mobilenet_v3_large.yaml')
+        tmp_path (Path): The temporary path for storing the outputs.
         fxt_target_dataset_per_task (dict): A dictionary mapping tasks to target datasets.
         fxt_accelerator (str): The accelerator used for predict.
 
@@ -56,6 +58,7 @@ def test_forward_explain(
         config_path=recipe,
         data=fxt_target_dataset_per_task[task],
         device=fxt_accelerator,
+        work_dir=tmp_path,
     )
 
     predict_result = engine.predict()

--- a/library/tests/integration/api/test_xai.py
+++ b/library/tests/integration/api/test_xai.py
@@ -132,13 +132,14 @@ def test_predict_with_explain(
         if "saliency_map" in output.get_names():
             saliency_map_output = output
     assert saliency_map_output is not None
+    saliency_map_output_rank = saliency_map_output.get_partial_shape().rank.get_length()
     if "instance_segmentation" in recipe:
-        assert len(saliency_map_output.get_shape()) == 1
+        assert saliency_map_output_rank == 1
     else:
-        assert len(saliency_map_output.get_shape()) in [3, 4]
+        assert saliency_map_output_rank in [3, 4]
 
     assert feature_vector_output is not None
-    assert len(feature_vector_output.get_shape()) == 2
+    assert feature_vector_output.get_partial_shape().rank.get_length() == 2
 
     # Predict OV model with xai & process maps
     ov_engine = create_engine(model=exported_model_path, data=engine.datamodule, work_dir=engine.work_dir)

--- a/library/tests/unit/backend/lightning/exporter/test_native.py
+++ b/library/tests/unit/backend/lightning/exporter/test_native.py
@@ -162,6 +162,7 @@ class TestLightningModelExporter:
             dim = value_info.type.tensor_type.shape.dim[0]
             # Symbolic dynamic dims have dim_param set, while dim_value stays at the default 0
             return (dim.dim_param != "") and (dim.dim_value == 0)
+
         assert batch_dim_is_dynamic(onnx_model.graph.input[0])
         for output in onnx_model.graph.output:
             assert batch_dim_is_dynamic(output)

--- a/library/tests/unit/backend/lightning/exporter/test_native.py
+++ b/library/tests/unit/backend/lightning/exporter/test_native.py
@@ -1,6 +1,9 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+from typing import Callable
+from unittest.mock import MagicMock
 
+import numpy as np
 import onnx
 import pytest
 import torch
@@ -12,30 +15,41 @@ from getitune.types.precision import Precision
 
 
 class TestLightningModelExporter:
+    BATCH_SIZE = 8
+
     @pytest.fixture
-    def exporter(self, mocker):
+    def fxt_exporter(self):
         # Create an instance of LightningModelExporter with default params
         return LightningModelExporter(
-            task_level_export_parameters=mocker.MagicMock(TaskLevelExportParameters),
+            task_level_export_parameters=MagicMock(spec=TaskLevelExportParameters),
             data_input_params=DataInputParams((224, 224), (0.0, 0.0, 0.0), (1.0, 1.0, 1.0)),
         )
 
     @pytest.fixture
-    def dummy_model(self):
+    def fxt_dummy_model(self):
         # Define a simple dummy torch model for testing
         return torch.nn.Sequential(
             torch.nn.Conv2d(3, 16, kernel_size=3, stride=1, padding=1),
             torch.nn.ReLU(),
         )
 
-    def test_to_openvino_export(self, exporter, dummy_model, tmp_path):
+    @pytest.fixture
+    def fxt_dummy_input(self) -> Callable[[int], np.ndarray]:
+        rng = np.random.default_rng(seed=42)
+
+        def _generate_dummy_input(batch_size) -> np.ndarray:
+            return rng.random((batch_size, 3, 224, 224)).astype(np.float32)
+
+        return _generate_dummy_input
+
+    def test_to_openvino_export(self, fxt_exporter, fxt_dummy_model, tmp_path):
         # Use tmp_path provided by pytest for temporary file creation
         output_dir = tmp_path / "model_export"
         output_dir.mkdir()
 
         # Call the to_openvino method
-        exported_path = exporter.to_openvino(
-            model=dummy_model,
+        exported_path = fxt_exporter.to_openvino(
+            model=fxt_dummy_model,
             output_dir=output_dir,
             base_model_name="test_model",
             precision=Precision.FP32,
@@ -46,9 +60,9 @@ class TestLightningModelExporter:
         assert (output_dir / "test_model.xml").exists()
         assert (output_dir / "test_model.bin").exists()
 
-        exporter.via_onnx = True
-        exported_path = exporter.to_openvino(
-            model=dummy_model,
+        fxt_exporter.via_onnx = True
+        exported_path = fxt_exporter.to_openvino(
+            model=fxt_dummy_model,
             output_dir=output_dir,
             base_model_name="test_model",
             precision=Precision.FP32,
@@ -58,14 +72,14 @@ class TestLightningModelExporter:
         assert (output_dir / "test_model.xml").exists()
         assert (output_dir / "test_model.bin").exists()
 
-    def test_to_onnx_export(self, exporter, dummy_model, tmp_path):
+    def test_to_onnx_export(self, fxt_exporter, fxt_dummy_model, tmp_path):
         # Use tmp_path provided by pytest for temporary file creation
         output_dir = tmp_path / "onnx_export"
         output_dir.mkdir()
 
         # Call the to_onnx method
-        exported_path = exporter.to_onnx(
-            model=dummy_model,
+        exported_path = fxt_exporter.to_onnx(
+            model=fxt_dummy_model,
             output_dir=output_dir,
             base_model_name="test_onnx_model",
             precision=Precision.FP32,
@@ -78,3 +92,85 @@ class TestLightningModelExporter:
         # Load the model to verify it's a valid ONNX file
         onnx_model = onnx.load(str(exported_path))
         onnx.checker.check_model(onnx_model)
+
+    def test_to_openvino_export_dynamic_batch(self, fxt_exporter, fxt_dummy_model, fxt_dummy_input, tmp_path):
+        """Exported OpenVINO model should accept batch sizes other than 1."""
+        import openvino as ov
+
+        output_dir = tmp_path / "model_export_dynamic"
+        output_dir.mkdir()
+
+        exported_path = fxt_exporter.to_openvino(
+            model=fxt_dummy_model,
+            output_dir=output_dir,
+            base_model_name="test_model_dynamic",
+            precision=Precision.FP32,
+        )
+
+        core = ov.Core()
+        ov_model = core.read_model(exported_path)
+        compiled_model = core.compile_model(ov_model, "CPU")
+
+        output = compiled_model(fxt_dummy_input(self.BATCH_SIZE))
+
+        # Sanity check: output batch dim matches input batch dim
+        result = next(iter(output.values()))
+        assert result.shape[0] == self.BATCH_SIZE
+
+    def test_to_openvino_export_dynamic_batch_via_onnx(self, fxt_exporter, fxt_dummy_model, fxt_dummy_input, tmp_path):
+        """Same dynamic-batch check for the via_onnx=True export path."""
+        import openvino as ov
+
+        output_dir = tmp_path / "model_export_dynamic_onnx"
+        output_dir.mkdir()
+
+        fxt_exporter.via_onnx = True
+        exported_path = fxt_exporter.to_openvino(
+            model=fxt_dummy_model,
+            output_dir=output_dir,
+            base_model_name="test_model_dynamic_onnx",
+            precision=Precision.FP32,
+        )
+
+        core = ov.Core()
+        ov_model = core.read_model(exported_path)
+        compiled_model = core.compile_model(ov_model, "CPU")
+
+        output = compiled_model(fxt_dummy_input(self.BATCH_SIZE))
+        result = next(iter(output.values()))
+        assert result.shape[0] == self.BATCH_SIZE
+
+    def test_to_onnx_export_dynamic_batch(self, fxt_exporter, fxt_dummy_model, fxt_dummy_input, tmp_path):
+        """Exported ONNX model's input/output batch axis should be dynamic (symbolic), not fixed to 1."""
+        output_dir = tmp_path / "onnx_export_dynamic"
+        output_dir.mkdir()
+
+        fxt_exporter.onnx_export_configuration = {
+            "dynamic_shapes": ({0: torch.export.Dim("batch")},),
+        }
+
+        exported_path = fxt_exporter.to_onnx(
+            model=fxt_dummy_model,
+            output_dir=output_dir,
+            base_model_name="test_onnx_model_dynamic",
+            precision=Precision.FP32,
+        )
+
+        onnx_model = onnx.load(str(exported_path))
+
+        def batch_dim_is_dynamic(value_info) -> bool:
+            dim = value_info.type.tensor_type.shape.dim[0]
+            # Dynamic dims have no dim_value set (dim_param may be set instead)
+            return dim.dim_value == 0
+
+        assert batch_dim_is_dynamic(onnx_model.graph.input[0])
+        for output in onnx_model.graph.output:
+            assert batch_dim_is_dynamic(output)
+
+        # Also functionally verify via onnxruntime with batch=8
+        import onnxruntime as ort
+
+        session = ort.InferenceSession(str(exported_path))
+        input_name = session.get_inputs()[0].name
+        outputs = session.run(None, {input_name: fxt_dummy_input(self.BATCH_SIZE)})
+        assert outputs[0].shape[0] == self.BATCH_SIZE  # pyrefly: ignore[missing-attribute]

--- a/library/tests/unit/backend/lightning/exporter/test_native.py
+++ b/library/tests/unit/backend/lightning/exporter/test_native.py
@@ -160,9 +160,8 @@ class TestLightningModelExporter:
 
         def batch_dim_is_dynamic(value_info) -> bool:
             dim = value_info.type.tensor_type.shape.dim[0]
-            # Dynamic dims have no dim_value set (dim_param may be set instead)
-            return dim.dim_value == 0
-
+            # Symbolic dynamic dims have dim_param set, while dim_value stays at the default 0
+            return (dim.dim_param != "") and (dim.dim_value == 0)
         assert batch_dim_is_dynamic(onnx_model.graph.input[0])
         for output in onnx_model.graph.output:
             assert batch_dim_is_dynamic(output)

--- a/library/tests/unit/backend/lightning/exporter/test_native.py
+++ b/library/tests/unit/backend/lightning/exporter/test_native.py
@@ -15,8 +15,6 @@ from getitune.types.precision import Precision
 
 
 class TestLightningModelExporter:
-    BATCH_SIZE = 8
-
     @pytest.fixture
     def fxt_exporter(self):
         # Create an instance of LightningModelExporter with default params
@@ -93,7 +91,10 @@ class TestLightningModelExporter:
         onnx_model = onnx.load(str(exported_path))
         onnx.checker.check_model(onnx_model)
 
-    def test_to_openvino_export_dynamic_batch(self, fxt_exporter, fxt_dummy_model, fxt_dummy_input, tmp_path):
+    @pytest.mark.parametrize("batch_size", [1, 2, 4])
+    def test_to_openvino_export_dynamic_batch(
+        self, batch_size, fxt_exporter, fxt_dummy_model, fxt_dummy_input, tmp_path
+    ):
         """Exported OpenVINO model should accept batch sizes other than 1."""
         import openvino as ov
 
@@ -111,13 +112,16 @@ class TestLightningModelExporter:
         ov_model = core.read_model(exported_path)
         compiled_model = core.compile_model(ov_model, "CPU")
 
-        output = compiled_model(fxt_dummy_input(self.BATCH_SIZE))
+        output = compiled_model(fxt_dummy_input(batch_size))
 
         # Sanity check: output batch dim matches input batch dim
         result = next(iter(output.values()))
-        assert result.shape[0] == self.BATCH_SIZE
+        assert result.shape[0] == batch_size
 
-    def test_to_openvino_export_dynamic_batch_via_onnx(self, fxt_exporter, fxt_dummy_model, fxt_dummy_input, tmp_path):
+    @pytest.mark.parametrize("batch_size", [1, 2, 4])
+    def test_to_openvino_export_dynamic_batch_via_onnx(
+        self, batch_size, fxt_exporter, fxt_dummy_model, fxt_dummy_input, tmp_path
+    ):
         """Same dynamic-batch check for the via_onnx=True export path."""
         import openvino as ov
 
@@ -136,11 +140,12 @@ class TestLightningModelExporter:
         ov_model = core.read_model(exported_path)
         compiled_model = core.compile_model(ov_model, "CPU")
 
-        output = compiled_model(fxt_dummy_input(self.BATCH_SIZE))
+        output = compiled_model(fxt_dummy_input(batch_size))
         result = next(iter(output.values()))
-        assert result.shape[0] == self.BATCH_SIZE
+        assert result.shape[0] == batch_size
 
-    def test_to_onnx_export_dynamic_batch(self, fxt_exporter, fxt_dummy_model, fxt_dummy_input, tmp_path):
+    @pytest.mark.parametrize("batch_size", [1, 2, 4])
+    def test_to_onnx_export_dynamic_batch(self, batch_size, fxt_exporter, fxt_dummy_model, fxt_dummy_input, tmp_path):
         """Exported ONNX model's input/output batch axis should be dynamic (symbolic), not fixed to 1."""
         output_dir = tmp_path / "onnx_export_dynamic"
         output_dir.mkdir()
@@ -172,5 +177,5 @@ class TestLightningModelExporter:
 
         session = ort.InferenceSession(str(exported_path))
         input_name = session.get_inputs()[0].name
-        outputs = session.run(None, {input_name: fxt_dummy_input(self.BATCH_SIZE)})
-        assert outputs[0].shape[0] == self.BATCH_SIZE  # pyrefly: ignore[missing-attribute]
+        outputs = session.run(None, {input_name: fxt_dummy_input(batch_size)})
+        assert outputs[0].shape[0] == batch_size  # pyrefly: ignore[missing-attribute]


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

- [x] Enabled dynamic dimension for `openvino.PartialShape`  in `LightningModelExporter#to_openvino` path

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
