### PR TITLE
feat: Display license check screen only in windows desktop app

### DIFF
--- a/.github/workflows/ui-lint-and-test.yaml
+++ b/.github/workflows/ui-lint-and-test.yaml
@@ -293,6 +293,10 @@ jobs:
         working-directory: "application/ui"
         run: tar -xzf dist.tar.gz
 
+      - name: Build UI (Tauri target)
+        working-directory: "application/ui"
+        run: npm run build:tauri
+
       - *download-openapi-spec
 
       - *build-openapi-types

--- a/.github/workflows/ui-lint-and-test.yaml
+++ b/.github/workflows/ui-lint-and-test.yaml
@@ -303,7 +303,7 @@ jobs:
 
       - name: Run Playwright tests
         working-directory: "application/ui"
-        run: npm run test:component -- --project "component" --project "Tauri component tests"
+        run: npm run test:component
 
       - name: Upload blob report to GitHub Actions Artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ui-lint-and-test.yaml
+++ b/.github/workflows/ui-lint-and-test.yaml
@@ -299,7 +299,7 @@ jobs:
 
       - name: Run Playwright tests
         working-directory: "application/ui"
-        run: npm run test:component -- --project "component"
+        run: npm run test:component -- --project "component" --project "Tauri component tests"
 
       - name: Upload blob report to GitHub Actions Artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/application/ui/.gitignore
+++ b/application/ui/.gitignore
@@ -6,6 +6,7 @@
 # Dist
 node_modules
 dist/
+dist-tauri/
 
 # Profile
 .rspack-profile-*/

--- a/application/ui/package.json
+++ b/application/ui/package.json
@@ -25,10 +25,11 @@
         "lint:fix": "eslint --fix \"./src/**/*.ts*\"",
         "preinstall": "npm run clone-geti-ui-packages",
         "preview": "npm run build && rsbuild preview",
+        "preview:tauri": "cross-env BUILD_TARGET=tauri rsbuild preview --port 3001",
         "test:unit": "vitest --config vitest.config.ts",
         "test:unit:watch": "vitest --config vitest.config.ts --reporter=tree --watch",
         "test:unit:coverage": "vitest --coverage",
-        "test:component": "npx playwright test --project=component",
+        "test:component": "npx playwright test --project=component --project=\"Tauri component tests\"",
         "test:e2e": "ENABLE_BACKEND=True npx playwright test --project=e2e",
         "type-check": "tsc --noEmit",
         "tauri": "tauri"

--- a/application/ui/playwright.config.ts
+++ b/application/ui/playwright.config.ts
@@ -57,12 +57,23 @@ export default defineConfig({
         {
             name: 'component',
             testDir: './tests',
-            testIgnore: '**/e2e/**',
+            testIgnore: ['**/e2e/**', /.*\.tauri\.spec\.ts/],
             use: {
                 ...devices['Desktop Chrome'],
                 headless: true,
                 viewport: { width: 1280, height: 720 },
             },
+        },
+        {
+            name: 'Tauri component tests',
+            testDir: './tests',
+            use: {
+                ...devices['Desktop Chrome'],
+                headless: true,
+                viewport: { width: 1280, height: 720 },
+                baseURL: 'http://localhost:3001',
+            },
+            testMatch: /.*\.tauri\.spec\.ts$/,
         },
         {
             name: 'e2e',
@@ -75,13 +86,21 @@ export default defineConfig({
         },
     ],
 
-    /* Run your local dev server before starting the tests */
+    /* Run your local dev server(s) before starting the tests */
     webServer: !process.env.ENABLE_BACKEND
-        ? {
-              command: CI ? 'npm run preview -- --port 3000' : 'npm run start',
-              url: 'http://localhost:3000',
-              reuseExistingServer: true,
-              timeout: ACTION_TIMEOUT,
-          }
+        ? [
+              {
+                  command: CI ? 'npm run preview -- --port 3000' : 'npm run start',
+                  url: 'http://localhost:3000',
+                  reuseExistingServer: true,
+                  timeout: ACTION_TIMEOUT,
+              },
+              {
+                  command: CI ? 'npm run preview:tauri' : 'npm run start:tauri -- --port 3001',
+                  url: 'http://localhost:3001',
+                  reuseExistingServer: true,
+                  timeout: ACTION_TIMEOUT,
+              },
+          ]
         : undefined,
 });

--- a/application/ui/playwright.config.ts
+++ b/application/ui/playwright.config.ts
@@ -1,6 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -17,6 +18,23 @@ dotenv.config({
 const CI = !!process.env.CI;
 
 const ACTION_TIMEOUT = 30000;
+
+// In CI we serve pre-built bundles via `rsbuild preview`, which requires the
+// output directories to already exist. Failing fast here produces a clearer
+// error than waiting for `webServer.timeout` to elapse on a 404-returning
+// preview server.
+if (CI) {
+    const requiredDirs = ['dist', 'dist-tauri'];
+    for (const dir of requiredDirs) {
+        const absolute = path.resolve(dirname, dir);
+        if (!existsSync(absolute)) {
+            throw new Error(
+                `Missing build output at ${absolute}. ` +
+                    `Run \`npm run build\` (web) and \`npm run build:tauri\` (tauri) before \`npm run test:component\`.`
+            );
+        }
+    }
+}
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/application/ui/rsbuild.config.ts
+++ b/application/ui/rsbuild.config.ts
@@ -70,6 +70,7 @@ export default defineConfig({
     ],
     output: {
         assetPrefix: process.env.ASSET_PREFIX,
+        distPath: { root: isTauriBuild ? 'dist-tauri' : 'dist' },
         minify: isTauriDebugBuild ? false : undefined,
         sourceMap: isTauriDebugBuild
             ? {

--- a/application/ui/src-tauri/tauri.conf.json
+++ b/application/ui/src-tauri/tauri.conf.json
@@ -4,7 +4,7 @@
     "version": "3.1.0",
     "identifier": "com.intel.geti",
     "build": {
-        "frontendDist": "../dist",
+        "frontendDist": "../dist-tauri",
         "devUrl": "http://localhost:3000",
         "beforeDevCommand": "npm run start:tauri",
         "beforeBuildCommand": "npm run build:tauri"

--- a/application/ui/src/features/license/license-check.component.tauri.tsx
+++ b/application/ui/src/features/license/license-check.component.tauri.tsx
@@ -1,0 +1,35 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { ReactNode } from 'react';
+
+import { $api } from '@/api';
+import { Loading } from '@geti-ui/ui';
+
+import { ServerErrorFallback } from '../../routes/root/server-error-fallback.component';
+import { License } from './license.component';
+
+const REFETCH_INTERVAL = 5000;
+
+export const LicenseCheck = ({ children }: { children: ReactNode }) => {
+    const { data, isPending, isError } = $api.useQuery('get', '/api/system/info', undefined, {
+        retry: 2,
+        refetchInterval: (query) => {
+            return query.state.data?.license_accepted ? false : REFETCH_INTERVAL;
+        },
+    });
+
+    if (isPending) {
+        return <Loading variant={'intel'} />;
+    }
+
+    if (isError) {
+        return <ServerErrorFallback />;
+    }
+
+    if (data && !data.license_accepted && data.platform === 'windows') {
+        return <License />;
+    }
+
+    return children;
+};

--- a/application/ui/src/features/license/license-check.component.tsx
+++ b/application/ui/src/features/license/license-check.component.tsx
@@ -1,0 +1,8 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { ReactNode } from 'react';
+
+export const LicenseCheck = ({ children }: { children: ReactNode }) => {
+    return children;
+};

--- a/application/ui/src/features/license/license.component.tsx
+++ b/application/ui/src/features/license/license.component.tsx
@@ -14,26 +14,15 @@ const LICENSE_LINKS = {
         // eslint-disable-next-line max-len
         href: 'https://www.intel.com/content/www/us/en/content-details/749362/intel-simplified-software-license-version-october-2022.html',
     },
-    apache2: {
-        label: 'Apache License 2.0',
-        href: 'https://www.apache.org/licenses/LICENSE-2.0',
-    },
+
     dinov2: {
         label: 'DINOv3 License',
         href: 'https://github.com/facebookresearch/dinov3/blob/main/LICENSE.md',
     },
 };
 
-type Platform = 'linux' | 'windows' | 'macos';
-
-type LicenseProps = {
-    platform: Platform;
-};
-
-export const License = ({ platform }: LicenseProps) => {
+export const License = () => {
     const { mutate: acceptLicense, isPending: isAccepting } = useAcceptLicense();
-
-    const appLicense = platform === 'windows' ? LICENSE_LINKS.intelSimplified : LICENSE_LINKS.apache2;
 
     return (
         <View UNSAFE_className={styles.licenseBackground} height={'100vh'}>
@@ -55,8 +44,12 @@ export const License = ({ platform }: LicenseProps) => {
                             <li>Accepted and agreed to the linked license terms.</li>
                         </ul>
                         <Flex direction={'column'} marginTop={'size-200'}>
-                            <Link href={appLicense.href} target={'_blank'} rel={'noopener noreferrer'}>
-                                {appLicense.label}
+                            <Link
+                                href={LICENSE_LINKS.intelSimplified.href}
+                                target={'_blank'}
+                                rel={'noopener noreferrer'}
+                            >
+                                {LICENSE_LINKS.intelSimplified.label}
                             </Link>
                             <Link href={LICENSE_LINKS.dinov2.href} target={'_blank'} rel={'noopener noreferrer'}>
                                 {LICENSE_LINKS.dinov2.label}

--- a/application/ui/src/routes/root/root.tsx
+++ b/application/ui/src/routes/root/root.tsx
@@ -4,11 +4,10 @@
 import { ReactNode, Suspense } from 'react';
 
 import { $api } from '@/api';
-import { Flex, Heading } from '@geti-ui/ui';
+import { Flex, Heading, Loading } from '@geti-ui/ui';
 import { Outlet } from 'react-router';
 
-import { License } from '../../features/license/license.component';
-import { IntelBrandedLoading } from '../../shared/components/intel-branded-loading/intel-branded-loading.component';
+import { LicenseCheck } from '../../features/license/license-check.component';
 import { ServerErrorFallback } from './server-error-fallback.component';
 
 const REFETCH_INTERVAL = 5000;
@@ -27,7 +26,7 @@ const HealthCheck = ({ children }: { children: ReactNode }) => {
     if (isPending) {
         return (
             <Flex direction={'column'} justifyContent={'center'} alignItems={'center'} height={'100vh'}>
-                <IntelBrandedLoading height={'auto'} />
+                <Loading variant={'intel'} mode={'inline'} />
                 <Heading bottom={'size-4600'} level={2}>
                     Loading...Please wait.
                 </Heading>
@@ -43,35 +42,12 @@ const HealthCheck = ({ children }: { children: ReactNode }) => {
         return children;
     }
 
-    return <IntelBrandedLoading />;
-};
-
-const LicenseCheck = ({ children }: { children: ReactNode }) => {
-    const { data, isPending, isError } = $api.useQuery('get', '/api/system/info', undefined, {
-        retry: 2,
-        refetchInterval: (query) => {
-            return query.state.data?.license_accepted ? false : REFETCH_INTERVAL;
-        },
-    });
-
-    if (isPending) {
-        return <IntelBrandedLoading />;
-    }
-
-    if (isError) {
-        return <ServerErrorFallback />;
-    }
-
-    if (data && !data.license_accepted) {
-        return <License platform={data.platform} />;
-    }
-
-    return children;
+    return <Loading variant={'intel'} />;
 };
 
 export const RootLayout = () => {
     return (
-        <Suspense fallback={<IntelBrandedLoading />}>
+        <Suspense fallback={<Loading variant={'intel'} />}>
             <HealthCheck>
                 <LicenseCheck>
                     <Outlet />

--- a/application/ui/tests/license/license.spec.ts
+++ b/application/ui/tests/license/license.spec.ts
@@ -1,86 +1,28 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 import { expect, http, test } from '../fixtures';
 
-test.describe('License agreement', () => {
-    test('shows the license screen and accepts the license', async ({ page, network }) => {
-        let licenseAccepted = false;
-
-        network.use(
-            http.get('/api/system/info', ({ response }) => {
-                return response(200).json({
-                    license_accepted: licenseAccepted,
-                    platform: 'linux',
-                });
-            }),
-            http.post('/api/license/accept', ({ response }) => {
-                licenseAccepted = true;
-
-                return response(200).json({ license_accepted: true });
-            }),
-            http.get('/api/projects', ({ response }) => {
-                return response(200).json([]);
-            })
-        );
-
-        await test.step('license screen is shown when license is not accepted', async () => {
-            await page.goto('/');
-
-            await expect(page.getByRole('heading', { name: /License Agreement/i })).toBeVisible();
-            await expect(page.getByRole('link', { name: /DINOv3 License/i })).toBeVisible();
-            await expect(page.getByRole('link', { name: /Apache License 2\.0/i })).toBeVisible();
-        });
-
-        await test.step('accepting the license redirects to the projects page', async () => {
-            await page.getByRole('button', { name: /Accept and continue/i }).click();
-
-            await expect(page.getByRole('heading', { name: /License Agreement/i })).toBeHidden();
-            await expect(page).toHaveURL(/\/projects$/);
-        });
-    });
-
-    test('shows Intel license on Windows platform', async ({ page, network }) => {
+test.describe('License agreement (web)', () => {
+    test('never shows the license screen, even when the backend reports it is unaccepted', async ({
+        page,
+        network,
+    }) => {
         network.use(
             http.get('/api/system/info', ({ response }) => {
                 return response(200).json({
                     license_accepted: false,
                     platform: 'windows',
                 });
-            })
-        );
-
-        await page.goto('/');
-
-        await expect(page.getByRole('link', { name: /Intel Simplified Software License/i })).toBeVisible();
-    });
-
-    test('skips license screen when license is already accepted', async ({ page, network }) => {
-        network.use(
-            http.get('/api/system/info', ({ response }) => {
-                return response(200).json({
-                    license_accepted: true,
-                    platform: 'linux',
-                });
+            }),
+            http.get('/api/projects', ({ response }) => {
+                return response(200).json([]);
             })
         );
 
         await page.goto('/');
 
         await expect(page.getByRole('heading', { name: /License Agreement/i })).toBeHidden();
-    });
-
-    test('shows error state when system info is unavailable', async ({ page, network }) => {
-        network.use(
-            http.get('/api/system/info', ({ response }) => {
-                // @ts-expect-error Simulate server error
-                return response(500).json({});
-            })
-        );
-
-        await page.goto('/');
-
-        await expect(page.getByRole('heading', { name: 'Server Error' })).toBeVisible();
-        await expect(page.getByRole('button', { name: 'Refresh' })).toBeVisible();
+        await expect(page).toHaveURL(/\/projects$/);
     });
 });

--- a/application/ui/tests/license/license.tauri.spec.ts
+++ b/application/ui/tests/license/license.tauri.spec.ts
@@ -2,8 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { expect, http, test } from '../fixtures';
+import { mockTauriRuntime } from '../utils/mock-tauri-runtime';
 
 test.describe('License agreement (Tauri)', () => {
+    test.beforeEach(async ({ page }) => {
+        // Provide the Tauri IPC bridge that the real desktop webview injects but
+        // Playwright's Chromium does not, so the desktop bundle can boot.
+        await mockTauriRuntime(page);
+    });
+
     test('shows the license screen and accepts the license on Windows', async ({ page, network }) => {
         let licenseAccepted = false;
 

--- a/application/ui/tests/license/license.tauri.spec.ts
+++ b/application/ui/tests/license/license.tauri.spec.ts
@@ -1,0 +1,92 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, http, test } from '../fixtures';
+
+test.describe('License agreement (Tauri)', () => {
+    test('shows the license screen and accepts the license on Windows', async ({ page, network }) => {
+        let licenseAccepted = false;
+
+        network.use(
+            http.get('/api/system/info', ({ response }) => {
+                return response(200).json({
+                    license_accepted: licenseAccepted,
+                    platform: 'windows',
+                });
+            }),
+            http.post('/api/license/accept', ({ response }) => {
+                licenseAccepted = true;
+
+                return response(200).json({ license_accepted: true });
+            }),
+            http.get('/api/projects', ({ response }) => {
+                return response(200).json([]);
+            })
+        );
+
+        await test.step('license screen is shown when license is not accepted', async () => {
+            await page.goto('/');
+
+            await expect(page.getByRole('heading', { name: /License Agreement/i })).toBeVisible();
+            await expect(page.getByRole('link', { name: /Intel Simplified Software License/i })).toBeVisible();
+            await expect(page.getByRole('link', { name: /DINOv3 License/i })).toBeVisible();
+        });
+
+        await test.step('accepting the license redirects to the projects page', async () => {
+            await page.getByRole('button', { name: /Accept and continue/i }).click();
+
+            await expect(page.getByRole('heading', { name: /License Agreement/i })).toBeHidden();
+            await expect(page).toHaveURL(/\/projects$/);
+        });
+    });
+
+    test('skips the license screen on non-Windows platforms', async ({ page, network }) => {
+        network.use(
+            http.get('/api/system/info', ({ response }) => {
+                return response(200).json({
+                    license_accepted: false,
+                    platform: 'linux',
+                });
+            }),
+            http.get('/api/projects', ({ response }) => {
+                return response(200).json([]);
+            })
+        );
+
+        await page.goto('/');
+
+        await expect(page.getByRole('heading', { name: /License Agreement/i })).toBeHidden();
+    });
+
+    test('skips the license screen when it is already accepted on Windows', async ({ page, network }) => {
+        network.use(
+            http.get('/api/system/info', ({ response }) => {
+                return response(200).json({
+                    license_accepted: true,
+                    platform: 'windows',
+                });
+            }),
+            http.get('/api/projects', ({ response }) => {
+                return response(200).json([]);
+            })
+        );
+
+        await page.goto('/');
+
+        await expect(page.getByRole('heading', { name: /License Agreement/i })).toBeHidden();
+    });
+
+    test('shows error state when system info is unavailable', async ({ page, network }) => {
+        network.use(
+            http.get('/api/system/info', ({ response }) => {
+                // @ts-expect-error Simulate server error
+                return response(500).json({});
+            })
+        );
+
+        await page.goto('/');
+
+        await expect(page.getByRole('heading', { name: 'Server Error' })).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Refresh' })).toBeVisible();
+    });
+});

--- a/application/ui/tests/utils/mock-tauri-runtime.ts
+++ b/application/ui/tests/utils/mock-tauri-runtime.ts
@@ -1,0 +1,46 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Page } from '@playwright/test';
+
+interface TauriInternals {
+    metadata: {
+        currentWindow: { label: string };
+        currentWebview: { windowLabel: string; label: string };
+    };
+}
+
+declare global {
+    interface Window {
+        // `@tauri-apps/api` reads this at runtime but ships no global type for it.
+        __TAURI_INTERNALS__?: TauriInternals;
+    }
+}
+
+/**
+ * The Tauri desktop bundle (files resolved via the `.tauri.*` extension) calls
+ * `@tauri-apps/api` at module load, e.g. `getCurrentWindow()` in
+ * `src/platform/storage-cleanup.tauri.ts`. Those functions dereference
+ * `window.__TAURI_INTERNALS__`, which is injected by the real Tauri webview
+ * runtime and is therefore absent in Playwright's plain Chromium. Without it the
+ * app throws `Cannot read properties of undefined (reading 'metadata')` before
+ * React renders.
+ */
+export const mockTauriRuntime = async (page: Page): Promise<void> => {
+    await page.addInitScript(() => {
+        const label = 'main';
+
+        // eslint-disable-next-line no-underscore-dangle -- required global name injected by the Tauri runtime
+        window.__TAURI_INTERNALS__ = {
+            metadata: {
+                currentWindow: { label },
+                currentWebview: { windowLabel: label, label },
+            },
+        };
+
+        // eslint-disable-next-line no-underscore-dangle -- required global name injected by the Tauri runtime
+        window.__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+            unregisterListener: () => {},
+        };
+    });
+};


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

1. Display license check only in tauri windows app.
2. Add playwright test for tauri.

Closes #7035 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
