### PR TITLE
feat: introduce fallback to mirror url if primary fails when download…

### DIFF
--- a/application/backend/app/services/base_weights_service.py
+++ b/application/backend/app/services/base_weights_service.py
@@ -213,7 +213,6 @@ class BaseWeightsService:
         Raises:
             RuntimeError: If none of the candidate URLs yield a file that passes integrity verification.
         """
-        self._check_disk_space(urls[0])
         local_path.parent.mkdir(parents=True, exist_ok=True)
         temp_path = local_path.with_suffix(".tmp")
 
@@ -222,6 +221,7 @@ class BaseWeightsService:
             for url in urls:
                 logger.info("Downloading pretrained weights from {}", url)
                 try:
+                    self._check_disk_space(url)
                     self._download_from_url(url, temp_path)
                 except requests.RequestException as e:
                     last_error = e

--- a/application/backend/app/services/base_weights_service.py
+++ b/application/backend/app/services/base_weights_service.py
@@ -65,18 +65,18 @@ class BaseWeightsService:
         local_path = self.pretrained_weights_dir / task.name.lower() / local_filename
         if local_path.exists():
             if self._verify_file_integrity(file_path=local_path, sha_sum=manifest.pretrained_weights.sha_sum):
-                logger.info(f"Using cached weights for {model_manifest_id}: {local_path}")
+                logger.info("Using cached weights for {}: {}", model_manifest_id, local_path)
                 return local_path
 
-            logger.warning(f"Cached weights for {model_manifest_id} failed integrity check, will re-download")
+            logger.warning("Cached weights for {} failed integrity check, will re-download", model_manifest_id)
             local_path.unlink()
 
         if not allow_download:
             raise FileNotFoundError(f"Weights not found locally for model {model_manifest_id} and download is disabled")
 
-        logger.info(f"Downloading pretrained weights for {model_manifest_id} from {manifest.pretrained_weights.url}")
+        logger.info("Downloading pretrained weights for {}", model_manifest_id)
         self._download_weights(
-            remote_url=manifest.pretrained_weights.url,
+            urls=[manifest.pretrained_weights.url, manifest.pretrained_weights.mirror_url],
             local_path=local_path,
             sha_sum=manifest.pretrained_weights.sha_sum,
         )
@@ -99,10 +99,10 @@ class BaseWeightsService:
         if local_path.exists():
             try:
                 local_path.unlink()
-                logger.info(f"Removed local weights for {model_manifest_id}: {local_path}")
+                logger.info("Removed local weights for {}: {}", model_manifest_id, local_path)
                 return True
             except OSError as e:
-                logger.error(f"Failed to remove weights file {local_path}: {e}")
+                logger.error("Failed to remove weights file {}: {}", local_path, e)
 
         return False
 
@@ -123,14 +123,14 @@ class BaseWeightsService:
                     try:
                         weights_file.unlink()
                         removed_count += 1
-                        logger.debug(f"Removed weights file: {weights_file}")
+                        logger.debug("Removed weights file: {}", weights_file)
                     except OSError as e:
-                        logger.error(f"Failed to remove weights file {weights_file}: {e}")
+                        logger.error("Failed to remove weights file {}: {}", weights_file, e)
 
-            logger.info(f"Removed {removed_count} cached weight files")
+            logger.info("Removed {} cached weight files", removed_count)
             return removed_count
         except OSError as e:
-            logger.error(f"Failed to remove cached weights: {e}")
+            logger.error("Failed to remove cached weights: {}", e)
             return 0
 
     @staticmethod
@@ -154,7 +154,7 @@ class BaseWeightsService:
             actual_sha_sum = sha256_hash.hexdigest()
             return actual_sha_sum == sha_sum
         except Exception as e:
-            logger.error(f"Failed to verify file integrity for {file_path}: {e}")
+            logger.error("Failed to verify file integrity for {}: {}", file_path, e)
             return False
 
     def _check_disk_space(self, remote_url: str, safety_margin_gb: float = 1.0) -> None:
@@ -181,14 +181,14 @@ class BaseWeightsService:
                     if content_length:
                         file_size = int(content_length)
                     else:
-                        logger.warning(f"Could not determine file size for {remote_url}, assuming 500MB")
+                        logger.warning("Could not determine file size for {}, assuming 500MB", remote_url)
                     break
             except Exception as e:
                 # Log per mode so we can see whether proxy or direct access failed.
                 proxy_mode = "env-proxy" if use_env_proxy else "direct"
-                logger.warning(f"Could not check remote file size for {remote_url} via {proxy_mode}: {e}")
+                logger.warning("Could not check remote file size for {} via {}: {}", remote_url, proxy_mode, e)
         else:
-            logger.warning(f"Could not check remote file size for {remote_url}; assuming 500MB")
+            logger.warning("Could not check remote file size for {}; assuming 500MB", remote_url)
 
         stat = shutil.disk_usage(self.pretrained_weights_dir)
         available_space = stat.free
@@ -200,67 +200,76 @@ class BaseWeightsService:
                 f"Available: {available_space / (1024**3):.2f} GB"
             )
 
-    def _download_weights(self, remote_url: str, local_path: Path, sha_sum: str) -> None:
+    def _download_weights(self, urls: list[str], local_path: Path, sha_sum: str) -> None:
         """
-        Download weights from remote URL to local path and verify integrity.
+        Download weights from the first working URL among the given candidates (e.g. primary then mirror).
         Before download, checks if there is enough space on disk.
 
         Args:
-            remote_url: URL to download from
+            urls: Candidate URLs in priority order.
             local_path: Local path to save the file
             sha_sum: Expected SHA256 checksum for verification
 
         Raises:
-            RuntimeError: If downloaded file fails integrity check, or if download fails
+            RuntimeError: If none of the candidate URLs yield a file that passes integrity verification.
         """
-        self._check_disk_space(remote_url)
-
-        # Create temporary file for download
+        self._check_disk_space(urls[0])
+        local_path.parent.mkdir(parents=True, exist_ok=True)
         temp_path = local_path.with_suffix(".tmp")
-        try:
-            # Ensure all folders exist for the destination path
-            local_path.parent.mkdir(parents=True, exist_ok=True)
 
-            # Attempt the download with and without proxies, since some environment may have proxy issues
-            last_error: Exception | None = None
-            for use_env_proxy in (True, False):
+        last_error: Exception | None = None
+        try:
+            for url in urls:
+                logger.info("Downloading pretrained weights from {}", url)
                 try:
-                    with (
-                        self._build_retry_session(use_env_proxy=use_env_proxy) as session,
-                        session.get(remote_url, stream=True, timeout=self.REQUEST_TIMEOUT) as response,
-                    ):
-                        response.raise_for_status()
-                        with open(temp_path, "wb") as f:
-                            for data in response.iter_content(chunk_size=4096):
-                                f.write(data)
-                    break
+                    self._download_from_url(url, temp_path)
                 except requests.RequestException as e:
                     last_error = e
-                    proxy_mode = "env-proxy" if use_env_proxy else "direct"
-                    logger.warning(f"Weight download failed via {proxy_mode} for {remote_url}: {e}")
-            else:
-                raise RuntimeError(f"Failed to download weights from {remote_url}: {last_error}")
+                    logger.warning("Failed to download weights from {}: {}", url, e)
+                    continue
 
-            if not self._verify_file_integrity(temp_path, sha_sum):
-                temp_path.unlink()
-                raise RuntimeError(f"Downloaded file failed integrity check for {remote_url}")
+                if self._verify_file_integrity(temp_path, sha_sum):
+                    temp_path.rename(local_path)
+                    logger.info("Successfully downloaded and verified weights: {}", local_path)
+                    return
 
-            # Move temporary file to final location
-            temp_path.rename(local_path)
-            logger.info(f"Successfully downloaded and verified weights: {local_path}")
-        except requests.RequestException as e:
-            logger.error(f"Failed to download weights from {remote_url}: {e}")
-            raise RuntimeError(f"Failed to download weights from {remote_url}: {e}") from e
-        except RuntimeError:
-            # Re-raise runtime errors to preserve the original error type and message and avoid the broad except clause
-            raise
-        except Exception as e:
-            logger.error(f"Unexpected error downloading weights from {remote_url}: {e}")
-            raise RuntimeError(f"Unexpected error downloading weights from {remote_url}: {e}") from e
+                last_error = RuntimeError(f"Integrity check failed for weights downloaded from {url}")
+                logger.warning("Downloaded weights from {} failed integrity check, trying next candidate URL", url)
+                temp_path.unlink(missing_ok=True)
+
+            raise RuntimeError(
+                f"Failed to download weights from any of the candidate URLs {urls}: {last_error}"
+            ) from last_error
+
         finally:
             # Clean up temporary file if it exists
             if temp_path.exists():
                 temp_path.unlink()
+
+    def _download_from_url(self, url: str, temp_path: Path) -> None:
+        """
+        Download a single URL to temp_path, retrying with & without the environment proxy on failure.
+
+        Raises:
+            requests.RequestException: If both the proxied and direct attempts fail.
+        """
+        last_error: Exception | None = None
+        for use_env_proxy in (True, False):
+            try:
+                with (
+                    self._build_retry_session(use_env_proxy=use_env_proxy) as session,
+                    session.get(url, stream=True, timeout=self.REQUEST_TIMEOUT) as response,
+                ):
+                    response.raise_for_status()
+                    with open(temp_path, "wb") as f:
+                        for data in response.iter_content(chunk_size=4096):
+                            f.write(data)
+                return
+            except requests.RequestException as e:
+                last_error = e
+                proxy_mode = "env-proxy" if use_env_proxy else "direct"
+                logger.warning("Weight download failed via {} for {}: {}", proxy_mode, url, e)
+        raise requests.RequestException(f"Failed to download from {url}") from last_error
 
     def _build_retry_session(self, use_env_proxy: bool) -> requests.Session:
         session = requests.Session()

--- a/application/backend/tests/integration/services/test_base_weights_service.py
+++ b/application/backend/tests/integration/services/test_base_weights_service.py
@@ -108,7 +108,7 @@ class TestBaseWeightsService:
             patch.object(
                 fxt_base_weights_service,
                 "_download_weights",
-                side_effect=lambda remote_url, local_path, sha_sum: local_path.write_bytes(WEIGHTS_CONTENT),
+                side_effect=lambda urls, local_path, sha_sum: local_path.write_bytes(WEIGHTS_CONTENT),
             ),
         ):
             result = fxt_base_weights_service.get_local_weights_path(
@@ -128,7 +128,7 @@ class TestBaseWeightsService:
             patch.object(
                 fxt_base_weights_service,
                 "_download_weights",
-                side_effect=lambda remote_url, local_path, sha_sum: local_path.write_bytes(WEIGHTS_CONTENT),
+                side_effect=lambda urls, local_path, sha_sum: local_path.write_bytes(WEIGHTS_CONTENT),
             ),
         ):
             result = fxt_base_weights_service.get_local_weights_path(

--- a/application/backend/tests/unit/services/test_base_weights_service.py
+++ b/application/backend/tests/unit/services/test_base_weights_service.py
@@ -168,7 +168,10 @@ class TestBaseWeightsServiceRetryLogic:
                 "_download_from_url",
                 side_effect=requests.RequestException("connection error"),
             ),
-            pytest.raises(RuntimeError, match="primary.example.com.*mirror.example.com|weights.pth"),
+            pytest.raises(
+                RuntimeError,
+                match="https://primary.example.com/weights.pth.*https://mirror.example.com/weights.pth",
+            ),
         ):
             fxt_base_weights_service._download_weights(
                 urls=["https://primary.example.com/weights.pth", "https://mirror.example.com/weights.pth"],

--- a/application/backend/tests/unit/services/test_base_weights_service.py
+++ b/application/backend/tests/unit/services/test_base_weights_service.py
@@ -92,31 +92,102 @@ class TestBaseWeightsServiceRetryLogic:
             patch.object(fxt_base_weights_service, "_verify_file_integrity", return_value=True),
         ):
             fxt_base_weights_service._download_weights(
-                remote_url="https://example.com/weights.pth",
+                urls=["https://example.com/weights.pth"],
                 local_path=local_path,
                 sha_sum="dummy_sha",
             )
         assert proxy_session.get.called
         assert direct_session.get.called
 
-    def test_download_weights_raises_when_both_connections_fail(self, fxt_base_weights_service):
-        """Test that download raises RuntimeError when both proxy and direct connections fail."""
-        proxy_session = self._make_mock_session()
-        proxy_session.get.side_effect = requests.RequestException("proxy error")
-        direct_session = self._make_mock_session()
-        direct_session.get.side_effect = requests.RequestException("direct error")
+    def test_download_weights_falls_back_to_mirror_when_primary_fails(self, fxt_base_weights_service):
+        """Test that download falls back to the mirror URL when the primary URL fails entirely."""
         local_path = fxt_base_weights_service.pretrained_weights_dir / "detection" / "test_weights.pth"
         with (
             patch.object(fxt_base_weights_service, "_check_disk_space"),
             patch.object(
                 fxt_base_weights_service,
-                "_build_retry_session",
-                side_effect=[proxy_session, direct_session],
-            ),
-            pytest.raises(RuntimeError, match="weights.pth"),
+                "_download_from_url",
+                side_effect=[requests.RequestException("primary failed"), None],
+            ) as mock_download_from_url,
+            patch.object(fxt_base_weights_service, "_verify_file_integrity", return_value=True),
+            patch.object(Path, "rename"),
         ):
             fxt_base_weights_service._download_weights(
-                remote_url="https://example.com/weights.pth",
+                urls=["https://primary.example.com/weights.pth", "https://mirror.example.com/weights.pth"],
+                local_path=local_path,
+                sha_sum="dummy_sha",
+            )
+        assert mock_download_from_url.call_count == 2
+        mock_download_from_url.assert_any_call(
+            "https://primary.example.com/weights.pth", local_path.with_suffix(".tmp")
+        )
+        mock_download_from_url.assert_any_call("https://mirror.example.com/weights.pth", local_path.with_suffix(".tmp"))
+
+    def test_download_weights_falls_back_to_mirror_when_primary_fails_integrity_check(self, fxt_base_weights_service):
+        """Test that download falls back to the mirror URL when the primary URL's file fails checksum verification."""
+        local_path = fxt_base_weights_service.pretrained_weights_dir / "detection" / "test_weights.pth"
+        with (
+            patch.object(fxt_base_weights_service, "_check_disk_space"),
+            patch.object(fxt_base_weights_service, "_download_from_url", return_value=None) as mock_download_from_url,
+            patch.object(fxt_base_weights_service, "_verify_file_integrity", side_effect=[False, True]),
+            patch.object(Path, "rename"),
+            patch.object(Path, "unlink"),
+        ):
+            fxt_base_weights_service._download_weights(
+                urls=["https://primary.example.com/weights.pth", "https://mirror.example.com/weights.pth"],
+                local_path=local_path,
+                sha_sum="dummy_sha",
+            )
+        assert mock_download_from_url.call_count == 2
+
+    def test_download_weights_does_not_use_mirror_when_primary_succeeds(self, fxt_base_weights_service):
+        """Test that the mirror URL is never attempted when the primary URL succeeds."""
+        local_path = fxt_base_weights_service.pretrained_weights_dir / "detection" / "test_weights.pth"
+        with (
+            patch.object(fxt_base_weights_service, "_check_disk_space"),
+            patch.object(fxt_base_weights_service, "_download_from_url", return_value=None) as mock_download_from_url,
+            patch.object(fxt_base_weights_service, "_verify_file_integrity", return_value=True),
+            patch.object(Path, "rename"),
+        ):
+            fxt_base_weights_service._download_weights(
+                urls=["https://primary.example.com/weights.pth", "https://mirror.example.com/weights.pth"],
+                local_path=local_path,
+                sha_sum="dummy_sha",
+            )
+        mock_download_from_url.assert_called_once_with(
+            "https://primary.example.com/weights.pth", local_path.with_suffix(".tmp")
+        )
+
+    def test_download_weights_raises_when_primary_and_mirror_both_fail(self, fxt_base_weights_service):
+        """Test that RuntimeError is raised, naming both URLs, when primary and mirror both fail."""
+        local_path = fxt_base_weights_service.pretrained_weights_dir / "detection" / "test_weights.pth"
+        with (
+            patch.object(fxt_base_weights_service, "_check_disk_space"),
+            patch.object(
+                fxt_base_weights_service,
+                "_download_from_url",
+                side_effect=requests.RequestException("connection error"),
+            ),
+            pytest.raises(RuntimeError, match="primary.example.com.*mirror.example.com|weights.pth"),
+        ):
+            fxt_base_weights_service._download_weights(
+                urls=["https://primary.example.com/weights.pth", "https://mirror.example.com/weights.pth"],
+                local_path=local_path,
+                sha_sum="dummy_sha",
+            )
+
+    def test_download_weights_raises_when_primary_and_mirror_both_fail_integrity(self, fxt_base_weights_service):
+        """Test that RuntimeError is raised when both primary and mirror downloads fail integrity verification."""
+        local_path = fxt_base_weights_service.pretrained_weights_dir / "detection" / "test_weights.pth"
+        with (
+            patch.object(fxt_base_weights_service, "_check_disk_space"),
+            patch.object(fxt_base_weights_service, "_download_from_url", return_value=None),
+            patch.object(fxt_base_weights_service, "_verify_file_integrity", return_value=False),
+            patch.object(Path, "unlink"),
+            pytest.raises(RuntimeError),
+        ):
+            fxt_base_weights_service._download_weights(
+                urls=["https://primary.example.com/weights.pth", "https://mirror.example.com/weights.pth"],
                 local_path=local_path,
                 sha_sum="dummy_sha",
             )


### PR DESCRIPTION
### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

- [x] Added fallback to `mirror_url` when downloading pretrained weights

### How to test

1. Select manifest and change primary url to a wrong location
2. Start the training job and observe logs - after failing primary attempts, the download attempt from mirror url succeeds

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
