### PR TITLE
fix: Label's hotkey updates when input is no longer focused

### DIFF
--- a/application/ui/src/components/label-fields/hotkey-field.component.test.tsx
+++ b/application/ui/src/components/label-fields/hotkey-field.component.test.tsx
@@ -76,4 +76,14 @@ describe('HotkeyField', () => {
             expect(mockOnHotkeyChange).not.toHaveBeenCalled();
         });
     });
+
+    describe('removing hotkeys', () => {
+        it('"Backspace" key press should remove existing hotkeys', () => {
+            const input = renderHotkeyField('ctrl+p');
+
+            fireEvent.keyDown(input, { key: 'Backspace' });
+
+            expect(mockOnHotkeyChange).toHaveBeenCalledWith(null);
+        });
+    });
 });

--- a/application/ui/src/components/label-fields/hotkey-field.component.tsx
+++ b/application/ui/src/components/label-fields/hotkey-field.component.tsx
@@ -23,9 +23,18 @@ const isBackspace = (event: KeyboardEvent) => {
     return event.key === 'Backspace';
 };
 
+const isTab = (event: KeyboardEvent) => {
+    return event.key === 'Tab';
+};
+
 export const HotkeyField = ({ hotkey, errorMessage, onEnter, onHotkeyChange, onBlur }: HotkeyFieldProps) => {
     const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
         event.preventDefault();
+
+        // We want to allow keyboard navigation with tabs
+        if (isTab(event)) {
+            return;
+        }
 
         if (isBackspace(event)) {
             onHotkeyChange(null);

--- a/application/ui/src/components/label-fields/hotkey-field.component.tsx
+++ b/application/ui/src/components/label-fields/hotkey-field.component.tsx
@@ -10,6 +10,7 @@ import { formatHotkeyForDisplay } from '../../shared/hotkeys-definition';
 type HotkeyFieldProps = {
     hotkey: string | null | undefined;
     onEnter?: () => void;
+    onBlur?: () => void;
     onHotkeyChange: (hotkey: string | null) => void;
     errorMessage?: string;
 };
@@ -18,7 +19,7 @@ const isEnter = (event: KeyboardEvent) => {
     return event.key === 'Enter';
 };
 
-export const HotkeyField = ({ hotkey, errorMessage, onEnter, onHotkeyChange }: HotkeyFieldProps) => {
+export const HotkeyField = ({ hotkey, errorMessage, onEnter, onHotkeyChange, onBlur }: HotkeyFieldProps) => {
     const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
         event.preventDefault();
 
@@ -50,6 +51,7 @@ export const HotkeyField = ({ hotkey, errorMessage, onEnter, onHotkeyChange }: H
             placeholder={'Hotkey'}
             value={formattedHotkey}
             onKeyDown={handleKeyDown}
+            onBlur={onBlur}
             width={'100%'}
             errorMessage={errorMessage}
             validationState={errorMessage ? 'invalid' : undefined}

--- a/application/ui/src/components/label-fields/hotkey-field.component.tsx
+++ b/application/ui/src/components/label-fields/hotkey-field.component.tsx
@@ -19,9 +19,19 @@ const isEnter = (event: KeyboardEvent) => {
     return event.key === 'Enter';
 };
 
+const isBackspace = (event: KeyboardEvent) => {
+    return event.key === 'Backspace';
+};
+
 export const HotkeyField = ({ hotkey, errorMessage, onEnter, onHotkeyChange, onBlur }: HotkeyFieldProps) => {
     const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
         event.preventDefault();
+
+        if (isBackspace(event)) {
+            onHotkeyChange(null);
+
+            return;
+        }
 
         const { key, ctrlKey, altKey, shiftKey, metaKey } = event;
 

--- a/application/ui/src/features/annotator/labels/label-row/label-row.component.tsx
+++ b/application/ui/src/features/annotator/labels/label-row/label-row.component.tsx
@@ -64,7 +64,8 @@ export const LabelRow = ({
     };
 
     const handleHotkeyChange = () => {
-        if (hasValidationErrors) return;
+        const isHotkeyChanged = label.hotkey !== trimmedHotkey;
+        if (hasValidationErrors || !isHotkeyChanged) return;
 
         onUpdate(label.id, { name: name.trim(), color, hotkey: trimmedHotkey });
     };

--- a/application/ui/src/features/annotator/labels/label-row/label-row.component.tsx
+++ b/application/ui/src/features/annotator/labels/label-row/label-row.component.tsx
@@ -111,6 +111,7 @@ export const LabelRow = ({
                     hotkey={hotkey}
                     onHotkeyChange={(newHotkey) => setHotkey(newHotkey ?? '')}
                     onEnter={handleHotkeyChange}
+                    onBlur={handleHotkeyChange}
                     aria-label={'Edited hotkey'}
                     errorMessage={hotkeyValidationError}
                 />

--- a/application/ui/src/features/annotator/labels/label-row/label-row.test.tsx
+++ b/application/ui/src/features/annotator/labels/label-row/label-row.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from 'test-utils/render';
 
@@ -120,6 +120,19 @@ describe('LabelRow', () => {
             await userEvent.keyboard('{Enter}');
 
             expect(onUpdate).toHaveBeenCalledWith(label.id, expect.objectContaining({ hotkey: 'a' }));
+        });
+
+        it('calls onUpdate when input is no longer focused', async () => {
+            const onUpdate = vi.fn();
+
+            renderApp({ label, onUpdate });
+
+            const hotkeyInput = screen.getByLabelText(/Hotkey input/i);
+            await userEvent.click(hotkeyInput);
+            await userEvent.keyboard('b');
+            fireEvent.blur(hotkeyInput);
+
+            expect(onUpdate).toHaveBeenCalledWith(label.id, expect.objectContaining({ hotkey: 'b' }));
         });
 
         it('does not call onUpdate when hotkey has validation error', async () => {

--- a/application/ui/src/features/annotator/labels/label-row/label-row.test.tsx
+++ b/application/ui/src/features/annotator/labels/label-row/label-row.test.tsx
@@ -108,18 +108,29 @@ describe('LabelRow', () => {
     describe('handleHotkeyChange', () => {
         const label = getMockedLabel({ id: 'label-1', name: 'old name', color: '#ffff00', hotkey: 'a' });
 
-        it('calls onUpdate on Enter when hotkey is valid', async () => {
+        it('calls onUpdate on Enter when hotkey is valid and is changed', async () => {
             const onUpdate = vi.fn();
 
             renderApp({ label, onUpdate });
 
             const hotkeyInput = screen.getByLabelText(/Hotkey input/i);
-            await userEvent.type(hotkeyInput, 'test 1');
             await userEvent.click(hotkeyInput);
-            await userEvent.keyboard('a');
+            await userEvent.keyboard('b');
             await userEvent.keyboard('{Enter}');
 
-            expect(onUpdate).toHaveBeenCalledWith(label.id, expect.objectContaining({ hotkey: 'a' }));
+            expect(onUpdate).toHaveBeenCalledWith(label.id, expect.objectContaining({ hotkey: 'b' }));
+        });
+
+        it('does not call onUpdate on Enter when hotkey is valid but is not changed', async () => {
+            const onUpdate = vi.fn();
+
+            renderApp({ label, onUpdate });
+
+            const hotkeyInput = screen.getByLabelText(/Hotkey input/i);
+            await userEvent.click(hotkeyInput);
+            await userEvent.keyboard('{Enter}');
+
+            expect(onUpdate).not.toHaveBeenCalled();
         });
 
         it('calls onUpdate when input is no longer focused', async () => {


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

1. Update label's hotkey on blur event (not only on enter press).
2. Allow user to remove the hotkey using backspace.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
