### PR TITLE
fix(ci): fix logic with `use-cache` and `exclude-agpl-models`, revert original CodeQL workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,8 +10,8 @@ on:
     inputs:
       use-cache:
         description: "Enable Docker build cache (set to false for cache-free verification builds)"
-        type: boolean
-        default: true
+        type: string
+        default: 'true'
       exclude-agpl-models:
         description: "Exclude Ultralytics and other AGPL-licensed models from the image"
         type: boolean
@@ -111,7 +111,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.event_name != 'pull_request' }}
-          use-cache: ${{ github.event_name != 'workflow_call' || inputs.use-cache == true }}
+          use-cache: ${{ github.event_name != 'workflow_call' || inputs.use-cache != 'false' }}
           # Fork PRs cannot write packages to the upstream org, so disable
           # cache export to avoid 403 errors from GHCR.
           cache-write: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,15 +7,6 @@ on:
       - release/**
   pull_request:
   workflow_call:
-    inputs:
-      use-cache:
-        description: "Enable Docker build cache (set to false for cache-free verification builds)"
-        type: string
-        default: 'false'
-      exclude-agpl-models:
-        description: "Exclude Ultralytics and other AGPL-licensed models from the image"
-        type: boolean
-        default: false
   workflow_dispatch:
 
 permissions: {} # No permissions by default on workflow level
@@ -111,11 +102,11 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.event_name != 'pull_request' }}
-          use-cache: ${{ github.event_name != 'workflow_call' || inputs.use-cache == 'true' }}
+          use-cache: ${{ github.event_name != 'workflow_call' }}
           # Fork PRs cannot write packages to the upstream org, so disable
           # cache export to avoid 403 errors from GHCR.
           cache-write: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request' }}
-          exclude-agpl-models: ${{ github.event_name == 'workflow_call' && inputs.exclude-agpl-models }}
+          exclude-agpl-models: ${{ github.event_name == 'workflow_call' }}
 
       - name: Resolve primary image tag for signing
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ on:
       use-cache:
         description: "Enable Docker build cache (set to false for cache-free verification builds)"
         type: string
-        default: 'true'
+        default: 'false'
       exclude-agpl-models:
         description: "Exclude Ultralytics and other AGPL-licensed models from the image"
         type: boolean
@@ -111,7 +111,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.event_name != 'pull_request' }}
-          use-cache: ${{ github.event_name != 'workflow_call' || inputs.use-cache != 'false' }}
+          use-cache: ${{ github.event_name != 'workflow_call' || inputs.use-cache == 'true' }}
           # Fork PRs cannot write packages to the upstream org, so disable
           # cache export to avoid 403 errors from GHCR.
           cache-write: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,11 +9,11 @@ on:
   workflow_call:
     inputs:
       use-cache:
-        description: "Enable Docker build cache (default: false — daily builds run cache-free for reproducibility)"
+        description: "Enable Docker build cache. Always enabled for pull_request and merge_group events regardless of provided input."
         type: string
         default: 'false'
       exclude-agpl-models:
-        description: "Exclude AGPL-licensed models from the image (default: true — daily images must not bundle them)"
+        description: "Exclude Ultralytics and other AGPL-licensed models from the image"
         type: string
         default: 'true'
   workflow_dispatch:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -111,11 +111,11 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.event_name != 'pull_request' }}
-          use-cache: ${{ inputs.use-cache == 'true' || github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+          use-cache: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || inputs.use-cache == 'true' }}
           # Fork PRs cannot write packages to the upstream org, so disable
           # cache export to avoid 403 errors from GHCR.
           cache-write: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request' }}
-          exclude-agpl-models: ${{ inputs.exclude-agpl-models != 'false' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
+          exclude-agpl-models: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' && inputs.exclude-agpl-models != 'false' }}
 
       - name: Resolve primary image tag for signing
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -102,11 +102,11 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.event_name != 'pull_request' }}
-          use-cache: ${{ github.event_name != 'workflow_call' }}
+          use-cache: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
           # Fork PRs cannot write packages to the upstream org, so disable
           # cache export to avoid 403 errors from GHCR.
           cache-write: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request' }}
-          exclude-agpl-models: ${{ github.event_name == 'workflow_call' }}
+          exclude-agpl-models: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
 
       - name: Resolve primary image tag for signing
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,15 @@ on:
       - release/**
   pull_request:
   workflow_call:
+    inputs:
+      use-cache:
+        description: "Enable Docker build cache (default: false — daily builds run cache-free for reproducibility)"
+        type: string
+        default: 'false'
+      exclude-agpl-models:
+        description: "Exclude AGPL-licensed models from the image (default: true — daily images must not bundle them)"
+        type: string
+        default: 'true'
   workflow_dispatch:
 
 permissions: {} # No permissions by default on workflow level
@@ -102,11 +111,11 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.event_name != 'pull_request' }}
-          use-cache: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+          use-cache: ${{ inputs.use-cache == 'true' || github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
           # Fork PRs cannot write packages to the upstream org, so disable
           # cache export to avoid 403 errors from GHCR.
           cache-write: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request' }}
-          exclude-agpl-models: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
+          exclude-agpl-models: ${{ inputs.exclude-agpl-models != 'false' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
 
       - name: Resolve primary image tag for signing
         if: github.event_name != 'pull_request'

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -48,13 +48,13 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -7,6 +7,7 @@ on:
     branches: ["develop", "release/**"]
   pull_request:
     branches: ["develop", "release/**"]
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -15,114 +15,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check_paths:
-    name: Check which language should be analyzed by CodeQL
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    outputs:
-      run_python: "${{ steps.prepare_outputs.outputs.run_python }}"
-      run_javascript_typescript: "${{ steps.prepare_outputs.outputs.run_javascript_typescript }}"
-      run_actions: "${{ steps.prepare_outputs.outputs.run_actions }}"
-      run_rust: "${{ steps.prepare_outputs.outputs.run_rust }}"
-    steps:
-      - &harden-runner
-        name: Harden the runner (audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: audit
-
-      - &checkout
-        name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-        with:
-          persist-credentials: false
-
-      - name: Get all paths that should trigger the workflow
-        id: changed-files-yaml
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
-        with:
-          files_yaml: |
-            python:
-              - application/backend/**
-              - library/**
-            rust:
-              - application/ui/**
-            javascript-typescript:
-              - application/ui/**
-            actions:
-              - .github/**
-
-      - name: Prepare outputs
-        id: prepare_outputs
-        env:
-          PYTHON_ANY_CHANGED: ${{ steps.changed-files-yaml.outputs.python_any_changed }}
-          JAVASCRIPT_ANY_CHANGED: ${{ steps.changed-files-yaml.outputs.javascript-typescript_any_changed }}
-          ACTIONS_ANY_CHANGED: ${{ steps.changed-files-yaml.outputs.actions_any_changed }}
-          RUST_ANY_CHANGED: ${{ steps.changed-files-yaml.outputs.rust_any_changed }}
-        run: |
-          echo "PYTHON_ANY_CHANGED=$PYTHON_ANY_CHANGED"
-          if [ "$PYTHON_ANY_CHANGED" = "true" ]; then
-            echo "run_python=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run_python=false" >> "$GITHUB_OUTPUT"
-          fi
-
-          echo "JAVASCRIPT_ANY_CHANGED=$JAVASCRIPT_ANY_CHANGED"
-          if [ "$JAVASCRIPT_ANY_CHANGED" = "true" ]; then
-            echo "run_javascript_typescript=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run_javascript_typescript=false" >> "$GITHUB_OUTPUT"
-          fi
-
-          echo "ACTIONS_ANY_CHANGED=$ACTIONS_ANY_CHANGED"
-          if [ "$ACTIONS_ANY_CHANGED" = "true" ]; then
-            echo "run_actions=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run_actions=false" >> "$GITHUB_OUTPUT"
-          fi
-
-          echo "RUST_ANY_CHANGED=$RUST_ANY_CHANGED"
-          if [ "$RUST_ANY_CHANGED" = "true" ]; then
-            echo "run_rust=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run_rust=false" >> "$GITHUB_OUTPUT"
-          fi
-
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:
       security-events: write # required to publish sarif
-    needs: check_paths
+
     strategy:
       fail-fast: false
       matrix:
         include:
           - language: actions
-            run: ${{ needs.check_paths.outputs.run_actions || 'true' }}
+            build-mode: none
           - language: python
-            run: ${{ needs.check_paths.outputs.run_python || 'true' }}
+            build-mode: none
           - language: javascript-typescript
-            run: ${{ needs.check_paths.outputs.run_javascript_typescript || 'true' }}
+            build-mode: none
           - language: rust
-            run: ${{ needs.check_paths.outputs.run_rust || 'true' }}
-
+            build-mode: none
     steps:
-      - *harden-runner
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          disable-sudo: true
+          disable-telemetry: true
+          egress-policy: audit
 
-      - *checkout
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
-      # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
-        if: ${{ matrix.run == 'true' }}
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
-          build-mode: none
+          build-mode: ${{ matrix.build-mode }}
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
-        if: ${{ matrix.run == 'true' }}
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -11,6 +11,9 @@ jobs:
   build:
     name: Daily build
     uses: ./.github/workflows/build.yaml
+    with:
+      use-cache: 'false' # Verify image is buildable from scratch without any cached layers
+      exclude-agpl-models: 'true' # Daily images (pushed to GHCR) must not bundle AGPL-licensed models
     permissions:
       contents: read
       packages: write # to push Docker images to GHCR

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -12,7 +12,7 @@ jobs:
     name: Daily build
     uses: ./.github/workflows/build.yaml
     with:
-      use-cache: 'false' # Verify image is buildable from scratch without any cached layers
+      use-cache: false # Verify image is buildable from scratch without any cached layers
       exclude-agpl-models: 'true' # Daily images (pushed to GHCR) must not bundle AGPL-licensed models
     permissions:
       contents: read

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -11,9 +11,6 @@ jobs:
   build:
     name: Daily build
     uses: ./.github/workflows/build.yaml
-    with:
-      use-cache: 'false' # Verify image is buildable from scratch without any cached layers
-      exclude-agpl-models: true # Daily images (pushed to GHCR) must not bundle AGPL-licensed models
     permissions:
       contents: read
       packages: write # to push Docker images to GHCR

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -12,7 +12,7 @@ jobs:
     name: Daily build
     uses: ./.github/workflows/build.yaml
     with:
-      use-cache: false # Verify image is buildable from scratch without any cached layers
+      use-cache: 'false' # Verify image is buildable from scratch without any cached layers
       exclude-agpl-models: true # Daily images (pushed to GHCR) must not bundle AGPL-licensed models
     permissions:
       contents: read

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -13,7 +13,7 @@ jobs:
     uses: ./.github/workflows/build.yaml
     with:
       use-cache: false # Verify image is buildable from scratch without any cached layers
-      exclude-agpl-models: 'true' # Daily images (pushed to GHCR) must not bundle AGPL-licensed models
+      exclude-agpl-models: true # Daily images (pushed to GHCR) must not bundle AGPL-licensed models
     permissions:
       contents: read
       packages: write # to push Docker images to GHCR


### PR DESCRIPTION
### Summary

This PR fixes logic with `use-cache` and `exclude-agpl-models` usage as currently wrong values are used in final action regardless of input provided to reusable workflow. This fix ensure that `use-cache: true` is used on PR/merge group and `use-cache: false` for daily builds.

Test workflows run in fork 
- daily/workflow_dispatch https://github.com/AlexanderBarabanov/geti/actions/runs/30098592827/job/89498793406 - cache is not used

- PR - https://github.com/AlexanderBarabanov/geti/actions/runs/30098647293/job/89499091746?pr=4 - cache is used 

Additionally, CodeQL workflow reverted to original state as currently it is not executed on schedule and on push, see e.g. https://github.com/open-edge-platform/geti/actions/workflows/codeql.yaml?query=event%3Aschedule


<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [x] Documentation has been updated (if applicable)
