### PR TITLE
Update pretrained URLs in library code

### DIFF
--- a/library/src/getitune/backend/lightning/models/classification/backbones/vision_transformer.py
+++ b/library/src/getitune/backend/lightning/models/classification/backbones/vision_transformer.py
@@ -225,7 +225,7 @@ class VisionTransformerBackbone(BaseModule):
         self.cls_token = nn.Parameter(torch.zeros(1, 1, self.embed_dim)) if class_token else None
         self.reg_token = nn.Parameter(torch.zeros(1, reg_tokens, self.embed_dim)) if reg_tokens else None
 
-        embed_len = num_patches if no_embed_class else num_patches + self.num_prefix_tokens
+        embed_len = num_patches + (1 if class_token else 0) if no_embed_class else num_patches + self.num_prefix_tokens
         self.pos_embed = nn.Parameter(torch.zeros(1, embed_len, self.embed_dim))
 
         self.pos_drop = nn.Dropout(p=pos_drop_rate)

--- a/library/src/getitune/backend/lightning/models/classification/backbones/vision_transformer.py
+++ b/library/src/getitune/backend/lightning/models/classification/backbones/vision_transformer.py
@@ -330,21 +330,14 @@ class VisionTransformerBackbone(BaseModule):
             state_dict.pop("mask_token", None)
             if "register_tokens" in state_dict:
                 state_dict["reg_token"] = state_dict.pop("register_tokens")
-            if self.no_embed_class:
-                state_dict["cls_token"] = state_dict.pop("cls_token")
-            else:
-                state_dict["cls_token"] = state_dict.pop("cls_token") + state_dict["pos_embed"][:, 0]
+            state_dict["cls_token"] = state_dict.pop("cls_token") + state_dict["pos_embed"][:, 0]
 
             img_size = (self.img_size, self.img_size) if isinstance(self.img_size, int) else self.img_size
             patch_size = (self.patch_size, self.patch_size)
 
             if state_dict["pos_embed"].shape != self.pos_embed.shape:
-                pos_embed = state_dict.pop("pos_embed")
-                if not self.no_embed_class:
-                    pos_embed = pos_embed[:, 1:]
-
                 state_dict["pos_embed"] = resize_positional_embeddings(
-                    pos_embed,
+                    state_dict.pop("pos_embed")[:, 1:],
                     (img_size[0] // patch_size[0], img_size[1] // patch_size[1]),
                 )
             self.load_state_dict(state_dict, strict=False)
@@ -403,7 +396,7 @@ class VisionTransformerBackbone(BaseModule):
         if npatch == n and w == h:
             return self.pos_embed
         pos_embed = self.pos_embed.float()
-        patch_pos_embed = pos_embed if self.no_embed_class else pos_embed[:, 1:]
+        patch_pos_embed = pos_embed[:, 1:]
         dim = x.shape[-1]
         w0 = w // self.patch_size
         h0 = h // self.patch_size
@@ -426,10 +419,6 @@ class VisionTransformerBackbone(BaseModule):
             **kwargs,
         )
         patch_pos_embed = patch_pos_embed.permute(0, 2, 3, 1).view(1, -1, dim).to(previous_dtype)
-
-        if self.no_embed_class:
-            return patch_pos_embed
-
         class_pos_embed = pos_embed[:, 0].unsqueeze(0).to(previous_dtype)
         return torch.cat((class_pos_embed, patch_pos_embed), dim=1)
 
@@ -448,7 +437,20 @@ class VisionTransformerBackbone(BaseModule):
         if masks is not None:
             x = torch.where(masks.unsqueeze(-1), self.mask_token.to(x.dtype).unsqueeze(0), x)
 
-        return self._pos_embed(x)
+        x = torch.cat((self.cls_token.expand(x.shape[0], -1, -1), x), dim=1)  # pyrefly: ignore[missing-attribute]
+        x = x + self.interpolate_pos_encoding(x, w, h)
+
+        if self.reg_token is not None:
+            x = torch.cat(
+                (
+                    x[:, :1],
+                    self.reg_token.expand(x.shape[0], -1, -1),
+                    x[:, 1:],
+                ),
+                dim=1,
+            )
+
+        return x
 
     def _get_intermediate_layers_not_chunked(self, x: torch.Tensor, n: int = 1) -> list[torch.Tensor]:
         """Get intermediate layers without chunking.

--- a/library/src/getitune/backend/lightning/models/classification/utils/pretrained_urls.py
+++ b/library/src/getitune/backend/lightning/models/classification/utils/pretrained_urls.py
@@ -14,41 +14,40 @@ resolve the URL for a given ``model_name``, download the file into
 ``PRETRAINED_WEIGHTS_CACHE_DIR``, and load it into the backbone.
 
 Note:
-    URLs point to ``https://storage.geti.intel.com/weights/`` and require network
-    access at load time unless the checkpoint is already cached.
+    URLs point to external resources and require network access at load time unless the
+    checkpoint is already cached.
 """
 
 from __future__ import annotations
 
-_BASE_STORAGE_URL = "https://storage.geti.intel.com/weights"
+_AUGREG_BASE_URL = "https://storage.googleapis.com/vit_models/augreg"
+_DINOV2_BASE_URL = "https://dl.fbaipublicfiles.com/dinov2"
+_MOBILENETV3_BASE_URL = "https://github.com/d-li14/mobilenetv3.pytorch/blob/master/pretrained"
+
 
 # ViT / DINOv2 ImageNet-21k checkpoints shared by classification models.
 VIT_PRETRAINED_URLS: dict[str, str] = {
     "vit-tiny": (
-        f"{_BASE_STORAGE_URL}/"
-        "Ti_16-i21k-300ep-lr_0.001-aug_none-wd_0.03-do_0.0-sd_0.0--imagenet2012-steps_20k-lr_0.03-res_224.npz"
+        f"{_AUGREG_BASE_URL}/Ti_16-i21k-300ep-lr_0.001-aug_none-wd_0.03-do_0.0-sd_0.0--imagenet2012-steps_20k-lr_0.03-res_224.npz"
     ),
     "vit-small": (
-        f"{_BASE_STORAGE_URL}/"
-        "S_16-i21k-300ep-lr_0.001-aug_light1-wd_0.03-do_0.0-sd_0.0--imagenet2012-steps_20k-lr_0.03-res_224.npz"
+        f"{_AUGREG_BASE_URL}/S_16-i21k-300ep-lr_0.001-aug_light1-wd_0.03-do_0.0-sd_0.0--imagenet2012-steps_20k-lr_0.03-res_224.npz"
     ),
     "vit-base": (
-        f"{_BASE_STORAGE_URL}/"
-        "B_16-i21k-300ep-lr_0.001-aug_medium1-wd_0.1-do_0.0-sd_0.0--imagenet2012-steps_20k-lr_0.01-res_224.npz"
+        f"{_AUGREG_BASE_URL}/B_16-i21k-300ep-lr_0.001-aug_medium1-wd_0.1-do_0.0-sd_0.0--imagenet2012-steps_20k-lr_0.01-res_224.npz"
     ),
     "vit-large": (
-        f"{_BASE_STORAGE_URL}/"
-        "L_16-i21k-300ep-lr_0.001-aug_medium1-wd_0.1-do_0.1-sd_0.1--imagenet2012-steps_20k-lr_0.01-res_224.npz"
+        f"{_AUGREG_BASE_URL}/L_16-i21k-300ep-lr_0.001-aug_medium1-wd_0.1-do_0.1-sd_0.1--imagenet2012-steps_20k-lr_0.01-res_224.npz"
     ),
-    "dinov2-small": f"{_BASE_STORAGE_URL}/dinov2_vits14_reg4_pretrain.pth",
-    "dinov2-base": f"{_BASE_STORAGE_URL}/dinov2_vitb14_reg4_pretrain.pth",
-    "dinov2-large": f"{_BASE_STORAGE_URL}/dinov2_vitl14_reg4_pretrain.pth",
-    "dinov2-giant": f"{_BASE_STORAGE_URL}/dinov2_vitg14_reg4_pretrain.pth",
+    "dinov2-small": f"{_DINOV2_BASE_URL}/dinov2_vits14_reg4_pretrain.pth",
+    "dinov2-base": f"{_DINOV2_BASE_URL}/dinov2_vitb14_reg4_pretrain.pth",
+    "dinov2-large": f"{_DINOV2_BASE_URL}/dinov2_vitl14_reg4_pretrain.pth",
+    "dinov2-giant": f"{_DINOV2_BASE_URL}/dinov2_vitg14_reg4_pretrain.pth",
 }
 
 # MobileNetV3 ImageNet checkpoints.
 MOBILENETV3_PRETRAINED_URLS: dict[str, str] = {
-    "mobilenetv3_small": f"{_BASE_STORAGE_URL}/mobilenetv3-small-55df8e1f.pth",
-    "mobilenetv3_large": f"{_BASE_STORAGE_URL}/mobilenetv3-large-1cd25616.pth",
-    "mobilenetv3_large_075": f"{_BASE_STORAGE_URL}/mobilenetv3-large-0.75-9632d2a8.pth",
+    "mobilenetv3_small": f"{_MOBILENETV3_BASE_URL}/mobilenetv3-small-55df8e1f.pth",
+    "mobilenetv3_large": f"{_MOBILENETV3_BASE_URL}/mobilenetv3-large-1cd25616.pth",
+    "mobilenetv3_large_075": f"{_MOBILENETV3_BASE_URL}/mobilenetv3-large-0.75-9632d2a8.pth",
 }

--- a/library/src/getitune/backend/lightning/models/classification/utils/pretrained_urls.py
+++ b/library/src/getitune/backend/lightning/models/classification/utils/pretrained_urls.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 _AUGREG_BASE_URL = "https://storage.googleapis.com/vit_models/augreg"
 _DINOV2_BASE_URL = "https://dl.fbaipublicfiles.com/dinov2"
-_MOBILENETV3_BASE_URL = "https://github.com/d-li14/mobilenetv3.pytorch/blob/master/pretrained"
+_MOBILENETV3_BASE_URL = "https://raw.githubusercontent.com/d-li14/mobilenetv3.pytorch/master/pretrained"
 
 
 # ViT / DINOv2 ImageNet-21k checkpoints shared by classification models.
@@ -39,10 +39,10 @@ VIT_PRETRAINED_URLS: dict[str, str] = {
     "vit-large": (
         f"{_AUGREG_BASE_URL}/L_16-i21k-300ep-lr_0.001-aug_medium1-wd_0.1-do_0.1-sd_0.1--imagenet2012-steps_20k-lr_0.01-res_224.npz"
     ),
-    "dinov2-small": f"{_DINOV2_BASE_URL}/dinov2_vits14_reg4_pretrain.pth",
-    "dinov2-base": f"{_DINOV2_BASE_URL}/dinov2_vitb14_reg4_pretrain.pth",
-    "dinov2-large": f"{_DINOV2_BASE_URL}/dinov2_vitl14_reg4_pretrain.pth",
-    "dinov2-giant": f"{_DINOV2_BASE_URL}/dinov2_vitg14_reg4_pretrain.pth",
+    "dinov2-small": f"{_DINOV2_BASE_URL}/dinov2_vits14/dinov2_vits14_reg4_pretrain.pth",
+    "dinov2-base": f"{_DINOV2_BASE_URL}/dinov2_vitb14/dinov2_vitb14_reg4_pretrain.pth",
+    "dinov2-large": f"{_DINOV2_BASE_URL}/dinov2_vitl14/dinov2_vitl14_reg4_pretrain.pth",
+    "dinov2-giant": f"{_DINOV2_BASE_URL}/dinov2_vitg14/dinov2_vitg14_reg4_pretrain.pth",
 }
 
 # MobileNetV3 ImageNet checkpoints.

--- a/library/src/getitune/backend/lightning/models/detection/atss.py
+++ b/library/src/getitune/backend/lightning/models/detection/atss.py
@@ -58,8 +58,10 @@ class ATSS(LightningDetectionModel):
     """
 
     pretrained_urls: ClassVar[dict[str, str]] = {
-        "atss_mobilenetv2": "https://storage.geti.intel.com/weights/mobilenet_v2-atss.pth",
-        "atss_resnext101": "https://storage.geti.intel.com/weights/resnext101_atss_070623.pth",
+        "atss_mobilenetv2": "https://storage.openvinotoolkit.org/repositories/openvino_training_extensions/models/"
+        "object_detection/v2/mobilenet_v2-atss.pth",
+        "atss_resnext101": "https://storage.openvinotoolkit.org/repositories/openvino_training_extensions/models/"
+        "object_detection/v2/resnext101_atss_070623.pth",
     }
 
     def __init__(

--- a/library/src/getitune/backend/lightning/models/detection/d_fine.py
+++ b/library/src/getitune/backend/lightning/models/detection/d_fine.py
@@ -53,11 +53,11 @@ class DFine(RTDETR):
     """
 
     pretrained_urls: ClassVar[dict[str, str]] = {
-        "dfine_hgnetv2_n": "https://storage.geti.intel.com/weights/dfine_n_coco.pth",
-        "dfine_hgnetv2_s": "https://storage.geti.intel.com/weights/dfine_s_coco.pth",
-        "dfine_hgnetv2_m": "https://storage.geti.intel.com/weights/dfine_m_coco.pth",
-        "dfine_hgnetv2_l": "https://storage.geti.intel.com/weights/dfine_l_coco.pth",
-        "dfine_hgnetv2_x": "https://storage.geti.intel.com/weights/dfine_x_coco.pth",
+        "dfine_hgnetv2_n": "https://github.com/Peterande/storage/releases/download/dfinev1.0/dfine_n_coco.pth",
+        "dfine_hgnetv2_s": "https://github.com/Peterande/storage/releases/download/dfinev1.0/dfine_s_coco.pth",
+        "dfine_hgnetv2_m": "https://github.com/Peterande/storage/releases/download/dfinev1.0/dfine_m_coco.pth",
+        "dfine_hgnetv2_l": "https://github.com/Peterande/storage/releases/download/dfinev1.0/dfine_l_coco.pth",
+        "dfine_hgnetv2_x": "https://github.com/Peterande/storage/releases/download/dfinev1.0/dfine_x_coco.pth",
     }
 
     input_size_multiplier = 32

--- a/library/src/getitune/backend/lightning/models/detection/deim.py
+++ b/library/src/getitune/backend/lightning/models/detection/deim.py
@@ -64,11 +64,11 @@ class DEIMDFine(RTDETR):
     """
 
     pretrained_urls: ClassVar[dict[str, str]] = {
-        "deim_dfine_hgnetv2_n": "https://storage.geti.intel.com/weights/deim_dfine_hgnetv2_n_coco_160e.pth",
-        "deim_dfine_hgnetv2_s": "https://storage.geti.intel.com/weights/deim_dfine_hgnetv2_s_coco_120e.pth",
-        "deim_dfine_hgnetv2_m": "https://storage.geti.intel.com/weights/deim_dfine_hgnetv2_m_coco_90e.pth",
-        "deim_dfine_hgnetv2_l": "https://storage.geti.intel.com/weights/deim_dfine_hgnetv2_l_coco_50e.pth",
-        "deim_dfine_hgnetv2_x": "https://storage.geti.intel.com/weights/deim_dfine_hgnetv2_x_coco_50e.pth",
+        "deim_dfine_hgnetv2_n": "https://github.com/eugene123tw/DEIM/releases/download/poc/deim_dfine_hgnetv2_n_coco_160e.pth",
+        "deim_dfine_hgnetv2_s": "https://github.com/eugene123tw/DEIM/releases/download/poc/deim_dfine_hgnetv2_s_coco_120e.pth",
+        "deim_dfine_hgnetv2_m": "https://github.com/eugene123tw/DEIM/releases/download/poc/deim_dfine_hgnetv2_m_coco_90e.pth",
+        "deim_dfine_hgnetv2_l": "https://github.com/eugene123tw/DEIM/releases/download/poc/deim_dfine_hgnetv2_l_coco_50e.pth",
+        "deim_dfine_hgnetv2_x": "https://github.com/eugene123tw/DEIM/releases/download/poc/deim_dfine_hgnetv2_x_coco_50e.pth",
     }
 
     input_size_multiplier = 32

--- a/library/src/getitune/backend/lightning/models/detection/deimv2.py
+++ b/library/src/getitune/backend/lightning/models/detection/deimv2.py
@@ -62,10 +62,10 @@ class DEIMV2(DEIMDFine):
     """
 
     pretrained_urls: ClassVar[dict[str, str]] = {
-        "deimv2_x": "https://storage.geti.intel.com/weights/deimv2_dinov3_x_coco.pth",
-        "deimv2_l": "https://storage.geti.intel.com/weights/deimv2_dinov3_l_coco.pth",
-        "deimv2_m": "https://storage.geti.intel.com/weights/deimv2_dinov3_m_coco.pth",
-        "deimv2_s": "https://storage.geti.intel.com/weights/deimv2_dinov3_s_coco.pth",
+        "deimv2_x": "https://github.com/kprokofi/DEIMv2/releases/download/1.0.0/deimv2_dinov3_x_coco.pth",
+        "deimv2_l": "https://github.com/kprokofi/DEIMv2/releases/download/1.0.0/deimv2_dinov3_l_coco.pth",
+        "deimv2_m": "https://github.com/kprokofi/DEIMv2/releases/download/1.0.0/deimv2_dinov3_m_coco.pth",
+        "deimv2_s": "https://github.com/kprokofi/DEIMv2/releases/download/1.0.0/deimv2_dinov3_s_coco.pth",
     }
 
     input_size_multiplier = 32

--- a/library/src/getitune/backend/lightning/models/detection/rfdetr.py
+++ b/library/src/getitune/backend/lightning/models/detection/rfdetr.py
@@ -78,10 +78,10 @@ class RFDETR(RFDETRMixin, LightningDetectionModel):  # pyrefly: ignore[inconsist
     """
 
     pretrained_urls: ClassVar[dict[str, str]] = {
-        "rfdetr_nano": "https://storage.geti.intel.com/weights/rf-detr-nano-2026.pth",
-        "rfdetr_small": "https://storage.geti.intel.com/weights/rf-detr-small-2026.pth",
-        "rfdetr_medium": "https://storage.geti.intel.com/weights/rf-detr-medium-2026.pth",
-        "rfdetr_large": "https://storage.geti.intel.com/weights/rf-detr-large-2026.pth",
+        "rfdetr_nano": "https://storage.googleapis.com/rfdetr/nano_coco/checkpoint_best_regular.pth",
+        "rfdetr_small": "https://storage.googleapis.com/rfdetr/small_coco/checkpoint_best_regular.pth",
+        "rfdetr_medium": "https://storage.googleapis.com/rfdetr/medium_coco/checkpoint_best_regular.pth",
+        "rfdetr_large": "https://storage.googleapis.com/rfdetr/rf-detr-large-2026.pth",
     }
 
     _model_config_mapping: ClassVar[dict[str, type]] = {

--- a/library/src/getitune/backend/lightning/models/detection/rtdetr.py
+++ b/library/src/getitune/backend/lightning/models/detection/rtdetr.py
@@ -64,9 +64,9 @@ class RTDETR(LightningDetectionModel):
     """
 
     pretrained_urls: ClassVar[dict[str, str]] = {
-        "rtdetr_18": "https://storage.geti.intel.com/weights/rtdetr_r18vd_5x_coco_objects365_from_paddle.pth",
-        "rtdetr_50": "https://storage.geti.intel.com/weights/rtdetr_r50vd_2x_coco_objects365_from_paddle.pth",
-        "rtdetr_101": "https://storage.geti.intel.com/weights/rtdetr_r101vd_2x_coco_objects365_from_paddle.pth",
+        "rtdetr_18": "https://github.com/lyuwenyu/storage/releases/download/v0.1/rtdetr_r18vd_5x_coco_objects365_from_paddle.pth",
+        "rtdetr_50": "https://github.com/lyuwenyu/storage/releases/download/v0.1/rtdetr_r50vd_2x_coco_objects365_from_paddle.pth",
+        "rtdetr_101": "https://github.com/lyuwenyu/storage/releases/download/v0.1/rtdetr_r101vd_2x_coco_objects365_from_paddle.pth",
     }
 
     input_size_multiplier = 32

--- a/library/src/getitune/backend/lightning/models/detection/ssd.py
+++ b/library/src/getitune/backend/lightning/models/detection/ssd.py
@@ -71,7 +71,8 @@ class SSD(LightningDetectionModel):
     """
 
     pretrained_urls: ClassVar[dict[str, str]] = {
-        "ssd_mobilenetv2": "https://storage.geti.intel.com/weights/mobilenet_v2-2s_ssd-992x736.pth",
+        "ssd_mobilenetv2": "https://storage.openvinotoolkit.org/repositories/openvino_training_extensions/models/"
+        "object_detection/v2/mobilenet_v2-2s_ssd-992x736.pth",
     }
 
     def __init__(

--- a/library/src/getitune/backend/lightning/models/detection/yolox.py
+++ b/library/src/getitune/backend/lightning/models/detection/yolox.py
@@ -70,10 +70,14 @@ class YOLOX(LightningDetectionModel):
     """
 
     pretrained_urls: ClassVar[dict[str, str]] = {
-        "yolox_tiny": "https://storage.geti.intel.com/weights/yolox_tiny_8x8.pth",
-        "yolox_s": "https://storage.geti.intel.com/weights/yolox_s_8x8_300e_coco_20211121_095711-4592a793.pth",
-        "yolox_l": "https://storage.geti.intel.com/weights/yolox_l_8x8_300e_coco_20211126_140236-d3bd2b23.pth",
-        "yolox_x": "https://storage.geti.intel.com/weights/yolox_x_8x8_300e_coco_20211126_140254-1ef88d67.pth",
+        "yolox_tiny": "https://storage.openvinotoolkit.org/repositories/openvino_training_extensions/models/"
+        "object_detection/v2/yolox_tiny_8x8.pth",
+        "yolox_s": "https://download.openmmlab.com/mmdetection/v2.0/yolox/yolox_s_8x8_300e_coco/"
+        "yolox_s_8x8_300e_coco_20211121_095711-4592a793.pth",
+        "yolox_l": "https://download.openmmlab.com/mmdetection/v2.0/yolox/yolox_l_8x8_300e_coco/"
+        "yolox_l_8x8_300e_coco_20211126_140236-d3bd2b23.pth",
+        "yolox_x": "https://download.openmmlab.com/mmdetection/v2.0/yolox/yolox_x_8x8_300e_coco/"
+        "yolox_x_8x8_300e_coco_20211126_140254-1ef88d67.pth",
     }
 
     input_size_multiplier = 32

--- a/library/src/getitune/backend/lightning/models/instance_segmentation/maskrcnn.py
+++ b/library/src/getitune/backend/lightning/models/instance_segmentation/maskrcnn.py
@@ -61,8 +61,11 @@ class MaskRCNN(LightningInstanceSegModel):
     """
 
     pretrained_urls: ClassVar[dict[str, str]] = {
-        "maskrcnn_efficientnet_b2b": "https://storage.geti.intel.com/weights/efficientnet_b2b-mask_rcnn-576x576.pth",
-        "maskrcnn_swin_tiny": "https://storage.geti.intel.com/weights/mask_rcnn_swin-t-p4-w7_fpn_fp16_ms-crop-3x_coco_20210908_165006-90a4008c.pth",
+        "maskrcnn_efficientnet_b2b": "https://storage.openvinotoolkit.org/repositories/openvino_training_extensions/"
+        "models/instance_segmentation/v2/efficientnet_b2b-mask_rcnn-576x576.pth",
+        "maskrcnn_swin_tiny": "https://download.openmmlab.com/mmdetection/v2.0/swin/"
+        "mask_rcnn_swin-t-p4-w7_fpn_fp16_ms-crop-3x_coco/"
+        "mask_rcnn_swin-t-p4-w7_fpn_fp16_ms-crop-3x_coco_20210908_165006-90a4008c.pth",
     }
 
     def __init__(

--- a/library/src/getitune/backend/lightning/models/instance_segmentation/rfdetr_inst.py
+++ b/library/src/getitune/backend/lightning/models/instance_segmentation/rfdetr_inst.py
@@ -72,12 +72,12 @@ class RFDETRInst(RFDETRMixin, LightningInstanceSegModel):  # pyrefly: ignore[inc
     """
 
     pretrained_urls: ClassVar[dict[str, str]] = {
-        "rfdetr_seg_n": "https://storage.geti.intel.com/weights/rf-detr-seg-n-ft.pth",
-        "rfdetr_seg_s": "https://storage.geti.intel.com/weights/rf-detr-seg-s-ft.pth",
-        "rfdetr_seg_m": "https://storage.geti.intel.com/weights/rf-detr-seg-m-ft.pth",
-        "rfdetr_seg_l": "https://storage.geti.intel.com/weights/rf-detr-seg-l-ft.pth",
-        "rfdetr_seg_xl": "https://storage.geti.intel.com/weights/rf-detr-seg-xl-ft.pth",
-        "rfdetr_seg_2xl": "https://storage.geti.intel.com/weights/rf-detr-seg-2xl-ft.pth",
+        "rfdetr_seg_n": "https://storage.googleapis.com/rfdetr/rf-detr-seg-n-ft.pth",
+        "rfdetr_seg_s": "https://storage.googleapis.com/rfdetr/rf-detr-seg-s-ft.pth",
+        "rfdetr_seg_m": "https://storage.googleapis.com/rfdetr/rf-detr-seg-m-ft.pth",
+        "rfdetr_seg_l": "https://storage.googleapis.com/rfdetr/rf-detr-seg-l-ft.pth",
+        "rfdetr_seg_xl": "https://storage.googleapis.com/rfdetr/rf-detr-seg-xl-ft.pth",
+        "rfdetr_seg_2xl": "https://storage.googleapis.com/rfdetr/rf-detr-seg-2xl-ft.pth",
     }
     _model_config_mapping: ClassVar[dict[str, type]] = {
         "rfdetr_seg_n": RFDETRSegNanoConfig,

--- a/library/src/getitune/backend/lightning/models/instance_segmentation/rtmdet_inst.py
+++ b/library/src/getitune/backend/lightning/models/instance_segmentation/rtmdet_inst.py
@@ -59,7 +59,8 @@ class RTMDetInst(LightningInstanceSegModel):
     """
 
     pretrained_urls: ClassVar[dict[str, str]] = {
-        "rtmdet_inst_tiny": "https://storage.geti.intel.com/weights/rtmdet-ins_tiny_8xb32-300e_coco_20221130_151727-ec670f7e.pth"
+        "rtmdet_inst_tiny": "https://download.openmmlab.com/mmdetection/v3.0/rtmdet/rtmdet-ins_tiny_8xb32-300e_coco/"
+        "rtmdet-ins_tiny_8xb32-300e_coco_20221130_151727-ec670f7e.pth"
     }
 
     def __init__(

--- a/library/src/getitune/backend/lightning/models/keypoint_detection/rtmpose.py
+++ b/library/src/getitune/backend/lightning/models/keypoint_detection/rtmpose.py
@@ -32,7 +32,8 @@ class RTMPose(LightningKeypointDetectionModel):
     """RTMPose Model."""
 
     pretrained_urls: ClassVar[dict[str, str]] = {
-        "rtmpose_tiny": "https://storage.geti.intel.com/weights/cspnext-tiny_udp-aic-coco_210e-256x192-cbed682d_20230130.pth",
+        "rtmpose_tiny": "https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/"
+        "cspnext-tiny_udp-aic-coco_210e-256x192-cbed682d_20230130.pth",
     }
 
     def __init__(

--- a/library/src/getitune/backend/lightning/models/segmentation/dino_v2_seg.py
+++ b/library/src/getitune/backend/lightning/models/segmentation/dino_v2_seg.py
@@ -123,9 +123,17 @@ class DinoV2Seg(LightningSegmentationModel):
             weights (PathLike | None, optional): Comma-separated ``"<backbone_weights>,<head_weights>"``
                 string pointing to the backbone and decode head weights (local paths or URLs).
                 If None, falls back to ``self.pretrained_urls[self.model_name]``. Defaults to None.
+
+        Raises:
+            ValueError: If ``weights`` (or the resolved default from ``pretrained_urls``) is not a
+                comma-separated ``"<backbone_weights>,<head_weights>"`` string.
         """
         if weights is None:
             weights = self.pretrained_urls[self.model_name]
+
+        if "," not in str(weights):
+            msg = "weights must be a comma-separated string of the form '<backbone_weights>,<head_weights>'"
+            raise ValueError(msg)
 
         backbone_weights, head_weights = str(weights).split(",")
 

--- a/library/src/getitune/backend/lightning/models/segmentation/dino_v2_seg.py
+++ b/library/src/getitune/backend/lightning/models/segmentation/dino_v2_seg.py
@@ -5,13 +5,11 @@
 
 from __future__ import annotations
 
-from collections import OrderedDict
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 from urllib.parse import urlparse
 
-import torch
 from torch.hub import download_url_to_file
 
 from getitune.backend.lightning.models.base import DataInputParams, DefaultOptimizerCallable, DefaultSchedulerCallable
@@ -20,6 +18,7 @@ from getitune.backend.lightning.models.segmentation.base import LightningSegment
 from getitune.backend.lightning.models.segmentation.heads import FCNHead
 from getitune.backend.lightning.models.segmentation.losses import CrossEntropyLossWithIgnore
 from getitune.backend.lightning.models.segmentation.segmentors import BaseSegmentationModel
+from getitune.backend.lightning.models.utils.utils import load_checkpoint
 from getitune.config.data import TileConfig
 from getitune.metrics.dice import SegmCallable
 from getitune.types import PathLike
@@ -154,31 +153,8 @@ class DinoV2Seg(LightningSegmentationModel):
 
         backbone = cast("VisionTransformerBackbone", self.model.backbone)
         backbone.load_checkpoint(backbone_weights)  # pyrefly: ignore[not-callable]
-        self._load_decode_head(Path(head_weights))
+        load_checkpoint(cast("nn.Module", self.model.decode_head), str(head_weights), prefix="decode_head")
 
         # freeze backbone
         for _, v in backbone.named_parameters():
             v.requires_grad = False
-
-    def _load_decode_head(self, weights_path: Path) -> None:
-        """Load compatible decode head weights from a full DinoV2Seg checkpoint.
-
-        Args:
-            weights_path: Path to the checkpoint containing ``model.decode_head.*`` keys.
-        """
-        state_dict = torch.load(weights_path, map_location="cpu")
-
-        prefix = "model.decode_head."
-        decode_head_state_dict = OrderedDict(
-            (key.removeprefix(prefix), value) for key, value in state_dict.items() if key.startswith(prefix)
-        )
-
-        decode_head = cast("nn.Module", self.model.decode_head)
-        target_state_dict = decode_head.state_dict()
-        compatible_state_dict = OrderedDict(
-            (key, value)
-            for key, value in decode_head_state_dict.items()
-            if key in target_state_dict and value.shape == target_state_dict[key].shape
-        )
-
-        decode_head.load_state_dict(compatible_state_dict, strict=False)

--- a/library/src/getitune/backend/lightning/models/segmentation/dino_v2_seg.py
+++ b/library/src/getitune/backend/lightning/models/segmentation/dino_v2_seg.py
@@ -52,7 +52,8 @@ class DinoV2Seg(LightningSegmentationModel):
     """
 
     pretrained_urls: ClassVar[dict[str, str]] = {
-        "dinov2-small-seg": "https://storage.geti.intel.com/weights/dinov2_vits14_reg4_with_ade20k_linear_head_pretrain.pth",
+        "dinov2-small-seg": "https://dl.fbaipublicfiles.com/dinov2/dinov2_vits14/dinov2_vits14_reg4_pretrain.pth,"
+        "https://dl.fbaipublicfiles.com/dinov2/dinov2_vits14/dinov2_vits14_ade20k_linear_head.pth"
     }
 
     def __init__(
@@ -113,26 +114,39 @@ class DinoV2Seg(LightningSegmentationModel):
     def load_pretrained(self, weights: PathLike | None = None) -> None:
         """Load pretrained weights for the model.
 
+        The DinoV2Seg backbone and decode head are pretrained separately, so ``weights`` is expected
+        to encode both locations as a single comma-separated string: ``"<backbone_weights>,<head_weights>"``.
+        Each part may be a local file path or a URL, and is downloaded to
+        ``$PRETRAINED_WEIGHTS_CACHE_DIR`` on first use if not already present locally.
+
         Args:
-            weights (PathLike | None, optional): Path to the pretrained weights. If None, uses default weights.
-            Defaults to None.
+            weights (PathLike | None, optional): Comma-separated ``"<backbone_weights>,<head_weights>"``
+                string pointing to the backbone and decode head weights (local paths or URLs).
+                If None, falls back to ``self.pretrained_urls[self.model_name]``. Defaults to None.
         """
         if weights is None:
             weights = self.pretrained_urls[self.model_name]
 
-        weights_path = Path(weights)
-        if not weights_path.exists():
+        backbone_weights, head_weights = str(weights).split(",")
+
+        def _download_from_url(weights: str) -> Path:
             import os
 
-            parts = urlparse(str(weights))
+            parts = urlparse(weights)
             filename = Path(parts.path).name
             weights_path = Path(os.environ["PRETRAINED_WEIGHTS_CACHE_DIR"]) / filename
             if not weights_path.exists():
                 download_url_to_file(str(weights), str(weights_path), "", progress=True)
+            return weights_path
+
+        if not Path(backbone_weights).exists():
+            backbone_weights = _download_from_url(backbone_weights)
+        if not Path(head_weights).exists():
+            head_weights = _download_from_url(head_weights)
 
         backbone = cast("VisionTransformerBackbone", self.model.backbone)
-        backbone.load_checkpoint(weights_path, prefix="model.backbone")  # pyrefly: ignore[not-callable]
-        self._load_decode_head(weights_path)
+        backbone.load_checkpoint(backbone_weights)  # pyrefly: ignore[not-callable]
+        self._load_decode_head(Path(head_weights))
 
         # freeze backbone
         for _, v in backbone.named_parameters():

--- a/library/src/getitune/backend/lightning/models/segmentation/litehrnet.py
+++ b/library/src/getitune/backend/lightning/models/segmentation/litehrnet.py
@@ -50,9 +50,12 @@ class LiteHRNet(LightningSegmentationModel):
 
     pretrained_weights_target = "backbone"
     pretrained_urls: ClassVar[dict[str, str]] = {
-        "lite_hrnet_s": "https://storage.geti.intel.com/weights/litehrnetsv2_imagenet1k_rsc.pth",
-        "lite_hrnet_18": "https://storage.geti.intel.com/weights/litehrnet18_imagenet1k_rsc.pth",
-        "lite_hrnet_x": "https://storage.geti.intel.com/weights/litehrnetxv3_imagenet1k_rsc.pth",
+        "lite_hrnet_s": "https://storage.openvinotoolkit.org/repositories/openvino_training_extensions/models/"
+        "custom_semantic_segmentation/litehrnetsv2_imagenet1k_rsc.pth",
+        "lite_hrnet_18": "https://storage.openvinotoolkit.org/repositories/openvino_training_extensions/models/"
+        "custom_semantic_segmentation/litehrnet18_imagenet1k_rsc.pth",
+        "lite_hrnet_x": "https://storage.openvinotoolkit.org/repositories/openvino_training_extensions/models/"
+        "custom_semantic_segmentation/litehrnetxv3_imagenet1k_rsc.pth",
     }
 
     def __init__(

--- a/library/src/getitune/backend/lightning/models/segmentation/segnext.py
+++ b/library/src/getitune/backend/lightning/models/segmentation/segnext.py
@@ -46,9 +46,9 @@ class SegNext(LightningSegmentationModel):
 
     pretrained_weights_target = "backbone"
     pretrained_urls: ClassVar[dict[str, str]] = {
-        "segnext_tiny": "https://storage.geti.intel.com/weights/mscan_t_20230227-119e8c9f.pth",
-        "segnext_small": "https://storage.geti.intel.com/weights/mscan_s_20230227-f33ccdf2.pth",
-        "segnext_base": "https://storage.geti.intel.com/weights/mscan_b_20230227-3ab7d230.pth",
+        "segnext_tiny": "https://download.openmmlab.com/mmsegmentation/v0.5/pretrain/segnext/mscan_t_20230227-119e8c9f.pth",
+        "segnext_small": "https://download.openmmlab.com/mmsegmentation/v0.5/pretrain/segnext/mscan_s_20230227-f33ccdf2.pth",
+        "segnext_base": "https://download.openmmlab.com/mmsegmentation/v0.5/pretrain/segnext/mscan_b_20230227-3ab7d230.pth",
     }
 
     def __init__(

--- a/library/tests/unit/backend/lightning/models/classification/test_timm_model.py
+++ b/library/tests/unit/backend/lightning/models/classification/test_timm_model.py
@@ -18,6 +18,7 @@ def fxt_multi_class_cls_model():
         label_info=10,
         model_name="tf_efficientnetv2_s.in21k",
         data_input_params=DataInputParams((224, 224), (0.0, 0.0, 0.0), (1.0, 1.0, 1.0)),
+        pretrained=False,
     )
 
 
@@ -58,6 +59,7 @@ class TestTimmModelForMulticlassCls:
             model_name="tf_efficientnetv2_s.in21k",
             data_input_params=data_input_params,
             freeze_backbone=True,
+            pretrained=False,
         )
 
         classification_layers = model._identify_classification_layers()
@@ -68,6 +70,7 @@ class TestTimmModelForMulticlassCls:
             model_name="tf_efficientnetv2_s.in21k",
             data_input_params=data_input_params,
             freeze_backbone=False,
+            pretrained=False,
         )
         assert all(param.requires_grad for param in model.parameters())
 
@@ -78,6 +81,7 @@ def fxt_multi_label_cls_model():
         label_info=10,
         model_name="tf_efficientnetv2_s.in21k",
         data_input_params=DataInputParams((224, 224), (0.0, 0.0, 0.0), (1.0, 1.0, 1.0)),
+        pretrained=False,
     )
 
 
@@ -118,6 +122,7 @@ class TestTimmModelForMultilabelCls:
             model_name="tf_efficientnetv2_s.in21k",
             data_input_params=data_input_params,
             freeze_backbone=True,
+            pretrained=False,
         )
 
         classification_layers = model._identify_classification_layers()
@@ -128,5 +133,6 @@ class TestTimmModelForMultilabelCls:
             model_name="tf_efficientnetv2_s.in21k",
             data_input_params=data_input_params,
             freeze_backbone=False,
+            pretrained=False,
         )
         assert all(param.requires_grad for param in model.parameters())


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

- [x] Revert `pretrained_urls` in library models to target original locations (no `storage.geti.intel.com` used)
- [x] Revert `VisionTransformerBackbone` dinov2 path to align with standard format (separate weights for backbone and head)

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
