### PR TITLE
fix: Refetch next unannotated media item when current media item changes

### DIFF
--- a/application/ui/src/features/dataset/media-preview/utils.test.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.test.ts
@@ -140,16 +140,19 @@ describe('useNextMediaItem', () => {
         // @ts-expect-error We only care about mocking part of the context for this test.
         mockUseDatasetMediaWithReviewStatus.mockReturnValue({ fetchNextPage: mockFetchNextPage });
         // @ts-expect-error We only care about mocking data and isPending for this test.
-        mockUseFetchNextUnannotatedMediaItem.mockReturnValue({ data: { items: [] }, isPending: false });
+        mockUseFetchNextUnannotatedMediaItem.mockReturnValue({ data: { items: [] }, isPending: false, refetch: vi.fn });
         vi.clearAllMocks();
     });
 
     it('prefers the next unannotated media item over the positional next item', () => {
         const items = getMultipleMockedMediaImage(3);
+        const refetchMock = vi.fn();
+
         mockUseFetchNextUnannotatedMediaItem.mockReturnValue({
             // @ts-expect-error We only care about mocking data and isPending for this test.
             data: { items: [getMockedDatasetItem({ id: items[2].id })] },
             isPending: false,
+            refetch: refetchMock,
         });
 
         const { result } = renderHook(() => useNextMediaItem(items[0], items));
@@ -168,10 +171,12 @@ describe('useNextMediaItem', () => {
     it('ignores annotation status and advances by frame when the current item is a video frame', () => {
         const frame = getMockedVideoFrame({ id: 'video-1', frame_number: 0, frame_count: 10 });
         const nextImage = getMockedMediaImage({ id: 'image-1' });
+        const refetchMock = vi.fn();
         mockUseFetchNextUnannotatedMediaItem.mockReturnValue({
             // @ts-expect-error We only care about mocking data and isPending for this test.
             data: { items: [getMockedDatasetItem({ id: nextImage.id })] },
             isPending: false,
+            refetch: refetchMock,
         });
 
         const { result } = renderHook(() => useNextMediaItem(frame, [frame, nextImage]));
@@ -191,10 +196,12 @@ describe('useNextMediaItem', () => {
 
     it('excludes the current item from the unannotated candidates', () => {
         const items = getMultipleMockedMediaImage(2);
+        const refetchMock = vi.fn();
         mockUseFetchNextUnannotatedMediaItem.mockReturnValue({
             // @ts-expect-error We only care about mocking data and isPending for this test.
             data: { items: [getMockedDatasetItem({ id: items[0].id })] },
             isPending: false,
+            refetch: refetchMock,
         });
 
         const { result } = renderHook(() => useNextMediaItem(items[0], items));
@@ -206,10 +213,12 @@ describe('useNextMediaItem', () => {
         const alreadyFetchedItems = getMultipleMockedMediaImage(2);
         const nextUnannotatedItem = getMockedDatasetItem({ id: 'not-loaded-item' });
         const nextUnannotatedMediaImage = getMockedMediaImage({ id: nextUnannotatedItem.id });
+        const refetchMock = vi.fn();
         mockUseFetchNextUnannotatedMediaItem.mockReturnValue({
             // @ts-expect-error We only care about mocking data and isPending for this test.
             data: { items: [nextUnannotatedItem] },
             isPending: false,
+            refetch: refetchMock,
         });
         // The candidate isn't among the already-fetched items, so there must be more
         // pages available (and none currently in flight) for a fetch to be worthwhile.
@@ -233,15 +242,40 @@ describe('useNextMediaItem', () => {
 
     it('does not fetch the next page when the next unannotated item is already among the fetched items', () => {
         const alreadyFetchedItems = getMultipleMockedMediaImage(2);
+        const refetchMock = vi.fn();
+
         mockUseFetchNextUnannotatedMediaItem.mockReturnValue({
             // @ts-expect-error We only care about mocking data and isPending for this test.
             data: { items: [getMockedDatasetItem({ id: alreadyFetchedItems[1].id })] },
             isPending: false,
+            refetch: refetchMock,
         });
 
         renderHook(() => useNextMediaItem(alreadyFetchedItems[0], alreadyFetchedItems));
 
         expect(mockFetchNextPage).not.toHaveBeenCalled();
+    });
+
+    it('refreshes the list of unannotated media items when current media item changes', () => {
+        const items = getMultipleMockedMediaImage(2);
+        const refetchMock = vi.fn();
+
+        let currentMediaItem = items[0];
+
+        mockUseFetchNextUnannotatedMediaItem.mockReturnValue({
+            // @ts-expect-error We only care about mocking data and isPending for this test.
+            data: { items: [getMockedDatasetItem({ id: items[1].id })] },
+            isPending: false,
+            refetch: refetchMock,
+        });
+
+        const { rerender } = renderHook(() => useNextMediaItem(currentMediaItem, items));
+
+        currentMediaItem = items[1];
+
+        rerender();
+
+        expect(refetchMock).toHaveBeenCalled();
     });
 });
 

--- a/application/ui/src/features/dataset/media-preview/utils.test.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.test.ts
@@ -136,11 +136,17 @@ describe('useNextMediaItem', () => {
     const mockFetchNextPage = vi.fn();
 
     beforeEach(() => {
+        const refetchMock = vi.fn();
+
         mockUseVideoPlayerContext.mockReturnValue(null);
         // @ts-expect-error We only care about mocking part of the context for this test.
         mockUseDatasetMediaWithReviewStatus.mockReturnValue({ fetchNextPage: mockFetchNextPage });
-        // @ts-expect-error We only care about mocking data and isPending for this test.
-        mockUseFetchNextUnannotatedMediaItem.mockReturnValue({ data: { items: [] }, isPending: false, refetch: vi.fn });
+        mockUseFetchNextUnannotatedMediaItem.mockReturnValue({
+            // @ts-expect-error We only care about mocking data and isPending for this test.
+            data: { items: [] },
+            isPending: false,
+            refetch: () => refetchMock(),
+        });
         vi.clearAllMocks();
     });
 

--- a/application/ui/src/features/dataset/media-preview/utils.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.ts
@@ -60,7 +60,7 @@ export const getNextMediaItem = (currentMediaItem: Media, allMediaItems: Media[]
 const useNextUnannotatedMediaItem = (currentMediaItem: Media, allMediaItems: Media[]) => {
     const { annotationStatus } = useDatasetFiltersSearchParams();
     const { fetchNextPage, hasNextPage, isFetchingNextPage } = useDatasetMediaWithReviewStatus();
-    const { data, isPending } = useFetchNextUnannotatedMediaItem();
+    const { data, isPending, refetch } = useFetchNextUnannotatedMediaItem();
     const items = data?.items ?? [];
 
     // Only relevant when the gallery can actually contain unannotated media.
@@ -75,6 +75,12 @@ const useNextUnannotatedMediaItem = (currentMediaItem: Media, allMediaItems: Med
         : undefined;
     const nextUnannotatedMediaItem = allMediaItems.find((item) => item.id === nextUnannotatedDatasetMediaItem?.id);
     const isInsideFetchedMediaItems = nextUnannotatedMediaItem !== undefined;
+
+    useEffect(() => {
+        // When we navigate to the next media item, we need to refresh the list of the next unannotated media items
+        // because the current media item has changed, and it may affect the next unannotated media item.
+        refetch();
+    }, [currentMediaItem.id, refetch]);
 
     useEffect(() => {
         // Nothing to do if we can't/shouldn't look for an unannotated item, the

--- a/application/ui/src/features/dataset/media-preview/utils.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.ts
@@ -77,10 +77,13 @@ const useNextUnannotatedMediaItem = (currentMediaItem: Media, allMediaItems: Med
     const isInsideFetchedMediaItems = nextUnannotatedMediaItem !== undefined;
 
     useEffect(() => {
+        if (!canNavigateToUnannotated) {
+            return;
+        }
         // When we navigate to the next media item, we need to refresh the list of the next unannotated media items
         // because the current media item has changed, and it may affect the next unannotated media item.
         refetch();
-    }, [currentMediaItem.id, refetch]);
+    }, [currentMediaItem.id, refetch, canNavigateToUnannotated]);
 
     useEffect(() => {
         // Nothing to do if we can't/shouldn't look for an unannotated item, the


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

The issue is that we fetch next unannotated media only once, we don't consider the current media item. This PR fixes it.
Follow up fix for https://github.com/open-edge-platform/geti/pull/6983.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
