### PR TITLE
chore(ci): limit scope in lib-lint-and-test.yaml

### DIFF
--- a/.github/workflows/lib-lint-and-test.yaml
+++ b/.github/workflows/lib-lint-and-test.yaml
@@ -48,7 +48,7 @@ jobs:
           files_yaml: |
             test:
               - library/**
-              - .github/**
+              - .github/workflows/lib-lint-and-test.yaml
 
       # Separate filter so we only run the (slow, network-bound) benchmark
       # dataset preparation tests when those scripts are touched.


### PR DESCRIPTION
### Summary

This PR limit changed file scope used in `.github/workflows/lib-lint-and-test.yaml` to reduce CI time for PRs that do not touch library.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
