### PR TITLE
chore: harden input validation

### DIFF
--- a/application/backend/app/api/routers/dataset_revisions.py
+++ b/application/backend/app/api/routers/dataset_revisions.py
@@ -126,7 +126,7 @@ def list_dataset_revision_items(
     dataset_revision_service: Annotated[DatasetRevisionService, Depends(get_dataset_revision_service)],
     dataset_revision: Annotated[DatasetRevision, Depends(get_dataset_revision)],
     limit: Annotated[int, Query(ge=1, le=MAX_DATASET_ITEMS_NUMBER_RETURNED)] = DEFAULT_DATASET_ITEMS_NUMBER_RETURNED,
-    offset: Annotated[int, Query(ge=0)] = 0,
+    offset: Annotated[int, Query(ge=0, le=2_147_483_647)] = 0,
     subsets: Annotated[list[DatasetItemSubset] | None, Query()] = None,
 ) -> DatasetRevisionItemsWithPagination:
     """List the items in a dataset revision. This endpoint supports pagination."""

--- a/application/backend/app/api/routers/datasets.py
+++ b/application/backend/app/api/routers/datasets.py
@@ -33,7 +33,7 @@ def list_dataset_items(  # noqa: PLR0913
     project: Annotated[Project, Depends(get_project)],
     dataset_service: Annotated[DatasetService, Depends(get_dataset_service)],
     limit: Annotated[int, Query(ge=1, le=MAX_DATASET_ITEMS_NUMBER_RETURNED)] = DEFAULT_DATASET_ITEMS_NUMBER_RETURNED,
-    offset: Annotated[int, Query(ge=0)] = 0,
+    offset: Annotated[int, Query(ge=0, le=2_147_483_647)] = 0,
     start_date: Annotated[datetime | None, Query()] = None,
     end_date: Annotated[datetime | None, Query()] = None,
     annotation_status: Annotated[DatasetItemAnnotationStatus | None, Query()] = None,

--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -224,7 +224,7 @@ def list_media(  # noqa: PLR0913
     project: Annotated[Project, Depends(get_project)],
     media_service: Annotated[MediaService, Depends(get_media_service)],
     limit: Annotated[int, Query(ge=1, le=MAX_MEDIA_NUMBER_RETURNED)] = DEFAULT_MEDIA_NUMBER_RETURNED,
-    offset: Annotated[int, Query(ge=0)] = 0,
+    offset: Annotated[int, Query(ge=0, le=2_147_483_647)] = 0,
     start_date: Annotated[datetime | None, Query()] = None,
     end_date: Annotated[datetime | None, Query()] = None,
     annotation_status: Annotated[DatasetItemAnnotationStatus | None, Query()] = None,

--- a/application/backend/app/api/routers/projects.py
+++ b/application/backend/app/api/routers/projects.py
@@ -3,11 +3,13 @@
 
 """Endpoints for managing projects"""
 
+import secrets
 from typing import Annotated
 
 from fastapi import APIRouter, Body, Depends, status
 from fastapi.exceptions import HTTPException
 from fastapi.openapi.models import Example
+from pydantic import ValidationError as PydanticValidationError
 from starlette.responses import FileResponse
 
 from app.api.dependencies import get_data_collector, get_label_service, get_project, get_project_service
@@ -20,6 +22,12 @@ from app.services.data_collect import DataCollector
 from app.services.label_service import DuplicateLabelsError
 
 router = APIRouter(prefix="/api/projects", tags=["Projects"])
+
+
+def _random_color() -> str:
+    """Return a random #RRGGBB hex color for label assignment when none is provided."""
+    return f"#{secrets.token_hex(3).upper()}"
+
 
 CREATE_PROJECT_BODY_DESCRIPTION = """
 Configuration for creating a new project. Specify the project name, problem type (classification, detection, 
@@ -87,10 +95,15 @@ def create_project(
         task = Task(
             exclusive_labels=project_config.task.exclusive_labels,
             task_type=project_config.task.task_type,
-            labels=[Label.model_validate(label) for label in project_config.task.labels],
+            labels=[
+                Label.model_validate({**label.model_dump(), "color": label.color or _random_color()})
+                for label in project_config.task.labels
+            ],
         )
         created_project = project_service.create_project(project_config.id, project_config.name, task)
         return ProjectView.model_validate(created_project, from_attributes=True)
+    except PydanticValidationError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
     except (ResourceWithIdAlreadyExistsError, DuplicateLabelsError) as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
 

--- a/application/backend/app/api/routers/projects.py
+++ b/application/backend/app/api/routers/projects.py
@@ -103,7 +103,7 @@ def create_project(
         created_project = project_service.create_project(project_config.id, project_config.name, task)
         return ProjectView.model_validate(created_project, from_attributes=True)
     except PydanticValidationError as e:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=e.errors())
     except (ResourceWithIdAlreadyExistsError, DuplicateLabelsError) as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
 

--- a/application/backend/app/api/routers/webrtc.py
+++ b/application/backend/app/api/routers/webrtc.py
@@ -21,12 +21,20 @@ router = APIRouter(prefix="/api/webrtc", tags=["WebRTC"])
 @router.post(
     "/offer",
     response_model=Answer,
-    responses={status.HTTP_200_OK: {"description": "WebRTC Answer"}},
+    responses={
+        status.HTTP_200_OK: {"description": "WebRTC Answer"},
+        status.HTTP_400_BAD_REQUEST: {"description": "Invalid SDP type or parameters"},
+    },
 )
 async def create_webrtc_offer(offer: Offer, webrtc_manager: Annotated[WebRTCManager, Depends(get_webrtc)]) -> Answer:
     """Create a WebRTC offer"""
     try:
         return await webrtc_manager.handle_offer(offer)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid WebRTC offer parameters.",
+        )
     except Exception:
         logger.exception("Error processing WebRTC offer")
         raise HTTPException(

--- a/application/backend/app/api/schemas/dataset.py
+++ b/application/backend/app/api/schemas/dataset.py
@@ -3,7 +3,7 @@
 
 from uuid import UUID
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, StrictBool, model_validator
 
 from app.core.models import BaseRequiredIDModel
 from app.models import DatasetFormat, DatasetItemSubset, StagedDataset
@@ -21,7 +21,7 @@ class DatasetFilters(BaseModel):
         description="List of subsets to consider during import or export; any item assigned a subset not present in "
         "the list will be filtered out; if the parameter is unspecified (null), then all subsets will be considered",
     )
-    include_unannotated: bool = Field(True, description="Whether to include unannotated items from the dataset")
+    include_unannotated: StrictBool = Field(True, description="Whether to include unannotated items from the dataset")
 
     model_config = {
         "json_schema_extra": {

--- a/application/backend/app/api/schemas/jobs/dataset_import.py
+++ b/application/backend/app/api/schemas/jobs/dataset_import.py
@@ -4,7 +4,7 @@
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, StrictBool, model_validator
 
 from app.api.schemas.dataset import DatasetFilters
 from app.core.jobs.models import JobType
@@ -37,7 +37,7 @@ class ImportDatasetProjectParams(BaseModel):
         description="Specify how to map the labels found in the dataset to the labels defined in the project. If and "
         "only if the dataset labels exactly match the project labels, this parameter can be left unspecified (null)",
     )
-    include_unannotated: bool = Field(True, description="Whether to include unannotated items from the dataset")
+    include_unannotated: StrictBool = Field(True, description="Whether to include unannotated items from the dataset")
 
     model_config = {
         "json_schema_extra": {

--- a/application/backend/app/models/webrtc.py
+++ b/application/backend/app/models/webrtc.py
@@ -3,12 +3,19 @@
 
 from typing import Literal
 
-from pydantic import BaseModel, Field, StrictFloat
+from pydantic import BaseModel, Field, field_validator
 
 
 class InputData(BaseModel):
     webrtc_id: str
-    conf_threshold: StrictFloat = Field(ge=0, le=1)
+    conf_threshold: float = Field(ge=0, le=1)
+
+    @field_validator("conf_threshold", mode="before")
+    @classmethod
+    def reject_bool_threshold(cls, v: object) -> object:
+        if isinstance(v, bool):
+            raise ValueError("conf_threshold must be a number, not a boolean")
+        return v
 
 
 class Offer(BaseModel):

--- a/application/backend/app/models/webrtc.py
+++ b/application/backend/app/models/webrtc.py
@@ -1,18 +1,20 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from pydantic import BaseModel, Field
+from typing import Literal
+
+from pydantic import BaseModel, Field, StrictFloat
 
 
 class InputData(BaseModel):
     webrtc_id: str
-    conf_threshold: float = Field(ge=0, le=1)
+    conf_threshold: StrictFloat = Field(ge=0, le=1)
 
 
 class Offer(BaseModel):
     webrtc_id: str
-    sdp: str
-    type: str
+    sdp: str = Field(min_length=1)
+    type: Literal["offer", "pranswer", "answer", "rollback"]
 
 
 class Answer(BaseModel):

--- a/application/backend/tests/unit/api/routers/test_dataset_revisions.py
+++ b/application/backend/tests/unit/api/routers/test_dataset_revisions.py
@@ -291,6 +291,18 @@ class TestDatasetRevisionItemEndpoints:
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         fxt_dataset_revision_service.list_dataset_revision_items.assert_not_called()
 
+    def test_list_dataset_revision_items_offset_overflow(
+        self, fxt_get_project, fxt_dataset_revision_id, fxt_dataset_revision_service, fxt_client
+    ):
+        """Integers larger than 2^31-1 must be rejected with 422, not cause a SQLite overflow 500."""
+        huge_offset = 2**63  # exceeds the le=2_147_483_647 bound
+        response = fxt_client.get(
+            f"/api/projects/{str(fxt_get_project.id)}/dataset_revisions/{str(fxt_dataset_revision_id)}/items?offset={huge_offset}"
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+        fxt_dataset_revision_service.list_dataset_revision_items.assert_not_called()
+
     def test_list_dataset_revision_items_invalid_revision_id(
         self, fxt_get_project, fxt_dataset_revision_service, fxt_client
     ):

--- a/application/backend/tests/unit/api/routers/test_datasets.py
+++ b/application/backend/tests/unit/api/routers/test_datasets.py
@@ -148,6 +148,14 @@ class TestDatasetItemEndpoints:
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         fxt_dataset_service.list_dataset_items.assert_not_called()
 
+    def test_list_dataset_items_offset_overflow(self, fxt_get_project, fxt_dataset_service, fxt_client):
+        """Integers larger than 2^31-1 must be rejected with 422, not cause a SQLite overflow 500."""
+        huge_offset = 2**63  # exceeds the le=2_147_483_647 bound
+        response = fxt_client.get(f"/api/projects/{uuid4()}/dataset/items?offset={huge_offset}")
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+        fxt_dataset_service.list_dataset_items.assert_not_called()
+
     @pytest.mark.parametrize("offset", [-20])
     def test_list_dataset_items_wrong_dates(self, fxt_get_project, fxt_dataset_service, fxt_client, offset):
         response = fxt_client.get(

--- a/application/backend/tests/unit/api/routers/test_media.py
+++ b/application/backend/tests/unit/api/routers/test_media.py
@@ -388,6 +388,14 @@ class TestMediaEndpoints:
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         fxt_media_service.list_media.assert_not_called()
 
+    def test_list_media_offset_overflow(self, fxt_get_project, fxt_media_service, fxt_client):
+        """Integers larger than 2^31-1 must be rejected with 422, not cause a SQLite overflow 500."""
+        huge_offset = 2**63  # exceeds the le=2_147_483_647 bound
+        response = fxt_client.get(f"/api/projects/{uuid4()}/dataset/media?offset={huge_offset}")
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+        fxt_media_service.list_media.assert_not_called()
+
     @pytest.mark.parametrize("offset", [-20])
     def test_list_media_wrong_dates(self, fxt_get_project, fxt_media_service, fxt_client, offset):
         response = fxt_client.get(

--- a/application/backend/tests/unit/api/routers/test_projects.py
+++ b/application/backend/tests/unit/api/routers/test_projects.py
@@ -106,6 +106,72 @@ class TestProjectEndpoints:
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         fxt_project_service.create_project.assert_not_called()
 
+
+class TestCreateProjectInputValidationSecurity:
+    """Regression tests for a null label color must not cause a 500 error."""
+
+    @pytest.mark.parametrize(
+        "label_payload",
+        [
+            {"name": "cat"},  # color omitted, defaults to None in LabelCreate
+            {"name": "cat", "color": None},  # color explicitly null
+        ],
+    )
+    def test_null_label_color_gets_random_default_assigned(
+        self, label_payload, fxt_project_service, fxt_project, fxt_client
+    ):
+        """Label with color=null must return 201 and receive a valid hex color, not cause 500."""
+        import re
+
+        fxt_project_service.create_project.return_value = fxt_project
+        payload = {
+            "name": "Security Test Project",
+            "task": {
+                "task_type": "classification",
+                "exclusive_labels": True,
+                # classification + exclusive_labels requires >= 2 labels (TaskCreate.validate_labels)
+                "labels": [
+                    {"id": str(uuid4()), **label_payload},
+                    {"id": str(uuid4()), "name": "dog", "color": "#001122"},
+                ],
+            },
+        }
+
+        response = fxt_client.post("/api/projects", json=payload)
+
+        assert response.status_code == status.HTTP_201_CREATED
+        fxt_project_service.create_project.assert_called_once()
+
+        # Verify the handler assigned a valid #RRGGBB hex color before calling the service
+        task_arg = fxt_project_service.create_project.call_args[0][2]
+        hex_pattern = re.compile(r"^#[0-9A-Fa-f]{6}$")
+        assert task_arg.labels, "expected at least one label"
+        for label in task_arg.labels:
+            assert label.color is not None, "color must not reach the service as None"
+            assert hex_pattern.match(label.color), f"color must be #RRGGBB, got {label.color!r}"
+
+    def test_provided_color_preserved(self, fxt_project_service, fxt_project, fxt_client):
+        """An explicitly provided color must not be overridden."""
+        fxt_project_service.create_project.return_value = fxt_project
+        payload = {
+            "name": "Color Project",
+            "task": {
+                "task_type": "classification",
+                "exclusive_labels": True,
+                # classification + exclusive_labels requires >= 2 labels
+                "labels": [
+                    {"id": str(uuid4()), "name": "cat", "color": "#AABB11"},
+                    {"id": str(uuid4()), "name": "dog", "color": "#112233"},
+                ],
+            },
+        }
+
+        response = fxt_client.post("/api/projects", json=payload)
+
+        assert response.status_code == status.HTTP_201_CREATED
+        task_arg = fxt_project_service.create_project.call_args[0][2]
+        assert task_arg.labels[0].color == "#AABB11"
+
     def test_delete_project_success(self, fxt_project, fxt_project_service, fxt_client):
         response = fxt_client.delete(f"/api/projects/{str(fxt_project.id)}")
 

--- a/application/backend/tests/unit/api/routers/test_webrtc.py
+++ b/application/backend/tests/unit/api/routers/test_webrtc.py
@@ -80,3 +80,45 @@ class TestWebRTCEndpoints:
                 {"urls": "stun:stun.example.com:3478", "username": None, "credential": None},
             ]
         }
+
+
+class TestWebRTCInputValidationSecurity:
+    """Security regression tests for H4 and H5 (PR1)."""
+
+    @pytest.mark.parametrize("type_value", ["invalid", "", "OFFER", "Answer", "rollback_extra", "null", "1"])
+    def test_offer_invalid_type_rejected(self, fxt_client, type_value):
+        """Type values outside the Literal enum must be rejected with 422, not cause 500."""
+        payload = {"sdp": "v=0\r\n", "type": type_value, "webrtc_id": "id"}
+        resp = fxt_client.post("/api/webrtc/offer", json=payload)
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+    def test_offer_empty_sdp_rejected(self, fxt_client):
+        """sdp requires at least 1 character (Field(min_length=1))."""
+        payload = {"sdp": "", "type": "offer", "webrtc_id": "id"}
+        resp = fxt_client.post("/api/webrtc/offer", json=payload)
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+    def test_offer_library_value_error_returns_400_not_500(self, fxt_client, fxt_webrtc_manager):
+        """ValueError from downstream library (e.g. aiortc) must map to 400, not 500."""
+        fxt_webrtc_manager.handle_offer.side_effect = ValueError("'type' must be in ['offer', ...]")
+        payload = {"sdp": "v=0\r\n", "type": "offer", "webrtc_id": "id"}
+        resp = fxt_client.post("/api/webrtc/offer", json=payload)
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert resp.json()["detail"] == "Invalid WebRTC offer parameters."
+
+    def test_offer_generic_exception_still_returns_500(self, fxt_client, fxt_webrtc_manager):
+        """Non-ValueError exceptions must still result in 500, not silently swallowed."""
+        fxt_webrtc_manager.handle_offer.side_effect = RuntimeError("unexpected")
+        payload = {"sdp": "v=0\r\n", "type": "offer", "webrtc_id": "id"}
+        resp = fxt_client.post("/api/webrtc/offer", json=payload)
+        assert resp.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+    def test_input_hook_conf_threshold_bool_coercion_rejected(self, fxt_client):
+        """Boolean False must NOT be silently coerced to 0.0 (StrictFloat)."""
+        resp = fxt_client.post("/api/webrtc/input_hook", json={"webrtc_id": "id", "conf_threshold": False})
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+    def test_input_hook_conf_threshold_float_accepted(self, fxt_client, fxt_webrtc_manager):
+        """A proper float value must still be accepted."""
+        resp = fxt_client.post("/api/webrtc/input_hook", json={"webrtc_id": "id", "conf_threshold": 0.75})
+        assert resp.status_code == status.HTTP_200_OK

--- a/application/ui/src/features/inference/stream/web-rtc-connection.ts
+++ b/application/ui/src/features/inference/stream/web-rtc-connection.ts
@@ -141,7 +141,9 @@ export class WebRTCConnection {
         if (!this.peerConnection) return;
 
         const localDescription = this.peerConnection.localDescription;
-        if (!localDescription) return;
+        if (!localDescription) {
+            throw new Error('WebRTC localDescription is not set');
+        }
 
         const { data } = await fetchClient.POST('/api/webrtc/offer', {
             body: {

--- a/application/ui/src/features/inference/stream/web-rtc-connection.ts
+++ b/application/ui/src/features/inference/stream/web-rtc-connection.ts
@@ -140,10 +140,13 @@ export class WebRTCConnection {
     private async sendOffer(): Promise<SessionData | undefined> {
         if (!this.peerConnection) return;
 
+        const localDescription = this.peerConnection.localDescription;
+        if (!localDescription) return;
+
         const { data } = await fetchClient.POST('/api/webrtc/offer', {
             body: {
-                sdp: this.peerConnection.localDescription?.sdp ?? '',
-                type: this.peerConnection.localDescription?.type ?? '',
+                sdp: localDescription.sdp,
+                type: localDescription.type,
                 webrtc_id: this.webrtcId,
             },
         });


### PR DESCRIPTION
### Summary

This PR fixes input validation issues discovered during a security scan of the backend API
using OWASP ZAP and Schemathesis fuzzing, for evidences see logs attached to https://github.com/open-edge-platform/geti/actions/runs/30606209030

### Changes

#### WebRTC offer endpoint - invalid `type` value caused HTTP 500

`POST /api/webrtc/offer` accepted any string for the `type` field and forwarded it to `aiortc`,
which raised a `ValueError` that the handler converted to 500 instead of 400.

Evidence (container log):

```
File "/application/backend/app/webrtc/manager.py", line 71, in handle_offer
    await pc.setRemoteDescription(RTCSessionDescription(sdp=offer.sdp, type=offer.type))
        │  └ 'John Doe'
        └ Offer(webrtc_id='John Doe', sdp='John Doe', type='John Doe')
  File "<string>", line 5, in __init__
  File ".../aiortc/rtcsessiondescription.py", line 16, in __post_init__
    raise ValueError(
ValueError: 'type' must be in ['offer', 'pranswer', 'answer', 'rollback'] (got 'John Doe')
```
Fix: `Offer.type` is now constrained to `Literal["offer", "pranswer", "answer", "rollback"]`, the
four values defined by the [WebRTC spec](https://www.w3.org/TR/webrtc/#dom-rtcsdptype) and enforced by `aiortc`.

The corresponding UI call in `web-rtc-connection.ts` was updated to guard against a missing
`localDescription` with an early return, replacing a `?? ''` fallback that was incompatible with
the new stricter type.

####  Unbounded `offset` parameter caused HTTP 500 on paginated endpoints

OWASP ZAP sent 44-digit integers as the `offset` query parameter on paginated dataset and media
endpoints and received HTTP 500 in all four cases.

```
Evidence (container log):

  File "/application/backend/.venv/lib/python3.13/site-packages/sqlalchemy/engine/default.py", line 952, in do_execute
    cursor.execute(statement, parameters)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
OverflowError: Python int too large to convert to SQLite INTEGER
ERROR [hypercorn.error] Error in ASGI Framework
Traceback (most recent call last):
  File "/application/backend/.venv/lib/python3.13/site-packages/hypercorn/asyncio/task_group.py", line 28, in _handle
    await app(scope, receive, send, sync_spawn, call_soon)
  File "/application/backend/.venv/lib/python3.13/site-packages/hypercorn/app_wrappers.py", line 34, in __call__
```

Python's `int` is unbounded, so these values passed Pydantic validation unchanged and were
forwarded to SQLAlchemy, which passed them to the SQLite Python binding (`pysqlite`/`aiosqlite`).
The binding raised `OverflowError: Python int too large to convert to C long`.

Fix: `offset` on `GET /api/projects/{id}/dataset/items`, `GET /api/projects/{id}/dataset/media`,
and `GET /api/projects/{id}/dataset_revisions/{id}/items` now has an upper bound of `le=2_147_483_647`.


#### `POST /api/projects` with `color: null` on a label caused HTTP 500

The API schema declares `LabelCreate.color` as optional (`str | None`, default `None`). The domain
model declares `Label.color` as required (`str`). The `create_project` handler passed `LabelCreate`
objects directly to `Label.model_validate` without checking for `None`.

The full call chain for `POST /api/projects` is:

```
Router: create_project()                                  ← crash happens here
    └─ Label.model_validate({..., color: None})           ← ValidationError raised, call aborted
       ProjectService.create_project(task)                ← never reached
           └─ LabelService.create_label(color=…)          ← never reached
                  └─ color if color else random_color()   ← fallback never fires
```

Evidence (container log):

```
[2026-07-23 22:21:16 +0000] [1] [INFO] 172.17.0.1:37666 - - [23/Jul/2026:22:21:16 +0000] "POST /api/projects 1.1" 500 21 "-" "schemathesis/4.24.2"
[2026-07-23 22:21:16 +0000] [1] [ERROR] Error in ASGI Framework
Traceback (most recent call last):
  File "/application/backend/.venv/lib/python3.13/site-packages/hypercorn/asyncio/task_group.py", line 28, in _handle
    await app(scope, receive, send, sync_spawn, call_soon)
....

  File "/application/backend/.venv/lib/python3.13/site-packages/pydantic/main.py", line 732, in model_validate
    return cls.__pydantic_validator__.validate_python(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        obj,
        ^^^^
    ...<5 lines>...
        by_name=by_name,
        ^^^^^^^^^^^^^^^^
    )
    ^
pydantic_core._pydantic_core.ValidationError: 1 validation error for Label
color
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
```

Fix: when `color` is `None`, a random hex color is now assigned using `secrets.token_hex()` before constructing the `Label`. Used `secrets.token_hex()` pattern is already the established pattern, see e.g https://github.com/open-edge-platform/geti/blob/develop/application/backend/app/execution/dataset_import/import_as_new_project.py#L76


### Type coercion accepted schema-violating input silently

Pydantic v2's default lax validation mode coerces across types at API boundaries:

- `include_unannotated: 0` (integer) was silently accepted as `False` for `bool` fields in
  import/export job requests
- `conf_threshold: false` (boolean) was silently accepted as `0.0` for the `float` confidence
  threshold, disabling inference thresholding without warning

Evidence (Schemathesis, `junit.xml` file)

```bash
# Integer coerced to bool:
POST /api/jobs  body: {"job_type":"import_dataset_as_new_project", ..., "filters":{"include_unannotated":0}}
→ 202 Accepted  (job created with include_unannotated=False)

# Bool coerced to float:
POST /api/webrtc/input_hook  body: {"conf_threshold": false, "webrtc_id": ""}
→ 200 OK  (threshold silently set to 0.0)
```

Fix: `DatasetFilters.include_unannotated` and `ImportDatasetProjectParams.include_unannotated` are now typed as `StrictBool`. `InputData.conf_threshold` keeps `float` but gains a `field_validator(mode="before")` that
explicitly rejects `bool` values.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
