### PR TITLE
Fix dataset filter by subset: video support

### DIFF
--- a/application/backend/app/repositories/filters.py
+++ b/application/backend/app/repositories/filters.py
@@ -131,3 +131,52 @@ def _apply_subset_filter(stmt: Select, subsets: list[str] | None = None) -> Sele
     if subsets:
         stmt = stmt.where(DatasetItemDB.subset.in_(subsets))
     return stmt
+
+
+def _apply_subset_filter_with_video_support(stmt: Select, subsets: list[str] | None = None) -> Select:
+    """Apply a subset filter to a media query, accounting for the video/frame hierarchy.
+
+    Unlike a plain filter on ``DatasetItemDB.subset``, this also works for videos, which do
+    not have their own ``DatasetItemDB`` rows. A video is considered to match if at least
+    one of its frames has a ``DatasetItemDB`` belonging to one of the given subsets. In that
+    case the video itself is returned (not its individual frames).
+
+    Images and video frames match when their own dataset item belongs to one of the subsets.
+
+    Args:
+        stmt: The base SQLAlchemy select statement, expected to have ``MediaDB`` as its
+              primary entity.
+        subsets: The list of subsets to filter by, or ``None``/empty to skip filtering.
+
+    Returns:
+        The select statement with the subset condition applied.
+    """
+    if not subsets:
+        return stmt
+
+    # Image or frame: its own dataset item belongs to one of the requested subsets
+    own_subset_exists = exists(
+        select(DatasetItemDB.id)
+        .where(
+            DatasetItemDB.id == MediaDB.id,
+            DatasetItemDB.subset.in_(subsets),
+        )
+        .correlate(MediaDB)
+    )
+
+    # Video: at least one of its frames has a dataset item belonging to one of the requested subsets
+    frame_alias = aliased(MediaDB)
+    frame_subset_exists = exists(
+        select(DatasetItemDB.id)
+        .join(frame_alias, frame_alias.id == DatasetItemDB.id)
+        .where(
+            frame_alias.video_id == MediaDB.id,
+            DatasetItemDB.subset.in_(subsets),
+        )
+        .correlate(MediaDB)
+    )
+
+    return stmt.where(
+        ((MediaDB.type != MediaType.VIDEO) & own_subset_exists)
+        | ((MediaDB.type == MediaType.VIDEO) & frame_subset_exists)
+    )

--- a/application/backend/app/repositories/filters.py
+++ b/application/backend/app/repositories/filters.py
@@ -164,11 +164,11 @@ def _apply_subset_filter_with_video_support(stmt: Select, subsets: list[str] | N
         .correlate(MediaDB)
     )
 
-    # Video: at least one of its frames has a dataset item belonging to one of the requested subsets
+    # Video: at least one of its frames has a dataset item belonging to one of the requested subsets.
     frame_alias = aliased(MediaDB)
     frame_subset_exists = exists(
-        select(DatasetItemDB.id)
-        .join(frame_alias, frame_alias.id == DatasetItemDB.id)
+        select(frame_alias.id)
+        .join(DatasetItemDB, DatasetItemDB.id == frame_alias.id)
         .where(
             frame_alias.video_id == MediaDB.id,
             DatasetItemDB.subset.in_(subsets),

--- a/application/backend/app/repositories/filters.py
+++ b/application/backend/app/repositories/filters.py
@@ -39,8 +39,8 @@ def _apply_annotation_status_filter_with_video_support(stmt: Select, annotation_
         # Videos: have no dataset_item themselves, but at least one annotated frame
         frame_alias = aliased(MediaDB)
         annotated_frame_exists = exists(
-            select(DatasetItemDB.id)
-            .join(frame_alias, frame_alias.id == DatasetItemDB.id)
+            select(frame_alias.id)
+            .join(DatasetItemDB, DatasetItemDB.id == frame_alias.id)
             .where(
                 frame_alias.video_id == MediaDB.id,
                 DatasetItemDB.annotation_data.isnot(None),
@@ -57,8 +57,8 @@ def _apply_annotation_status_filter_with_video_support(stmt: Select, annotation_
     elif annotation_status == DatasetItemAnnotationStatus.MISSING_ANNOTATIONS:
         frame_alias = aliased(MediaDB)
         annotated_frame_count = (
-            select(func.count(DatasetItemDB.id))
-            .join(frame_alias, frame_alias.id == DatasetItemDB.id)
+            select(func.count(frame_alias.id))
+            .join(DatasetItemDB, DatasetItemDB.id == frame_alias.id)
             .where(
                 frame_alias.video_id == MediaDB.id,
                 DatasetItemDB.annotation_data.isnot(None),
@@ -111,8 +111,8 @@ def _apply_label_filter_with_video_support(stmt: Select, label_ids: list[str] | 
     # Video: at least one of its frames has a dataset item carrying one of the requested labels
     frame_alias = aliased(MediaDB)
     frame_label_exists = exists(
-        select(DatasetItemLabelDB.dataset_item_id)
-        .join(frame_alias, frame_alias.id == DatasetItemLabelDB.dataset_item_id)
+        select(frame_alias.id)
+        .join(DatasetItemLabelDB, DatasetItemLabelDB.dataset_item_id == frame_alias.id)
         .where(
             frame_alias.video_id == MediaDB.id,
             DatasetItemLabelDB.label_id.in_(label_ids),

--- a/application/backend/app/repositories/media_repo.py
+++ b/application/backend/app/repositories/media_repo.py
@@ -13,7 +13,7 @@ from app.models.media import MediaSortBy, SortDirection
 from .filters import (
     _apply_annotation_status_filter_with_video_support,
     _apply_label_filter_with_video_support,
-    _apply_subset_filter,
+    _apply_subset_filter_with_video_support,
 )
 
 # Maps each sortable field to its underlying DB column. Extend this when a new
@@ -74,7 +74,7 @@ class MediaRepository:
             stmt = stmt.where(MediaDB.type.not_in(exclude_types))
         stmt = self._apply_date_filters(stmt, start_date, end_date)
         stmt = _apply_annotation_status_filter_with_video_support(stmt, annotation_status)
-        stmt = _apply_subset_filter(stmt, subsets)
+        stmt = _apply_subset_filter_with_video_support(stmt, subsets)
         stmt = _apply_label_filter_with_video_support(stmt, label_ids)
         return self.db.scalar(stmt) or 0
 
@@ -96,7 +96,7 @@ class MediaRepository:
             stmt = stmt.where(MediaDB.type.not_in(exclude_types))
         stmt = self._apply_date_filters(stmt, start_date, end_date)
         stmt = _apply_annotation_status_filter_with_video_support(stmt, annotation_status)
-        stmt = _apply_subset_filter(stmt, subsets)
+        stmt = _apply_subset_filter_with_video_support(stmt, subsets)
         stmt = _apply_label_filter_with_video_support(stmt, label_ids)
         sort_column = _SORT_BY_COLUMN[sort_by]
         order_by_column = sort_column.asc() if sort_direction == SortDirection.ASC else sort_column.desc()

--- a/application/backend/tests/integration/services/test_media_service.py
+++ b/application/backend/tests/integration/services/test_media_service.py
@@ -990,7 +990,7 @@ class TestMediaServiceIntegration:
         "annotation_status",
         [None, DatasetItemAnnotationStatus.WITH_ANNOTATIONS, DatasetItemAnnotationStatus.MISSING_ANNOTATIONS],
     )
-    def test_list_media_with_annotated_frame(
+    def test_list_media_with_annotated_frame_annotation_status(
         self,
         annotation_status: DatasetItemAnnotationStatus | None,
         fxt_media_service: MediaService,
@@ -1013,6 +1013,36 @@ class TestMediaServiceIntegration:
         media_list = fxt_media_service.list_media(
             project_id=project.id,
             filters=MediaFilters(annotation_status=annotation_status),
+        )
+
+        videos = [m for m in media_list if isinstance(m, Video)]
+        assert len(videos) == 1
+        assert videos[0].annotated_frame_count == 1
+
+    @pytest.mark.parametrize("subsets", [None, ["unassigned"]])
+    def test_list_media_with_annotated_frame_subsets(
+        self,
+        subsets: list[str] | None,
+        fxt_media_service: MediaService,
+        fxt_project_with_media: tuple[Project, list[MediaDB]],
+        db_session: Session,
+    ) -> None:
+        """Test listing media should include the video that have annotated frame with each filter option."""
+        project, db_media_list = fxt_project_with_media
+
+        db_video_frame = next(db_media for db_media in db_media_list if db_media.type == MediaType.VIDEO_FRAME)
+        db_dataset_item = DatasetItemDB(
+            id=db_video_frame.id,
+            project_id=str(project.id),
+            subset="unassigned",
+            annotation_data=[{"labels": [{"id": str(uuid4())}], "shape": {"type": "full_image"}}],
+        )
+        db_session.add(db_dataset_item)
+        db_session.flush()
+
+        media_list = fxt_media_service.list_media(
+            project_id=project.id,
+            filters=MediaFilters(subsets=subsets),
         )
 
         videos = [m for m in media_list if isinstance(m, Video)]

--- a/application/backend/tests/integration/services/test_media_service.py
+++ b/application/backend/tests/integration/services/test_media_service.py
@@ -1019,22 +1019,22 @@ class TestMediaServiceIntegration:
         assert len(videos) == 1
         assert videos[0].annotated_frame_count == 1
 
-    @pytest.mark.parametrize("subsets", [None, ["unassigned"]])
+    @pytest.mark.parametrize("subset", ["unassigned", "training"])
     def test_list_media_with_annotated_frame_subsets(
         self,
-        subsets: list[str] | None,
+        subset: str,
         fxt_media_service: MediaService,
         fxt_project_with_media: tuple[Project, list[MediaDB]],
         db_session: Session,
     ) -> None:
-        """Test listing media should include the video that have annotated frame with each filter option."""
+        """Test listing media should include the video that has annotated frame with each filter option."""
         project, db_media_list = fxt_project_with_media
 
         db_video_frame = next(db_media for db_media in db_media_list if db_media.type == MediaType.VIDEO_FRAME)
         db_dataset_item = DatasetItemDB(
             id=db_video_frame.id,
             project_id=str(project.id),
-            subset="unassigned",
+            subset=subset,
             annotation_data=[{"labels": [{"id": str(uuid4())}], "shape": {"type": "full_image"}}],
         )
         db_session.add(db_dataset_item)
@@ -1042,7 +1042,7 @@ class TestMediaServiceIntegration:
 
         media_list = fxt_media_service.list_media(
             project_id=project.id,
-            filters=MediaFilters(subsets=subsets),
+            filters=MediaFilters(subsets=[subset]),
         )
 
         videos = [m for m in media_list if isinstance(m, Video)]


### PR DESCRIPTION
Extend filtering logic  for videos, which do not have their own ``DatasetItemDB`` rows. A video is considered to match if at least one of its frames has a ``DatasetItemDB`` belonging to one of the given subsets. In that case the video itself is returned (not its individual frames).

Resolves #7135