### PR TITLE
Fix pipeline & source updates

### DIFF
--- a/application/backend/app/db/__init__.py
+++ b/application/backend/app/db/__init__.py
@@ -3,10 +3,12 @@
 
 from app.db.engine import db_engine, get_db_session
 from app.db.migration import MigrationFatalError, MigrationManager
+from app.db.session_hooks import run_after_commit
 
 __all__ = [
     "MigrationFatalError",
     "MigrationManager",
     "db_engine",
     "get_db_session",
+    "run_after_commit",
 ]

--- a/application/backend/app/db/session_hooks.py
+++ b/application/backend/app/db/session_hooks.py
@@ -1,0 +1,51 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Defer side effects until a database session successfully commits.
+
+Cross-process consumers (e.g. the ``StreamLoader``) react to events by re-reading the affected
+entity from the database in their own session/process. Emitting such an event while the writing
+transaction is still open lets that reload race the commit and read *stale* data (e.g. the previous
+``video_path`` of a source). Registering the emission as an ``after_commit`` hook guarantees the new
+data is durably visible before any consumer is notified.
+
+Callbacks are scheduled per :class:`~sqlalchemy.orm.Session` via :func:`run_after_commit` and are
+executed by the module-level ``after_commit`` listener. Callbacks scheduled on a transaction that is
+rolled back are discarded.
+"""
+
+from collections.abc import Callable
+
+from loguru import logger
+from sqlalchemy import event
+from sqlalchemy.orm import Session
+
+# Key under which the pending callbacks are stored in ``Session.info`` (a per-session dict that is
+# reset for every new Session instance, so callbacks never leak across requests).
+_CALLBACKS_KEY = "after_commit_callbacks"
+
+
+def run_after_commit(session: Session, callback: Callable[[], None]) -> None:
+    """Schedule ``callback`` to run once ``session`` successfully commits.
+
+    Callbacks registered for a transaction that is later rolled back are discarded.
+    """
+    session.info.setdefault(_CALLBACKS_KEY, []).append(callback)
+
+
+@event.listens_for(Session, "after_commit")
+def _run_after_commit_callbacks(session: Session) -> None:
+    """Run and clear the callbacks scheduled for ``session`` once its transaction has committed."""
+    callbacks: list[Callable[[], None]] = session.info.pop(_CALLBACKS_KEY, [])
+    for callback in callbacks:
+        try:
+            callback()
+        except Exception:
+            # A misbehaving callback must not prevent the remaining callbacks from running.
+            logger.exception("after-commit callback raised an exception; continuing")
+
+
+@event.listens_for(Session, "after_rollback")
+def _discard_after_commit_callbacks(session: Session) -> None:
+    """Drop any callbacks scheduled for ``session`` when its transaction is rolled back."""
+    session.info.pop(_CALLBACKS_KEY, None)

--- a/application/backend/app/services/event/event_bus.py
+++ b/application/backend/app/services/event/event_bus.py
@@ -4,6 +4,10 @@
 from enum import StrEnum
 from multiprocessing.synchronize import Condition, Event
 
+from sqlalchemy.orm import Session
+
+from app.db.session_hooks import run_after_commit
+
 from .base import BaseEventBus
 
 
@@ -76,3 +80,15 @@ class EventBus(BaseEventBus[EventType]):
             self._should_notify_model(event_type) or self._should_notify_device(event_type)
         ) and self._model_reload_event:
             self._model_reload_event.set()
+
+    def emit_event_after_commit(self, db_session: Session, event_type: EventType) -> None:
+        """Emit ``event_type`` only after ``db_session`` successfully commits.
+
+        Prefer this over :meth:`emit_event` when the emission is triggered by a database write whose
+        result consumers must observe. Consumers (possibly in other processes, e.g. the
+        ``StreamLoader``) react by re-reading the affected entity from the database; emitting before
+        the write is durably committed would let that reload race the commit and read stale data
+        (e.g. the previous ``video_path`` of a source). If the transaction is rolled back instead,
+        the event is never emitted.
+        """
+        run_after_commit(db_session, lambda: self.emit_event(event_type))

--- a/application/backend/app/services/pipeline_service.py
+++ b/application/backend/app/services/pipeline_service.py
@@ -269,22 +269,27 @@ class PipelineService(BaseSessionManagedService):
                 "Event bus is required to update pipeline. This is because updating pipeline may trigger events that "
                 "require other services to react."
             )
+        # Emit only after this transaction commits: consumers (e.g. the StreamLoader) react by
+        # re-reading the pipeline/source in their own session/process, so notifying before the new
+        # state is durable would let them race the commit and observe the previous configuration.
         if pipeline.status == PipelineStatus.RUNNING and updated.status == PipelineStatus.RUNNING:
             # If the pipeline source_id or sink_id is being updated while running
             if pipeline.source_id != updated.source_id:
-                self._event_bus.emit_event(EventType.SOURCE_CHANGED)
+                self._event_bus.emit_event_after_commit(self.db_session, EventType.SOURCE_CHANGED)
             if pipeline.sink_id != updated.sink_id:
                 # Sink may be None (disconnected): in that case predictions are only routed to WebRTC.
-                self._event_bus.emit_event(EventType.SINK_CHANGED)
+                self._event_bus.emit_event_after_commit(self.db_session, EventType.SINK_CHANGED)
             if pipeline.data_collection != updated.data_collection:
-                self._event_bus.emit_event(EventType.PIPELINE_DATASET_COLLECTION_POLICIES_CHANGED)
+                self._event_bus.emit_event_after_commit(
+                    self.db_session, EventType.PIPELINE_DATASET_COLLECTION_POLICIES_CHANGED
+                )
             if pipeline.device != updated.device:
-                self._event_bus.emit_event(EventType.INFERENCE_DEVICE_CHANGED)
+                self._event_bus.emit_event_after_commit(self.db_session, EventType.INFERENCE_DEVICE_CHANGED)
             if pipeline.model_id != updated.model_id or pipeline.model_variant_id != updated.model_variant_id:
-                self._event_bus.emit_event(EventType.MODEL_CHANGED)
+                self._event_bus.emit_event_after_commit(self.db_session, EventType.MODEL_CHANGED)
         elif pipeline.status != updated.status:
             # If the pipeline is being activated or stopped
-            self._event_bus.emit_event(EventType.PIPELINE_STATUS_CHANGED)
+            self._event_bus.emit_event_after_commit(self.db_session, EventType.PIPELINE_STATUS_CHANGED)
 
     def _validate_int8_support(self, device: str) -> None:
         """Validate that the device supports INT8 inference.

--- a/application/backend/app/services/sink_service.py
+++ b/application/backend/app/services/sink_service.py
@@ -120,7 +120,10 @@ class SinkService:
             )
             active_sink_id = self.get_active_sink_id()
             if active_sink_id == UUID(db_sink.id):
-                self._event_bus.emit_event(EventType.SINK_CHANGED)
+                # Emit only after this transaction commits, so consumers reacting to SINK_CHANGED
+                # re-read the new (durable) sink config instead of racing the commit and reading the
+                # previous configuration.
+                self._event_bus.emit_event_after_commit(self._db_session, EventType.SINK_CHANGED)
             return SinkAdapter.validate_python(db_sink, from_attributes=True)
         except UniqueConstraintIntegrityError:
             raise ResourceWithNameAlreadyExistsError(ResourceType.SINK, new_name)  # type: ignore[arg-type]

--- a/application/backend/app/services/source_service.py
+++ b/application/backend/app/services/source_service.py
@@ -183,7 +183,11 @@ class SourceUpdateService(SourceService):
             )
             active_source_id = self.get_active_source_id()
             if active_source_id == UUID(db_source.id):
-                self._event_bus.emit_event(EventType.SOURCE_CHANGED)
+                # Emit only after this transaction commits: the StreamLoader reacts to SOURCE_CHANGED
+                # by re-reading the active source in its own session/process, so notifying before the
+                # new config is durable would let it reopen the stream with stale data (e.g. the old
+                # video_path).
+                self._event_bus.emit_event_after_commit(self._db_session, EventType.SOURCE_CHANGED)
         except UniqueConstraintIntegrityError:
             raise ResourceWithNameAlreadyExistsError(ResourceType.SOURCE, new_name)
 

--- a/application/backend/tests/integration/services/test_pipeline_service.py
+++ b/application/backend/tests/integration/services/test_pipeline_service.py
@@ -175,9 +175,9 @@ class TestPipelineServiceIntegration:
         updated = fxt_pipeline_service.update_pipeline(db_pipeline.project_id, {pipeline_attr: item_id})
 
         if pipeline_attr == PipelineField.SINK_ID:
-            fxt_event_bus.emit_event.assert_called_once_with(EventType.SINK_CHANGED)
+            fxt_event_bus.emit_event_after_commit.assert_called_once_with(db_session, EventType.SINK_CHANGED)
         else:
-            fxt_event_bus.emit_event.assert_called_once_with(EventType.SOURCE_CHANGED)
+            fxt_event_bus.emit_event_after_commit.assert_called_once_with(db_session, EventType.SOURCE_CHANGED)
         db_updated = db_session.get(PipelineDB, db_pipeline.project_id)
         assert str(getattr(updated, pipeline_attr)) == item_id
         assert str(getattr(updated, pipeline_attr)) == getattr(db_updated, pipeline_attr)
@@ -200,7 +200,7 @@ class TestPipelineServiceIntegration:
 
         updated = fxt_pipeline_service.update_pipeline(db_pipeline.project_id, {model_attr: model_id})
 
-        fxt_event_bus.emit_event.assert_called_once_with(EventType.MODEL_CHANGED)
+        fxt_event_bus.emit_event_after_commit.assert_called_once_with(db_session, EventType.MODEL_CHANGED)
         db_updated = db_session.get(PipelineDB, db_pipeline.project_id)
         assert str(updated.model_id) == model_id
         assert str(updated.model_id) == db_updated.model_revision_id
@@ -227,7 +227,7 @@ class TestPipelineServiceIntegration:
             {"model_id": target_model.id, "model_variant_id": target_variant.id},
         )
 
-        fxt_event_bus.emit_event.assert_called_once_with(EventType.MODEL_CHANGED)
+        fxt_event_bus.emit_event_after_commit.assert_called_once_with(db_session, EventType.MODEL_CHANGED)
         db_updated = db_session.get(PipelineDB, db_pipeline.project_id)
         assert str(updated.model_id) == target_model.id
         assert db_updated.model_variant_id == target_variant.id
@@ -486,7 +486,7 @@ class TestPipelineServiceIntegration:
 
         fxt_pipeline_service.update_pipeline(db_pipeline.project_id, {"status": pipeline_status})
 
-        fxt_event_bus.emit_event.assert_called_once_with(EventType.PIPELINE_STATUS_CHANGED)
+        fxt_event_bus.emit_event_after_commit.assert_called_once_with(db_session, EventType.PIPELINE_STATUS_CHANGED)
         db_updated = db_session.get(PipelineDB, db_pipeline.project_id)
         if pipeline_status == PipelineStatus.RUNNING:
             assert db_updated.is_running

--- a/application/backend/tests/integration/services/test_sink_service.py
+++ b/application/backend/tests/integration/services/test_sink_service.py
@@ -406,7 +406,7 @@ class TestSinkServiceIntegration:
         db_sink = db_session.get(SinkDB, db_sink.id)
         assert db_sink.name == "Updated Sink"
         assert db_sink.config_data["folder_path"] == "/new/folder"
-        fxt_event_bus.emit_event.assert_called_once_with(EventType.SINK_CHANGED)
+        fxt_event_bus.emit_event_after_commit.assert_called_once_with(db_session, EventType.SINK_CHANGED)
 
     def test_delete_sink(self, fxt_db_sinks, fxt_sink_service, db_session):
         """Test deleting a sink."""

--- a/application/backend/tests/integration/services/test_source_service.py
+++ b/application/backend/tests/integration/services/test_source_service.py
@@ -423,7 +423,7 @@ class TestSourceUpdateServiceIntegration:
         db_source = db_session.get(SourceDB, db_source.id)
         assert db_source.name == "Updated Source"
         assert db_source.config_data["video_path"] == "/new/path"
-        fxt_event_bus.emit_event.assert_called_once_with(EventType.SOURCE_CHANGED)
+        fxt_event_bus.emit_event_after_commit.assert_called_once_with(db_session, EventType.SOURCE_CHANGED)
 
     def test_update_source_video_file_path_changed_deletes_old_video(
         self,

--- a/application/backend/tests/unit/db/test_session_hooks.py
+++ b/application/backend/tests/unit/db/test_session_hooks.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+from collections.abc import Generator
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.db.session_hooks import run_after_commit
+
+
+@pytest.fixture
+def session() -> Generator[Session]:
+    """A real (in-memory) SQLAlchemy session to exercise the commit/rollback lifecycle."""
+    engine = create_engine("sqlite://", poolclass=StaticPool)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+    engine.dispose()
+
+
+class TestRunAfterCommit:
+    def test_callback_runs_after_commit(self, session: Session) -> None:
+        """The scheduled callback runs only once the session commits, not before."""
+        callback = MagicMock()
+        # Ensure a transaction is active so commit actually fires the after_commit event.
+        session.begin()
+
+        run_after_commit(session, callback)
+        callback.assert_not_called()
+
+        session.commit()
+
+        callback.assert_called_once_with()
+
+    def test_callback_discarded_on_rollback(self, session: Session) -> None:
+        """A callback scheduled on a rolled-back transaction is never run, even after a later commit."""
+        callback = MagicMock()
+        session.begin()
+
+        run_after_commit(session, callback)
+        session.rollback()
+
+        callback.assert_not_called()
+
+        # A subsequent, unrelated commit must not resurrect the discarded callback.
+        session.begin()
+        session.commit()
+        callback.assert_not_called()
+
+    def test_multiple_callbacks_run_in_order(self, session: Session) -> None:
+        """All callbacks scheduled for a transaction run, in registration order, on commit."""
+        calls: list[str] = []
+        session.begin()
+
+        run_after_commit(session, lambda: calls.append("first"))
+        run_after_commit(session, lambda: calls.append("second"))
+        session.commit()
+
+        assert calls == ["first", "second"]
+
+    def test_failing_callback_does_not_block_others(self, session: Session) -> None:
+        """A raising callback is isolated so the remaining callbacks still run."""
+        ok_callback = MagicMock()
+        session.begin()
+
+        run_after_commit(session, MagicMock(side_effect=RuntimeError("boom")))
+        run_after_commit(session, ok_callback)
+        # Must not raise despite the first callback failing.
+        session.commit()
+
+        ok_callback.assert_called_once_with()

--- a/application/backend/tests/unit/services/event/test_event_bus.py
+++ b/application/backend/tests/unit/services/event/test_event_bus.py
@@ -1,15 +1,28 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 import multiprocessing as mp
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from multiprocessing.synchronize import Condition, Event
 from unittest.mock import MagicMock
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
 
 from app.services.event.event_bus import EventBus, EventType
 
 type EventBusFactory = Callable[[Condition | None, Condition | None, Event | None], EventBus]
+
+
+@pytest.fixture
+def fxt_db_session() -> Generator[Session]:
+    """A real (in-memory) SQLAlchemy session to exercise the commit-deferred emission."""
+    engine = create_engine("sqlite://", poolclass=StaticPool)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+    engine.dispose()
 
 
 @pytest.fixture
@@ -142,3 +155,39 @@ class TestEventBus:
         ok_handler.assert_called_once_with()
         # ... and the side-effect notifications (model reload) still happen.
         assert model_reload_event.is_set()
+
+    def test_emit_event_after_commit_defers_until_commit(
+        self, fxt_event_bus: EventBusFactory, fxt_db_session: Session
+    ) -> None:
+        """`emit_event_after_commit` must not notify anyone until the session actually commits."""
+        handler = MagicMock(spec=Callable)
+        source_changed_condition = mp.Condition()
+        event_bus = fxt_event_bus(source_changed_condition, None, None)
+        event_bus.subscribe(event_types=[EventType.SOURCE_CHANGED], handler=handler)
+        fxt_db_session.begin()
+
+        event_bus.emit_event_after_commit(fxt_db_session, EventType.SOURCE_CHANGED)
+
+        # Nothing must happen before the commit: consumers would otherwise read stale data.
+        handler.assert_not_called()
+
+        fxt_db_session.commit()
+
+        handler.assert_called_once_with()
+        with source_changed_condition:
+            notified = source_changed_condition.acquire()
+        assert notified
+
+    def test_emit_event_after_commit_skipped_on_rollback(
+        self, fxt_event_bus: EventBusFactory, fxt_db_session: Session
+    ) -> None:
+        """If the transaction is rolled back, the event is never emitted."""
+        handler = MagicMock(spec=Callable)
+        event_bus = fxt_event_bus(None, None, None)
+        event_bus.subscribe(event_types=[EventType.SOURCE_CHANGED], handler=handler)
+        fxt_db_session.begin()
+
+        event_bus.emit_event_after_commit(fxt_db_session, EventType.SOURCE_CHANGED)
+        fxt_db_session.rollback()
+
+        handler.assert_not_called()

--- a/application/backend/tests/unit/services/event/test_event_bus.py
+++ b/application/backend/tests/unit/services/event/test_event_bus.py
@@ -57,30 +57,26 @@ class TestEventBus:
     def test_source_changed(self, fxt_event_bus: EventBusFactory) -> None:
         """Test source changed"""
         handler = MagicMock(spec=Callable)
-        source_changed_condition = mp.Condition()
+        source_changed_condition = MagicMock(spec=Condition)
         event_bus = fxt_event_bus(source_changed_condition, None, None)
         event_bus.subscribe(event_types=[EventType.SOURCE_CHANGED], handler=handler)
 
         event_bus.emit_event(EventType.SOURCE_CHANGED)
 
         handler.assert_called_once_with()
-        with source_changed_condition:
-            notified = source_changed_condition.acquire()
-        assert notified
+        source_changed_condition.notify_all.assert_called_once_with()
 
     def test_sink_changed(self, fxt_event_bus: EventBusFactory) -> None:
         """Test sink changed"""
         handler = MagicMock(spec=Callable)
-        sink_changed_condition = mp.Condition()
+        sink_changed_condition = MagicMock(spec=Condition)
         event_bus = fxt_event_bus(None, sink_changed_condition, None)
         event_bus.subscribe(event_types=[EventType.SINK_CHANGED], handler=handler)
 
         event_bus.emit_event(EventType.SINK_CHANGED)
 
         handler.assert_called_once_with()
-        with sink_changed_condition:
-            notified = sink_changed_condition.acquire()
-        assert notified
+        sink_changed_condition.notify_all.assert_called_once_with()
 
     def test_model_changed(self, fxt_event_bus: EventBusFactory) -> None:
         """Test model changed"""
@@ -107,8 +103,8 @@ class TestEventBus:
     def test_pipeline_status_changed(self, fxt_event_bus: EventBusFactory) -> None:
         """Test pipeline status changed"""
         handler = MagicMock(spec=Callable)
-        source_changed_condition = mp.Condition()
-        sink_changed_condition = mp.Condition()
+        source_changed_condition = MagicMock(spec=Condition)
+        sink_changed_condition = MagicMock(spec=Condition)
         model_reload_event = mp.Event()
         event_bus = fxt_event_bus(source_changed_condition, sink_changed_condition, model_reload_event)
         event_bus.subscribe(event_types=[EventType.PIPELINE_STATUS_CHANGED], handler=handler)
@@ -116,12 +112,8 @@ class TestEventBus:
         event_bus.emit_event(EventType.PIPELINE_STATUS_CHANGED)
 
         handler.assert_called_once_with()
-        with source_changed_condition:
-            notified = source_changed_condition.acquire()
-        assert notified
-        with sink_changed_condition:
-            notified = sink_changed_condition.acquire()
-        assert notified
+        source_changed_condition.notify_all.assert_called_once_with()
+        sink_changed_condition.notify_all.assert_called_once_with()
         assert model_reload_event.is_set()
 
     def test_inference_device_changed(self, fxt_event_bus: EventBusFactory) -> None:
@@ -140,7 +132,7 @@ class TestEventBus:
         """A failing subscriber must not stop other subscribers or the condition notification."""
         failing_handler = MagicMock(spec=Callable, side_effect=RuntimeError("boom"))
         ok_handler = MagicMock(spec=Callable)
-        source_changed_condition = mp.Condition()
+        source_changed_condition = MagicMock(spec=Condition)
         model_reload_event = mp.Event()
         event_bus = fxt_event_bus(source_changed_condition, None, model_reload_event)
         # Subscribe the failing handler first so it would otherwise short-circuit the rest.
@@ -153,7 +145,8 @@ class TestEventBus:
         failing_handler.assert_called_once_with()
         # The remaining handler is still invoked ...
         ok_handler.assert_called_once_with()
-        # ... and the side-effect notifications (model reload) still happen.
+        # ... and the side-effect notifications still happen (condition notified, model reload set).
+        source_changed_condition.notify_all.assert_called_once_with()
         assert model_reload_event.is_set()
 
     def test_emit_event_after_commit_defers_until_commit(
@@ -161,7 +154,7 @@ class TestEventBus:
     ) -> None:
         """`emit_event_after_commit` must not notify anyone until the session actually commits."""
         handler = MagicMock(spec=Callable)
-        source_changed_condition = mp.Condition()
+        source_changed_condition = MagicMock(spec=Condition)
         event_bus = fxt_event_bus(source_changed_condition, None, None)
         event_bus.subscribe(event_types=[EventType.SOURCE_CHANGED], handler=handler)
         fxt_db_session.begin()
@@ -170,13 +163,12 @@ class TestEventBus:
 
         # Nothing must happen before the commit: consumers would otherwise read stale data.
         handler.assert_not_called()
+        source_changed_condition.notify_all.assert_not_called()
 
         fxt_db_session.commit()
 
         handler.assert_called_once_with()
-        with source_changed_condition:
-            notified = source_changed_condition.acquire()
-        assert notified
+        source_changed_condition.notify_all.assert_called_once_with()
 
     def test_emit_event_after_commit_skipped_on_rollback(
         self, fxt_event_bus: EventBusFactory, fxt_db_session: Session


### PR DESCRIPTION
Fixes problem of event(-s) being triggered while transaction is still active and not committed, therefore listener re-reads stale data from the database.
New approach is to pass event emission as a callback to DB after_commit.
Resolves #7134